### PR TITLE
Fix match state update after concurrent board saves

### DIFF
--- a/storage.py
+++ b/storage.py
@@ -144,6 +144,8 @@ def save_board(match: Match, player_key: str, board: Board) -> None:
     match.turn = current.turn
     match.players = current.players
     match.boards = current.boards
+    match.shots = current.shots
+    match.messages = current.messages
 
 
 def finish(match: Match, winner: str) -> str | None:

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -1,0 +1,30 @@
+import threading
+from logic.placement import random_board
+import storage
+
+
+def test_concurrent_save_board(monkeypatch, tmp_path):
+    monkeypatch.setattr(storage, "DATA_FILE", tmp_path / "data.json")
+    match = storage.create_match(1, 100)
+    storage.join_match(match.match_id, 2, 200)
+
+    board_a = random_board()
+    board_b = random_board()
+
+    barrier = threading.Barrier(2)
+
+    def worker(key, board):
+        barrier.wait()
+        storage.save_board(match, key, board)
+
+    t1 = threading.Thread(target=worker, args=("A", board_a))
+    t2 = threading.Thread(target=worker, args=("B", board_b))
+    t1.start(); t2.start()
+    t1.join(); t2.join()
+
+    updated = storage.get_match(match.match_id)
+    assert updated.status == "playing"
+    assert updated.players["A"].ready and updated.players["B"].ready
+    # match object passed into save_board should also be updated
+    assert match.status == "playing"
+    assert match.players["A"].ready and match.players["B"].ready


### PR DESCRIPTION
## Summary
- keep in-memory match state in sync with persisted data when saving a board
- add regression test covering concurrent board placement

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a9ce54d2bc8326aaed19214fe3a5ea