### PR TITLE
Delay auto placement prompt until opponent joins

### DIFF
--- a/handlers/commands.py
+++ b/handlers/commands.py
@@ -69,7 +69,6 @@ async def newgame(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
     link = f"https://t.me/{username}?start=inv_{match.match_id}"
     await update.message.reply_text(f"Пригласите друга: {link}")
     await update.message.reply_text('Матч создан. Ожидаем подключения соперника.')
-    await update.message.reply_text('Отправьте "авто" для расстановки кораблей.')
 
 
 async def board(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:

--- a/tests/test_newgame.py
+++ b/tests/test_newgame.py
@@ -28,7 +28,6 @@ def test_newgame_message_sequence(monkeypatch):
             call('Среда игры готова.'),
             call(f'Пригласите друга: {link}'),
             call('Матч создан. Ожидаем подключения соперника.'),
-            call('Отправьте "авто" для расстановки кораблей.'),
         ]
 
     asyncio.run(run_test())


### PR DESCRIPTION
## Summary
- remove early "auto" placement prompt during /newgame
- adjust unit test for new message sequence

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68aae51cc81c8326bccea6af105d65ad