### PR TITLE
Fix board rendering and ship destruction messages

### DIFF
--- a/handlers/router.py
+++ b/handlers/router.py
@@ -115,11 +115,11 @@ async def router_text(update: Update, context: ContextTypes.DEFAULT_TYPE) -> Non
     else:
         if match.boards[enemy_key].alive_cells == 0:
             error = storage.finish(match, player_key)
-            result_self = f'{coord_str} Корабль уничтожен! Вы победили. 🏆🎉'
+            result_self = f'{coord_str} Корабль соперника уничтожен! Вы победили. 🏆🎉'
             result_enemy = f'{coord_str} Все ваши корабли уничтожены. Соперник победил. Не сдавайтесь, капитан! ⚓'
         else:
-            result_self = f'{coord_str} Корабль уничтожен! Ваш ход.'
-            result_enemy = f'{coord_str} Соперник уничтожил ваш корабль. Ход соперника.'
+            result_self = f'{coord_str} Корабль соперника уничтожен! Ваш ход.'
+            result_enemy = f'{coord_str} Ваш корабль уничтожен. Ход соперника.'
             error = storage.save_match(match)
 
     if error:

--- a/logic/render.py
+++ b/logic/render.py
@@ -7,10 +7,15 @@ from logic.parser import ROWS
 
 # letters on top for columns
 COL_HEADER = ' '.join(ROWS)
+CELL_WIDTH = 3
+
+
+def format_cell(symbol: str) -> str:
+    return symbol.center(CELL_WIDTH)
 
 
 def _render_line(cells: List[str]) -> str:
-    return ' '.join(cells)
+    return ''.join(cells)
 
 
 def render_board_own(board: Board) -> str:
@@ -28,7 +33,7 @@ def render_board_own(board: Board) -> str:
                     sym = f"[{mapping.get(v, '·')}]"
             else:
                 sym = mapping.get(v, '·')
-            cells.append(sym)
+            cells.append(format_cell(sym))
         lines.append(f"{r_idx+1:>2} " + _render_line(cells))
     return '<pre>' + '\n'.join(lines) + '</pre>'
 
@@ -48,6 +53,6 @@ def render_board_enemy(board: Board) -> str:
                     sym = f"[{mapping.get(v, '·')}]"
             else:
                 sym = mapping.get(v, '·')
-            cells.append(sym)
+            cells.append(format_cell(sym))
         lines.append(f"{r_idx+1:>2} " + _render_line(cells))
     return '<pre>' + '\n'.join(lines) + '</pre>'

--- a/tests/test_battle.py
+++ b/tests/test_battle.py
@@ -33,3 +33,16 @@ def test_apply_shot_highlight():
     board.alive_cells = 1
     assert apply_shot(board, (1, 1)) == KILL
     assert board.highlight == [(1, 1)]
+
+
+def test_apply_shot_kill_marks_contour():
+    board = Board()
+    ship = Ship(cells=[(1, 1), (1, 2)])
+    board.ships.append(ship)
+    board.grid[1][1] = 1
+    board.grid[1][2] = 1
+    board.alive_cells = 2
+    assert apply_shot(board, (1, 1)) == HIT
+    assert apply_shot(board, (1, 2)) == KILL
+    assert board.grid[0][0] == 5
+    assert board.grid[2][3] == 5

--- a/tests/test_render.py
+++ b/tests/test_render.py
@@ -11,8 +11,8 @@ def test_render_board_own_and_enemy():
     board.grid[0][4] = 5
     own = render_board_own(board).replace('<pre>', '').replace('</pre>', '').splitlines()
     enemy = render_board_enemy(board).replace('<pre>', '').replace('</pre>', '').splitlines()
-    assert own[1] == " 1 □ x ■ ▓ x · · · · ·"
-    assert enemy[1] == " 1 · x ■ ▓ x · · · · ·"
+    assert own[1] == " 1  □  x  ■  ▓  x  ·  ·  ·  ·  · "
+    assert enemy[1] == " 1  ·  x  ■  ▓  x  ·  ·  ·  ·  · "
 
 
 def test_render_highlight_last_move():
@@ -35,11 +35,11 @@ def test_render_highlight_last_move():
     board.highlight = [(0, 0), (0, 1)]
     own = render_board_own(board).replace('<pre>', '').replace('</pre>', '').splitlines()
     enemy = render_board_enemy(board).replace('<pre>', '').replace('</pre>', '').splitlines()
-    assert own[1].startswith(" 1 💣 💣")
-    assert enemy[1].startswith(" 1 💣 💣")
+    assert own[1].startswith(" 1  💣  💣")
+    assert enemy[1].startswith(" 1  💣  💣")
     # after next move (no highlight)
     board.highlight = []
     own = render_board_own(board).replace('<pre>', '').replace('</pre>', '').splitlines()
     enemy = render_board_enemy(board).replace('<pre>', '').replace('</pre>', '').splitlines()
-    assert own[1].startswith(" 1 ▓ ▓")
-    assert enemy[1].startswith(" 1 ▓ ▓")
+    assert own[1].startswith(" 1  ▓  ▓")
+    assert enemy[1].startswith(" 1  ▓  ▓")

--- a/tests/test_router_text.py
+++ b/tests/test_router_text.py
@@ -4,6 +4,7 @@ from unittest.mock import AsyncMock, call
 
 import storage
 from handlers import router
+from models import Board, Ship
 
 
 def test_router_invalid_cell_shows_board(monkeypatch):
@@ -96,4 +97,82 @@ def test_router_auto_shows_board(monkeypatch):
             call(10, 'Ваше поле:\nown\nПоле соперника:\nenemy\nКорабли расставлены. Бой начинается! Ваш ход.', parse_mode='HTML'),
             call(20, 'Ваше поле:\nown\nПоле соперника:\nenemy\nСоперник готов. Бой начинается! Ход соперника.', parse_mode='HTML'),
         ]
+    asyncio.run(run_test())
+
+
+def test_router_kill_message(monkeypatch):
+    async def run_test():
+        board_self = Board()
+        board_enemy = Board()
+        ship1 = Ship(cells=[(0, 0)])
+        ship2 = Ship(cells=[(9, 9)])
+        board_enemy.ships = [ship1, ship2]
+        board_enemy.grid[0][0] = 1
+        board_enemy.grid[9][9] = 1
+        board_enemy.alive_cells = 2
+        match = SimpleNamespace(
+            status='playing',
+            players={'A': SimpleNamespace(user_id=1, chat_id=10),
+                     'B': SimpleNamespace(user_id=2, chat_id=20)},
+            boards={'A': board_self, 'B': board_enemy},
+            turn='A',
+            shots={'A': {'history': [], 'last_result': None},
+                   'B': {'history': [], 'last_result': None}},
+        )
+        monkeypatch.setattr(storage, 'find_match_by_user', lambda uid: match)
+        monkeypatch.setattr(router, 'render_board_own', lambda b: 'own')
+        monkeypatch.setattr(router, 'render_board_enemy', lambda b: 'enemy')
+        monkeypatch.setattr(storage, 'save_match', lambda m: None)
+        send_message = AsyncMock()
+        context = SimpleNamespace(bot=SimpleNamespace(send_message=send_message))
+        update = SimpleNamespace(
+            message=SimpleNamespace(text='a1', reply_text=AsyncMock()),
+            effective_user=SimpleNamespace(id=1),
+        )
+        await router.router_text(update, context)
+        assert send_message.call_args_list == [
+            call(10, 'Ваше поле:\nown\nПоле соперника:\nenemy\nа1 Корабль соперника уничтожен! Ваш ход.', parse_mode='HTML'),
+            call(20, 'Ваше поле:\nown\nПоле соперника:\nenemy\nа1 Ваш корабль уничтожен. Ход соперника.', parse_mode='HTML'),
+        ]
+    asyncio.run(run_test())
+
+
+def test_router_game_over_messages(monkeypatch):
+    async def run_test():
+        board_self = Board()
+        board_enemy = Board()
+        ship1 = Ship(cells=[(0, 0)])
+        board_enemy.ships = [ship1]
+        board_enemy.grid[0][0] = 1
+        board_enemy.alive_cells = 1
+        match = SimpleNamespace(
+            status='playing',
+            players={'A': SimpleNamespace(user_id=1, chat_id=10),
+                     'B': SimpleNamespace(user_id=2, chat_id=20)},
+            boards={'A': board_self, 'B': board_enemy},
+            turn='A',
+            shots={'A': {'history': [], 'last_result': None},
+                   'B': {'history': [], 'last_result': None}},
+        )
+        def fake_finish(m, winner):
+            m.status = 'finished'
+            return None
+        monkeypatch.setattr(storage, 'find_match_by_user', lambda uid: match)
+        monkeypatch.setattr(router, 'render_board_own', lambda b: 'own')
+        monkeypatch.setattr(router, 'render_board_enemy', lambda b: 'enemy')
+        monkeypatch.setattr(storage, 'finish', fake_finish)
+        send_message = AsyncMock()
+        context = SimpleNamespace(bot=SimpleNamespace(send_message=send_message))
+        update = SimpleNamespace(
+            message=SimpleNamespace(text='a1', reply_text=AsyncMock()),
+            effective_user=SimpleNamespace(id=1),
+        )
+        await router.router_text(update, context)
+        calls = send_message.call_args_list
+        assert 'Вы победили. 🏆🎉' in calls[0].args[1]
+        assert 'Все ваши корабли уничтожены' in calls[1].args[1]
+        assert calls[2].args[1] == 'Игра завершена!'
+        assert calls[3].args[1] == 'Игра завершена!'
+        assert calls[2].kwargs['reply_markup'].keyboard[0][0].text == 'Начать новую игру'
+        assert calls[3].kwargs['reply_markup'].keyboard[0][0].text == 'Начать новую игру'
     asyncio.run(run_test())


### PR DESCRIPTION
## Summary
- render boards with fixed-width cells to avoid shifting when highlighting last moves
- reword ship destruction notices and send celebratory messages on victory
- add tests for contour marking and endgame messaging

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68aa321099a88326b58a5a15e10deff7