### PR TITLE
Return latest active match for user

### DIFF
--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -1,6 +1,7 @@
 import threading
 from logic.placement import random_board
 import storage
+from datetime import datetime, timedelta
 
 
 def test_concurrent_save_board(monkeypatch, tmp_path):
@@ -28,3 +29,48 @@ def test_concurrent_save_board(monkeypatch, tmp_path):
     # match object passed into save_board should also be updated
     assert match.status == "playing"
     assert match.players["A"].ready and match.players["B"].ready
+
+
+def _set_time(match, dt):
+    """Helper to set created_at and persist match."""
+    match.created_at = dt.isoformat()
+    storage.save_match(match)
+
+
+def test_find_match_by_user_returns_latest_active(monkeypatch, tmp_path):
+    monkeypatch.setattr(storage, "DATA_FILE", tmp_path / "data.json")
+    base = datetime(2023, 1, 1)
+
+    m1 = storage.create_match(1, 100)
+    _set_time(m1, base)
+
+    m2 = storage.create_match(1, 200)
+    m2.status = "placing"
+    _set_time(m2, base + timedelta(seconds=1))
+
+    m3 = storage.create_match(1, 300)
+    m3.status = "playing"
+    _set_time(m3, base + timedelta(seconds=2))
+
+    found = storage.find_match_by_user(1)
+    assert found.match_id == m3.match_id
+
+
+def test_find_match_by_user_ignores_finished(monkeypatch, tmp_path):
+    monkeypatch.setattr(storage, "DATA_FILE", tmp_path / "data.json")
+    base = datetime(2023, 1, 1)
+
+    active = storage.create_match(1, 100)
+    active.status = "playing"
+    _set_time(active, base)
+
+    finished = storage.create_match(1, 200)
+    finished.status = "finished"
+    _set_time(finished, base + timedelta(seconds=1))
+
+    finished_only = storage.create_match(2, 300)
+    finished_only.status = "finished"
+    _set_time(finished_only, base + timedelta(seconds=2))
+
+    assert storage.find_match_by_user(1).match_id == active.match_id
+    assert storage.find_match_by_user(2) is None


### PR DESCRIPTION
## Summary
- filter matches by active statuses and return the most recent one for a user
- document and test ignoring finished matches

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68aadb407a5c8326905b794de04c4a5e