### PR TITLE
Ensure bot application starts and stops with FastAPI lifecycle

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -55,12 +55,14 @@ app = FastAPI()
 @app.on_event("startup")
 async def on_startup() -> None:
     await bot_app.initialize()
+    await bot_app.start()
     await bot_app.bot.set_webhook(f"{webhook_url}/webhook")
 
 
 @app.on_event("shutdown")
 async def on_shutdown() -> None:
     await bot_app.bot.delete_webhook()
+    await bot_app.stop()
     await bot_app.shutdown()
 
 


### PR DESCRIPTION
## Summary
- Start the Telegram bot application during FastAPI startup
- Stop the bot application cleanly during FastAPI shutdown

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a9d96c40188326bc89ec9f92db740c