### PR TITLE
Fix sunk ship detection after match reload

### DIFF
--- a/storage.py
+++ b/storage.py
@@ -57,10 +57,16 @@ def get_match(match_id: str) -> Match | None:
     # boards
     match.boards = {}
     for key, b in m['boards'].items():
-        ships = [Ship(**s) for s in b.get('ships', [])]
-        match.boards[key] = Board(grid=b.get('grid', [[0]*10 for _ in range(10)]),
-                                  ships=ships,
-                                  alive_cells=b.get('alive_cells', 20))
+        ships = [
+            Ship(cells=[tuple(cell) for cell in s.get('cells', [])],
+                 alive=s.get('alive', True))
+            for s in b.get('ships', [])
+        ]
+        match.boards[key] = Board(
+            grid=b.get('grid', [[0] * 10 for _ in range(10)]),
+            ships=ships,
+            alive_cells=b.get('alive_cells', 20),
+        )
     match.turn = m.get('turn', 'A')
     match.shots = m.get('shots', match.shots)
     match.messages = m.get('messages', {})
@@ -106,10 +112,16 @@ def save_board(match: Match, player_key: str, board: Board) -> None:
             current.players = {key: Player(**p) for key, p in m_dict['players'].items()}
             current.boards = {}
             for key, b in m_dict['boards'].items():
-                ships = [Ship(**s) for s in b.get('ships', [])]
-                current.boards[key] = Board(grid=b.get('grid', [[0]*10 for _ in range(10)]),
-                                            ships=ships,
-                                            alive_cells=b.get('alive_cells', 20))
+                ships = [
+                    Ship(cells=[tuple(cell) for cell in s.get('cells', [])],
+                         alive=s.get('alive', True))
+                    for s in b.get('ships', [])
+                ]
+                current.boards[key] = Board(
+                    grid=b.get('grid', [[0] * 10 for _ in range(10)]),
+                    ships=ships,
+                    alive_cells=b.get('alive_cells', 20),
+                )
             current.turn = m_dict.get('turn', 'A')
             current.shots = m_dict.get('shots', current.shots)
             current.messages = m_dict.get('messages', {})

--- a/tests/test_ship_persistence.py
+++ b/tests/test_ship_persistence.py
@@ -1,0 +1,27 @@
+from models import Board, Ship
+from logic.battle import apply_shot, HIT, KILL
+import storage
+
+
+def test_kill_after_reload(monkeypatch, tmp_path):
+    monkeypatch.setattr(storage, "DATA_FILE", tmp_path / "data.json")
+    match = storage.create_match(1, 100)
+    storage.join_match(match.match_id, 2, 200)
+
+    board_b = Board()
+    ship = Ship(cells=[(0, 0), (1, 0)])
+    board_b.ships = [ship]
+    board_b.grid[0][0] = 1
+    board_b.grid[1][0] = 1
+    board_b.alive_cells = 2
+
+    storage.save_board(match, "B", board_b)
+    storage.save_board(match, "A", Board())
+
+    loaded = storage.get_match(match.match_id)
+
+    assert apply_shot(loaded.boards["B"], (0, 0)) == HIT
+    assert apply_shot(loaded.boards["B"], (1, 0)) == KILL
+
+    assert loaded.boards["B"].grid[0][1] == 5
+    assert loaded.boards["B"].grid[2][0] == 5


### PR DESCRIPTION
## Summary
- reconstruct ship cells as tuples when loading boards from storage
- ensure kill detection and contour marking survive save/load
- add regression test for sinking logic after reload

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68aa91ae2a2883269be60f4a794f45f6