### PR TITLE
Add health check endpoint

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -103,3 +103,13 @@ async def telegram_webhook(request: Request) -> dict[str, bool]:
 @app.api_route("/", methods=["GET", "HEAD"])
 async def root() -> dict[str, str]:
     return {"status": "running"}
+
+
+@app.get("/healthz")
+async def healthz() -> dict[str, str]:
+    """Simple health-check endpoint for Render.
+
+    Returns a JSON response indicating the application is up. Used by the
+    hosting platform to verify the service is healthy.
+    """
+    return {"status": "ok"}

--- a/tests/test_healthz.py
+++ b/tests/test_healthz.py
@@ -1,0 +1,23 @@
+import os
+from fastapi.testclient import TestClient
+from unittest.mock import AsyncMock
+
+def test_healthz(monkeypatch):
+    os.environ.setdefault("BOT_TOKEN", "test")
+    os.environ.setdefault("WEBHOOK_URL", "http://example.com")
+
+    from app import main
+
+    monkeypatch.setattr(main.bot_app, "initialize", AsyncMock())
+    monkeypatch.setattr(main.bot_app, "start", AsyncMock())
+    monkeypatch.setattr(main.bot_app, "stop", AsyncMock())
+    monkeypatch.setattr(main.bot_app, "shutdown", AsyncMock())
+    bot_cls = main.bot_app.bot.__class__
+    monkeypatch.setattr(bot_cls, "set_webhook", AsyncMock())
+    monkeypatch.setattr(bot_cls, "delete_webhook", AsyncMock())
+
+    with TestClient(main.app) as client:
+        response = client.get("/healthz")
+    assert response.status_code == 200
+    assert response.json() == {"status": "ok"}
+


### PR DESCRIPTION
## Summary
- add `/healthz` FastAPI route for uptime checks
- cover `/healthz` with a unit test

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a9e86596bc83268b63acd99c6dec51