### PR TITLE
Improve startup and command logging with clearer invitations

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -56,7 +56,9 @@ app = FastAPI()
 async def on_startup() -> None:
     await bot_app.initialize()
     await bot_app.start()
-    await bot_app.bot.set_webhook(f"{webhook_url}/webhook")
+    webhook = f"{webhook_url}/webhook"
+    await bot_app.bot.set_webhook(webhook)
+    logger.info("Setting webhook to %s", webhook)
 
 
 @app.on_event("shutdown")

--- a/handlers/commands.py
+++ b/handlers/commands.py
@@ -12,8 +12,14 @@ logger = logging.getLogger(__name__)
 
 
 async def start(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
-    if context.args and context.args[0].startswith('inv_'):
-        match_id = context.args[0][4:]
+    args = getattr(context, 'args', None)
+    logger.info(
+        '/start called: user_id=%s args=%s',
+        update.effective_user.id,
+        args,
+    )
+    if args and args[0].startswith('inv_'):
+        match_id = args[0][4:]
         match = storage.join_match(match_id, update.effective_user.id, update.effective_chat.id)
         if match:
             await update.message.reply_text('Вы присоединились к матчу. Отправьте "авто" для расстановки кораблей.')
@@ -42,10 +48,20 @@ async def start(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
             )
             await update.message.reply_text(msg)
     else:
-        await update.message.reply_text('Привет! Используйте /newgame чтобы создать матч.')
+        await update.message.reply_text(
+            'Привет! Используйте /newgame чтобы создать матч. '
+            'Если вы переходили по ссылке-приглашению, отправьте её текст '
+            'вручную: /start inv_<id>.'
+        )
 
 
 async def newgame(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+    args = getattr(context, 'args', None)
+    logger.info(
+        '/newgame called: user_id=%s args=%s',
+        update.effective_user.id,
+        args,
+    )
     await update.message.reply_text('Подождите, подготавливаем игровую среду...')
     match = storage.create_match(update.effective_user.id, update.effective_chat.id)
     username = (await context.bot.get_me()).username
@@ -57,6 +73,12 @@ async def newgame(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
 
 
 async def board(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+    args = getattr(context, 'args', None)
+    logger.info(
+        '/board called: user_id=%s args=%s',
+        update.effective_user.id,
+        args,
+    )
     match = storage.find_match_by_user(update.effective_user.id)
     if not match:
         await update.message.reply_text('Вы не участвуете в матче. Используйте /newgame.')


### PR DESCRIPTION
## Summary
- log webhook URL during startup
- add logging for /start, /newgame and /board commands
- show instructions when /start lacks an invitation argument

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a9dc1f5ef883269c7cbf3bcbe1be31