### PR TITLE
Improve setup status visibility

### DIFF
--- a/handlers/commands.py
+++ b/handlers/commands.py
@@ -11,6 +11,12 @@ async def start(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
         match = storage.join_match(match_id, update.effective_user.id, update.effective_chat.id)
         if match:
             await update.message.reply_text('Вы присоединились к матчу. Отправьте "авто" для расстановки кораблей.')
+            msg_a = 'Соперник присоединился. '
+            if match.players['A'].ready:
+                msg_a += 'Ожидаем его расстановку.'
+            else:
+                msg_a += 'Отправьте "авто" для расстановки кораблей.'
+            await context.bot.send_message(match.players['A'].chat_id, msg_a)
         else:
             await update.message.reply_text('Не удалось присоединиться к матчу.')
     else:
@@ -22,4 +28,5 @@ async def newgame(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
     username = (await context.bot.get_me()).username
     link = f"https://t.me/{username}?start=inv_{match.match_id}"
     await update.message.reply_text(f"Пригласите друга: {link}")
+    await update.message.reply_text('Матч создан. Ожидаем подключения соперника.')
     await update.message.reply_text('Отправьте "авто" для расстановки кораблей.')

--- a/handlers/router.py
+++ b/handlers/router.py
@@ -26,14 +26,22 @@ async def router_text(update: Update, context: ContextTypes.DEFAULT_TYPE) -> Non
             storage.save_board(match, player_key, board)
             if match.status == 'playing':
                 await update.message.reply_text('Корабли расставлены. Бой начинается!')
+                await context.bot.send_message(match.players[enemy_key].chat_id,
+                                               'Соперник готов. Бой начинается! '
+                                               + ('Ваш ход.' if match.turn == enemy_key else 'Ход соперника.'))
             else:
                 await update.message.reply_text('Корабли расставлены. Ожидаем соперника.')
+                await context.bot.send_message(match.players[enemy_key].chat_id,
+                                               'Соперник готов. Отправьте "авто" для расстановки кораблей.')
         else:
             await update.message.reply_text('Введите "авто" для автоматической расстановки.')
         return
 
     if match.status != 'playing':
-        await update.message.reply_text('Матч ещё не начался.')
+        if match.status == 'waiting':
+            await update.message.reply_text('Матч ещё не начался. Ожидаем соперника.')
+        else:
+            await update.message.reply_text('Матч ещё не начался.')
         return
 
     if match.turn != player_key:


### PR DESCRIPTION
## Summary
- Notify the first player when an opponent joins the match
- Add clearer pre-game messages during board placement and when waiting for opponent

## Testing
- `python -m py_compile handlers/commands.py handlers/router.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68a9952d1a28832680b68f96874e27b6