### PR TITLE
Add welcome image and '@' prefix for opponent messaging

### DIFF
--- a/handlers/router.py
+++ b/handlers/router.py
@@ -65,8 +65,8 @@ async def router_text(update: Update, context: ContextTypes.DEFAULT_TYPE) -> Non
     player_key = 'A' if match.players['A'].user_id == user_id else 'B'
     enemy_key = 'B' if player_key == 'A' else 'A'
 
-    if text_lower.startswith('toenemy:'):
-        msg = text[len('toenemy:'):].strip()
+    if text.startswith('@'):
+        msg = text[1:].strip()
         await context.bot.send_message(match.players[enemy_key].chat_id, msg)
         return
 
@@ -104,7 +104,7 @@ async def router_text(update: Update, context: ContextTypes.DEFAULT_TYPE) -> Non
                 )
                 await context.bot.send_message(
                     match.players[enemy_key].chat_id,
-                    'Используйте toenemy: <ваше сообщение>, чтобы отправить сообщение сопернику.',
+                    'Используйте @<ваше сообщение>, чтобы отправить сообщение сопернику.',
                 )
         else:
             await update.message.reply_text('Введите "авто" для автоматической расстановки.')

--- a/tests/test_newgame.py
+++ b/tests/test_newgame.py
@@ -1,6 +1,6 @@
 import asyncio
 from types import SimpleNamespace
-from unittest.mock import AsyncMock, call
+from unittest.mock import AsyncMock, call, ANY
 
 import storage
 from handlers.commands import newgame
@@ -12,8 +12,9 @@ def test_newgame_message_sequence(monkeypatch):
         monkeypatch.setattr(storage, 'create_match', lambda user_id, chat_id: match)
 
         reply_text = AsyncMock()
+        reply_photo = AsyncMock()
         update = SimpleNamespace(
-            message=SimpleNamespace(reply_text=reply_text),
+            message=SimpleNamespace(reply_text=reply_text, reply_photo=reply_photo),
             effective_user=SimpleNamespace(id=1),
             effective_chat=SimpleNamespace(id=1),
         )
@@ -23,6 +24,7 @@ def test_newgame_message_sequence(monkeypatch):
         await newgame(update, context)
 
         link = f"https://t.me/TestBot?start=inv_{match.match_id}"
+        assert reply_photo.call_args_list == [call(ANY, caption='Добро пожаловать в игру!')]
         assert reply_text.call_args_list == [
             call('Подождите, подготавливаем игровую среду...'),
             call('Среда игры готова.'),

--- a/tests/test_router_text.py
+++ b/tests/test_router_text.py
@@ -136,7 +136,7 @@ def test_router_auto_waits_and_sends_instruction(monkeypatch):
         assert send_message.call_args_list == [
             call(10, 'Ваше поле:\nown\nПоле соперника:\nenemy\nКорабли расставлены. Ожидаем соперника.', parse_mode='HTML'),
             call(20, 'Ваше поле:\nown\nПоле соперника:\nenemy\nСоперник готов. Отправьте "авто" для расстановки кораблей.', parse_mode='HTML'),
-            call(20, 'Используйте toenemy: <ваше сообщение>, чтобы отправить сообщение сопернику.'),
+            call(20, 'Используйте @<ваше сообщение>, чтобы отправить сообщение сопернику.'),
         ]
 
     asyncio.run(run_test())
@@ -185,7 +185,7 @@ def test_router_kill_message(monkeypatch):
     asyncio.run(run_test())
 
 
-def test_router_toenemy_sends_to_opponent(monkeypatch):
+def test_router_at_sends_to_opponent(monkeypatch):
     async def run_test():
         match = SimpleNamespace(
             status='playing',
@@ -201,7 +201,7 @@ def test_router_toenemy_sends_to_opponent(monkeypatch):
         send_message = AsyncMock()
         context = SimpleNamespace(bot=SimpleNamespace(send_message=send_message))
         update = SimpleNamespace(
-            message=SimpleNamespace(text='toenemy: Привет', reply_text=AsyncMock()),
+            message=SimpleNamespace(text='@ Привет', reply_text=AsyncMock()),
             effective_user=SimpleNamespace(id=1),
         )
         await router.router_text(update, context)


### PR DESCRIPTION
## Summary
- load welcome image via context manager using file or embedded placeholder to avoid binary data
- display welcome greeting photo for match creator and joining player
- use `@` prefix to send messages to opponent and update instructions

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ab34f5fa848326b1bf7873d0999462