### PR TITLE
Improve ship placement and storage, handle repeat shots, add tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,16 @@
+name: tests
+
+on: [push, pull_request]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.11'
+      - run: python -m pip install --upgrade pip
+      - run: pip install -r requirements.txt
+      - run: pip install pytest
+      - run: pytest

--- a/handlers/router.py
+++ b/handlers/router.py
@@ -5,7 +5,7 @@ from telegram.ext import ContextTypes
 import storage
 from logic.parser import parse_coord
 from logic.placement import random_board
-from logic.battle import apply_shot, MISS, HIT, KILL
+from logic.battle import apply_shot, MISS, HIT, KILL, REPEAT
 from logic.render import render_board_own, render_board_enemy
 
 
@@ -62,6 +62,8 @@ async def router_text(update: Update, context: ContextTypes.DEFAULT_TYPE) -> Non
         result_msg = 'Мимо. Ход соперника.'
     elif result == HIT:
         result_msg = 'Ранил. Ваш ход.'
+    elif result == REPEAT:
+        result_msg = 'Клетка уже обстреляна. Ваш ход.'
     else:
         if match.boards[enemy_key].alive_cells == 0:
             storage.finish(match, player_key)

--- a/logic/battle.py
+++ b/logic/battle.py
@@ -4,7 +4,7 @@ from typing import Tuple
 from models import Board, Ship
 
 
-MISS, HIT, KILL = 'miss', 'hit', 'kill'
+MISS, HIT, KILL, REPEAT = 'miss', 'hit', 'kill', 'repeat'
 
 
 def mark_contour(board: Board, cells: list[Tuple[int,int]]) -> None:
@@ -21,7 +21,7 @@ def apply_shot(board: Board, coord: Tuple[int,int]) -> str:
     r, c = coord
     cell = board.grid[r][c]
     if cell in (2,3,4,5):
-        return MISS  # already shot here or around
+        return REPEAT  # already shot here or around
     if cell == 0:
         board.grid[r][c] = 2
         return MISS

--- a/logic/placement.py
+++ b/logic/placement.py
@@ -30,11 +30,9 @@ def place_ship(board: Board, size: int) -> None:
         orient = random.choice(['h','v'])
         if orient == 'h':
             r = random.randint(0,9)
-        else:
-            r = random.randint(0,9)
-        if orient == 'h':
             c = random.randint(0,10-size)
         else:
+            r = random.randint(0,10-size)
             c = random.randint(0,9)
         cells = []
         for i in range(size):

--- a/storage.py
+++ b/storage.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 import json
 from pathlib import Path
+import logging
 from threading import Lock
 from typing import Dict
 
@@ -8,6 +9,7 @@ from models import Match, Board
 
 DATA_FILE = Path("data.json")
 _lock = Lock()
+logger = logging.getLogger(__name__)
 
 
 def _load_all() -> Dict[str, dict]:
@@ -22,12 +24,14 @@ def _load_all() -> Dict[str, dict]:
 
 
 def _save_all(data: Dict[str, dict]) -> None:
+    tmp_file = DATA_FILE.with_suffix('.tmp')
     try:
-        with DATA_FILE.open('w', encoding='utf-8') as f:
+        with tmp_file.open('w', encoding='utf-8') as f:
             json.dump(data, f, ensure_ascii=False, indent=2)
+        tmp_file.replace(DATA_FILE)
     except OSError:
-        # ignore write errors to avoid crashing the bot
-        pass
+        logger.exception("Failed to save data file")
+        raise
 
 
 def create_match(a_user_id: int, a_chat_id: int) -> Match:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,3 @@
+import sys
+from pathlib import Path
+sys.path.append(str(Path(__file__).resolve().parents[1]))

--- a/tests/test_battle.py
+++ b/tests/test_battle.py
@@ -1,0 +1,21 @@
+from models import Board, Ship
+from logic.battle import apply_shot, MISS, HIT, KILL, REPEAT
+
+
+def test_apply_shot_miss_and_repeat():
+    board = Board()
+    assert apply_shot(board, (0, 0)) == MISS
+    assert board.grid[0][0] == 2
+    assert apply_shot(board, (0, 0)) == REPEAT
+
+
+def test_apply_shot_kill_and_repeat():
+    board = Board()
+    ship = Ship(cells=[(0, 0)])
+    board.ships.append(ship)
+    board.grid[0][0] = 1
+    board.alive_cells = 1
+    assert apply_shot(board, (0, 0)) == KILL
+    assert board.grid[0][0] == 4
+    assert board.alive_cells == 0
+    assert apply_shot(board, (0, 0)) == REPEAT

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -1,0 +1,16 @@
+import pytest
+from logic.parser import parse_coord
+
+@pytest.mark.parametrize("text,expected", [
+    ("а1", (0,0)),
+    ("A1", (0,0)),
+    ("к10", (9,9)),
+    ("k10", (9,9)),
+    ("d5", (3,4)),
+])
+def test_parse_coord_valid(text, expected):
+    assert parse_coord(text) == expected
+
+@pytest.mark.parametrize("text", ["x1", "a0", "d11", "", "л1"])
+def test_parse_coord_invalid(text):
+    assert parse_coord(text) is None

--- a/tests/test_placement.py
+++ b/tests/test_placement.py
@@ -1,0 +1,25 @@
+import random
+from models import Board
+from logic.placement import place_ship, random_board
+
+
+def test_vertical_start_row_respects_ship_size(monkeypatch):
+    board = Board()
+    monkeypatch.setattr(random, 'choice', lambda seq: 'v')
+    calls = []
+    def fake_randint(a, b):
+        calls.append((a, b))
+        return a
+    monkeypatch.setattr(random, 'randint', fake_randint)
+    place_ship(board, 4)
+    assert calls[0] == (0, 6)
+    assert calls[1] == (0, 9)
+    for r, c in board.ships[0].cells:
+        assert 0 <= r < 10
+        assert 0 <= c < 10
+
+
+def test_random_board_ship_count():
+    board = random_board()
+    total = sum(cell == 1 for row in board.grid for cell in row)
+    assert total == 20

--- a/tests/test_render.py
+++ b/tests/test_render.py
@@ -1,0 +1,16 @@
+from models import Board
+from logic.render import render_board_own, render_board_enemy
+from logic.parser import ROWS
+
+
+def test_render_board_own_and_enemy():
+    board = Board()
+    board.grid[0][0] = 1
+    board.grid[0][1] = 2
+    board.grid[0][2] = 3
+    board.grid[0][3] = 4
+    board.grid[0][4] = 5
+    own = render_board_own(board).replace('<pre>', '').replace('</pre>', '').splitlines()
+    enemy = render_board_enemy(board).replace('<pre>', '').replace('</pre>', '').splitlines()
+    assert own[1] == f"{ROWS[0]} □ x ■ ▓ x · · · · ·"
+    assert enemy[1] == f"{ROWS[0]} · x ■ ▓ x · · · · ·"


### PR DESCRIPTION
## Summary
- Fix vertical ship placement by constraining start row
- Atomically persist matches with logging for storage reliability
- Handle repeated shots without losing turn and inform players
- Add pytest suite for parsing, placement, battle mechanics, and rendering
- Enable GitHub Actions to run tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a9a1a4e2ec832688042ea3e4d2409e