### PR TITLE
Delay invite link until game environment is ready

### DIFF
--- a/handlers/commands.py
+++ b/handlers/commands.py
@@ -45,8 +45,10 @@ async def start(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
 
 
 async def newgame(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+    await update.message.reply_text('Подождите, подготавливаем игровую среду...')
     match = storage.create_match(update.effective_user.id, update.effective_chat.id)
     username = (await context.bot.get_me()).username
+    await update.message.reply_text('Среда игры готова.')
     link = f"https://t.me/{username}?start=inv_{match.match_id}"
     await update.message.reply_text(f"Пригласите друга: {link}")
     await update.message.reply_text('Матч создан. Ожидаем подключения соперника.')

--- a/tests/test_newgame.py
+++ b/tests/test_newgame.py
@@ -1,0 +1,34 @@
+import asyncio
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, call
+
+import storage
+from handlers.commands import newgame
+
+
+def test_newgame_message_sequence(monkeypatch):
+    async def run_test():
+        match = SimpleNamespace(match_id='m1')
+        monkeypatch.setattr(storage, 'create_match', lambda user_id, chat_id: match)
+
+        reply_text = AsyncMock()
+        update = SimpleNamespace(
+            message=SimpleNamespace(reply_text=reply_text),
+            effective_user=SimpleNamespace(id=1),
+            effective_chat=SimpleNamespace(id=1),
+        )
+        bot = SimpleNamespace(get_me=AsyncMock(return_value=SimpleNamespace(username='TestBot')))
+        context = SimpleNamespace(bot=bot)
+
+        await newgame(update, context)
+
+        link = f"https://t.me/TestBot?start=inv_{match.match_id}"
+        assert reply_text.call_args_list == [
+            call('Подождите, подготавливаем игровую среду...'),
+            call('Среда игры готова.'),
+            call(f'Пригласите друга: {link}'),
+            call('Матч создан. Ожидаем подключения соперника.'),
+            call('Отправьте "авто" для расстановки кораблей.'),
+        ]
+
+    asyncio.run(run_test())


### PR DESCRIPTION
## Summary
- tell players to wait while the game environment is prepared
- confirm when the environment is ready before sending the invite link
- test newgame command message sequence

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a9ab1e5b1c83269255c6b21f4887a5