### PR TITLE
feat: invite opponents via contacts or link

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -10,11 +10,12 @@ from telegram.ext import (
     ApplicationBuilder,
     CommandHandler,
     MessageHandler,
+    CallbackQueryHandler,
     ContextTypes,
     filters,
 )
 
-from handlers.commands import start, newgame, board
+from handlers.commands import start, newgame, board, send_invite_link
 from handlers.router import router_text
 
 
@@ -50,6 +51,7 @@ bot_app = ApplicationBuilder().token(token).updater(None).build()
 bot_app.add_handler(CommandHandler("start", start))
 bot_app.add_handler(CommandHandler("newgame", newgame))
 bot_app.add_handler(CommandHandler("board", board))
+bot_app.add_handler(CallbackQueryHandler(send_invite_link, pattern="^get_link$"))
 bot_app.add_handler(MessageHandler(filters.TEXT & ~filters.COMMAND, router_text))
 
 

--- a/tests/test_newgame.py
+++ b/tests/test_newgame.py
@@ -3,7 +3,7 @@ from types import SimpleNamespace
 from unittest.mock import AsyncMock, call, ANY
 
 import storage
-from handlers.commands import newgame
+from handlers.commands import newgame, send_invite_link
 
 
 def test_newgame_message_sequence(monkeypatch):
@@ -28,8 +28,31 @@ def test_newgame_message_sequence(monkeypatch):
         assert reply_text.call_args_list == [
             call('Подождите, подготавливаем игровую среду...'),
             call('Среда игры готова.'),
-            call(f'Пригласите друга: {link}'),
+            call('Выберите способ приглашения соперника:', reply_markup=ANY),
             call('Матч создан. Ожидаем подключения соперника.'),
         ]
+
+    asyncio.run(run_test())
+
+
+def test_send_invite_link(monkeypatch):
+    async def run_test():
+        match = SimpleNamespace(match_id='m1')
+        monkeypatch.setattr(storage, 'find_match_by_user', lambda uid: match)
+        reply_text = AsyncMock()
+        query = SimpleNamespace(
+            from_user=SimpleNamespace(id=1),
+            message=SimpleNamespace(reply_text=reply_text),
+            answer=AsyncMock(),
+        )
+        update = SimpleNamespace(callback_query=query)
+        bot = SimpleNamespace(get_me=AsyncMock(return_value=SimpleNamespace(username='TestBot')))
+        context = SimpleNamespace(bot=bot)
+
+        await send_invite_link(update, context)
+
+        link = f"https://t.me/TestBot?start=inv_{match.match_id}"
+        assert reply_text.call_args_list == [call(f'Пригласите друга: {link}')]
+        assert query.answer.call_count == 1
 
     asyncio.run(run_test())


### PR DESCRIPTION
## Summary
- provide contact and link options after new game
- add callback handler for sharing game link
- update tests for new invitation flow

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ab3afaf5bc832687b9741c867b9e48