### PR TITLE
feat: allow messaging opponent

### DIFF
--- a/handlers/commands.py
+++ b/handlers/commands.py
@@ -23,12 +23,18 @@ async def start(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
         match = storage.join_match(match_id, update.effective_user.id, update.effective_chat.id)
         if match:
             await update.message.reply_text('Вы присоединились к матчу. Отправьте "авто" для расстановки кораблей.')
+            await update.message.reply_text('Используйте toenemy: <ваше сообщение>, чтобы отправить сообщение сопернику.')
             msg_a = 'Соперник присоединился. '
             if match.players['A'].ready:
                 msg_a += 'Ожидаем его расстановку.'
             else:
                 msg_a += 'Отправьте "авто" для расстановки кораблей.'
             await context.bot.send_message(match.players['A'].chat_id, msg_a)
+            if 'Отправьте "авто"' in msg_a:
+                await context.bot.send_message(
+                    match.players['A'].chat_id,
+                    'Используйте toenemy: <ваше сообщение>, чтобы отправить сообщение сопернику.',
+                )
         else:
             existing = storage.get_match(match_id)
             reason = 'match not found'


### PR DESCRIPTION
## Summary
- allow players to message opponents using `toenemy:` prefix
- highlight messaging command when prompting for ship placement
- adjust joke formatting so jokes follow status and leave a blank line before the next turn

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68ab1b4a2c1483269eb3906ce12f05a2