### PR TITLE
Manage Telegram bot lifecycle on app startup/shutdown

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -49,12 +49,14 @@ app = FastAPI()
 @app.on_event("startup")
 async def on_startup() -> None:
     await bot_app.initialize()
+    await bot_app.start()
     await bot_app.bot.set_webhook(f"{webhook_url}/webhook")
 
 
 @app.on_event("shutdown")
 async def on_shutdown() -> None:
     await bot_app.bot.delete_webhook()
+    await bot_app.stop()
     await bot_app.shutdown()
 
 


### PR DESCRIPTION
## Summary
- start the Telegram bot application during FastAPI startup
- stop the bot before application shutdown

## Testing
- `pytest`
- `BOT_TOKEN=test WEBHOOK_URL=https://example.com timeout 5 ./start.sh 2>&1 | tail -n 20` *(fails: telegram.error.NetworkError: httpx.ProxyError: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68a9d24e04e4832690f423a8e23134e6