### PR TITLE
Fix board alignment on some Telegram clients

### DIFF
--- a/logic/render.py
+++ b/logic/render.py
@@ -6,6 +6,10 @@ from logic.parser import ROWS
 from wcwidth import wcswidth
 
 
+# figure space keeps alignment even when clients collapse regular spaces
+FIGURE_SPACE = "\u2007"
+
+
 # letters on top for columns
 # expanded slightly so that emoji icons do not stretch rows or columns
 CELL_WIDTH = 3
@@ -15,7 +19,7 @@ def format_cell(symbol: str) -> str:
     pad = CELL_WIDTH - wcswidth(symbol)
     if pad < 0:
         pad = 0
-    return symbol + " " * pad
+    return symbol + FIGURE_SPACE * pad
 
 
 COL_HEADER = ''.join(format_cell(ch) for ch in ROWS)
@@ -26,7 +30,7 @@ def _render_line(cells: List[str]) -> str:
 
 
 def render_board_own(board: Board) -> str:
-    lines = [" " * (CELL_WIDTH + 1) + COL_HEADER]
+    lines = [FIGURE_SPACE * (CELL_WIDTH + 1) + COL_HEADER]
     mapping = {0: '·', 1: '□', 2: 'x', 3: '■', 4: '▓', 5: 'x'}
     highlight = set(board.highlight)
     for r_idx, row in enumerate(board.grid):
@@ -45,12 +49,14 @@ def render_board_own(board: Board) -> str:
             else:
                 sym = mapping.get(v, '·')
             cells.append(format_cell(sym))
-        lines.append(f"{r_idx+1:>{CELL_WIDTH}} " + _render_line(cells))
+        num = str(r_idx + 1)
+        pad = FIGURE_SPACE * (CELL_WIDTH - wcswidth(num))
+        lines.append(f"{pad}{num}{FIGURE_SPACE}" + _render_line(cells))
     return '<pre>' + '\n'.join(lines) + '</pre>'
 
 
 def render_board_enemy(board: Board) -> str:
-    lines = [" " * (CELL_WIDTH + 1) + COL_HEADER]
+    lines = [FIGURE_SPACE * (CELL_WIDTH + 1) + COL_HEADER]
     mapping = {0: '·', 1: '·', 2: 'x', 3: '■', 4: '▓', 5: 'x'}
     highlight = set(board.highlight)
     for r_idx, row in enumerate(board.grid):
@@ -69,5 +75,7 @@ def render_board_enemy(board: Board) -> str:
             else:
                 sym = mapping.get(v, '·')
             cells.append(format_cell(sym))
-        lines.append(f"{r_idx+1:>{CELL_WIDTH}} " + _render_line(cells))
+        num = str(r_idx + 1)
+        pad = FIGURE_SPACE * (CELL_WIDTH - wcswidth(num))
+        lines.append(f"{pad}{num}{FIGURE_SPACE}" + _render_line(cells))
     return '<pre>' + '\n'.join(lines) + '</pre>'


### PR DESCRIPTION
## Summary
- ensure board uses figure spaces for padding to keep column alignment across devices

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ab12400ab88326bc3702f1c8dd0ca5