### PR TITLE
feat: implement full three-player 15x15 mode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+assets/fonts/DejaVuSans.ttf

--- a/app/main.py
+++ b/app/main.py
@@ -15,8 +15,12 @@ from telegram.ext import (
     filters,
 )
 
-from handlers.commands import start, newgame, board, send_invite_link
+from handlers.commands import start, newgame, board, send_invite_link, choose_mode
 from handlers.router import router_text
+
+BOARD15_ENABLED = os.getenv("BOARD15_ENABLED") == "1"
+if BOARD15_ENABLED:
+    from game_board15.handlers import board15, board15_on_click
 
 
 token = os.getenv("BOT_TOKEN")
@@ -52,6 +56,10 @@ bot_app.add_handler(CommandHandler("start", start))
 bot_app.add_handler(CommandHandler("newgame", newgame))
 bot_app.add_handler(CommandHandler("board", board))
 bot_app.add_handler(CallbackQueryHandler(send_invite_link, pattern="^get_link$"))
+bot_app.add_handler(CallbackQueryHandler(choose_mode, pattern="^mode_"))
+if BOARD15_ENABLED:
+    bot_app.add_handler(CommandHandler("board15", board15))
+    bot_app.add_handler(CallbackQueryHandler(board15_on_click, pattern=r"^b15\|"))
 bot_app.add_handler(MessageHandler(filters.TEXT & ~filters.COMMAND, router_text))
 
 

--- a/game_board15/battle.py
+++ b/game_board15/battle.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+from typing import Tuple
+
+from .models import Board15, Ship
+
+MISS, HIT, KILL, REPEAT = 'miss', 'hit', 'kill', 'repeat'
+
+
+def mark_contour(board: Board15, cells: list[Tuple[int, int]]) -> None:
+    for r, c in cells:
+        for dr in (-1, 0, 1):
+            for dc in (-1, 0, 1):
+                nr, nc = r + dr, c + dc
+                if 0 <= nr < 15 and 0 <= nc < 15:
+                    if board.grid[nr][nc] == 0:
+                        board.grid[nr][nc] = 5
+
+
+def apply_shot(board: Board15, coord: Tuple[int, int]) -> str:
+    board.highlight = []
+    r, c = coord
+    cell = board.grid[r][c]
+    if cell in (2, 3, 4, 5):
+        board.highlight = [coord]
+        return REPEAT
+    if cell == 0:
+        board.grid[r][c] = 2
+        board.highlight = [coord]
+        return MISS
+    if cell == 1:
+        board.grid[r][c] = 3
+        board.alive_cells -= 1
+        ship = None
+        for s in board.ships:
+            if coord in s.cells:
+                ship = s
+                break
+        if ship:
+            all_hit = all(board.grid[rr][cc] == 3 for rr, cc in ship.cells)
+            if all_hit:
+                ship.alive = False
+                for rr, cc in ship.cells:
+                    board.grid[rr][cc] = 4
+                mark_contour(board, ship.cells)
+                board.highlight = ship.cells.copy()
+                return KILL
+        board.highlight = [coord]
+        return HIT
+    return MISS

--- a/game_board15/handlers.py
+++ b/game_board15/handlers.py
@@ -1,0 +1,177 @@
+from __future__ import annotations
+
+from telegram import (
+    Update,
+    InputMediaPhoto,
+    InlineKeyboardMarkup,
+    InlineKeyboardButton,
+)
+from telegram.ext import ContextTypes
+
+from .state import Board15State
+from .renderer import render_board, VIEW
+from . import storage, parser, battle
+from logic.phrases import (
+    ENEMY_HIT,
+    ENEMY_KILL,
+    ENEMY_MISS,
+    SELF_HIT,
+    SELF_KILL,
+    SELF_MISS,
+    random_phrase,
+    random_joke,
+)
+import random
+
+STATE_KEY = "board15_state"
+
+
+def _keyboard() -> InlineKeyboardMarkup:
+    arrows = [
+        [
+            InlineKeyboardButton("◀️", callback_data="b15|mv|-1|0"),
+            InlineKeyboardButton("▲", callback_data="b15|mv|0|-1"),
+            InlineKeyboardButton("▼", callback_data="b15|mv|0|1"),
+            InlineKeyboardButton("▶️", callback_data="b15|mv|1|0"),
+        ]
+    ]
+    matrix = []
+    for r in range(VIEW):
+        row = []
+        for c in range(VIEW):
+            row.append(InlineKeyboardButton("·", callback_data=f"b15|pick|{r}|{c}"))
+        matrix.append(row)
+    actions = [
+        [
+            InlineKeyboardButton("✅", callback_data="b15|act|confirm"),
+            InlineKeyboardButton("↩️", callback_data="b15|act|cancel"),
+        ]
+    ]
+    return InlineKeyboardMarkup(arrows + matrix + actions)
+
+
+def _phrase_or_joke(match, player_key: str, phrases: list[str]) -> str:
+    shots = match.shots[player_key]
+    start = shots.get("joke_start")
+    if start is None:
+        start = shots["joke_start"] = random.randint(1, 10)
+    count = shots.get("move_count", 0)
+    if count >= start and (count - start) % 10 == 0:
+        return f"Слушай анекдот:\n{random_joke()}\n\n"
+    return f"{random_phrase(phrases)} "
+
+
+async def board15(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+    args = getattr(context, 'args', None)
+    if args:
+        match_id = args[0]
+        match = storage.join_match(match_id, update.effective_user.id, update.effective_chat.id)
+        if not match:
+            await update.message.reply_text('Матч не найден или заполнен.')
+            return
+        await update.message.reply_text('Вы присоединились к матчу. Отправьте "авто" для расстановки.')
+    else:
+        match = storage.create_match(update.effective_user.id, update.effective_chat.id)
+        await update.message.reply_text(
+            f'Матч создан. Передайте друзьям команду /board15 {match.match_id} для присоединения.'
+        )
+    player_key = next(k for k, p in match.players.items() if p.user_id == update.effective_user.id)
+    state = Board15State(chat_id=update.effective_chat.id)
+    state.board = [row[:] for row in match.boards[player_key].grid]
+    buf = render_board(state)
+    msg = await update.message.reply_photo(buf, reply_markup=_keyboard())
+    state.message_id = msg.message_id
+    context.chat_data[STATE_KEY] = state
+
+
+async def board15_on_click(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+    query = update.callback_query
+    data = query.data.split("|")
+    state: Board15State = context.chat_data.get(STATE_KEY)
+    if not state:
+        await query.answer()
+        return
+    if data[1] == "mv":
+        dx, dy = int(data[2]), int(data[3])
+        state.window_left = max(0, min(15 - VIEW, state.window_left + dx))
+        state.window_top = max(0, min(15 - VIEW, state.window_top + dy))
+    elif data[1] == "pick":
+        r, c = int(data[2]), int(data[3])
+        state.selected = (state.window_top + r, state.window_left + c)
+    elif data[1] == "act" and data[2] == "confirm":
+        if state.selected is None:
+            await query.answer("Клетка не выбрана")
+            return
+        match = storage.find_match_by_user(query.from_user.id)
+        if not match:
+            await query.answer("Матч не найден")
+            return
+        player_key = next(k for k, p in match.players.items() if p.user_id == query.from_user.id)
+        if match.turn != player_key:
+            await query.answer("Не ваш ход")
+            return
+        coord = state.selected
+        enemies = [k for k in match.players if k != player_key]
+        results = {}
+        hit_any = False
+        for enemy in enemies:
+            res = battle.apply_shot(match.boards[enemy], coord)
+            results[enemy] = res
+            if res in (battle.HIT, battle.KILL):
+                hit_any = True
+        for k in match.shots:
+            shots = match.shots[k]
+            shots.setdefault('move_count', 0)
+            shots.setdefault('joke_start', random.randint(1, 10))
+            shots['move_count'] += 1
+        coord_str = parser.format_coord(coord)
+        parts_self = []
+        next_player = player_key
+        for enemy, res in results.items():
+            if res == battle.MISS:
+                phrase_self = _phrase_or_joke(match, player_key, SELF_MISS)
+                phrase_enemy = _phrase_or_joke(match, enemy, ENEMY_MISS)
+                parts_self.append(f"{enemy}: мимо. {phrase_self}")
+                await context.bot.send_message(match.players[enemy].chat_id, f"{coord_str} - соперник промахнулся. {phrase_enemy}")
+            elif res == battle.HIT:
+                phrase_self = _phrase_or_joke(match, player_key, SELF_HIT)
+                phrase_enemy = _phrase_or_joke(match, enemy, ENEMY_HIT)
+                parts_self.append(f"{enemy}: ранил. {phrase_self}")
+                await context.bot.send_message(match.players[enemy].chat_id, f"{coord_str} - ваш корабль ранен. {phrase_enemy}")
+            elif res == battle.KILL:
+                phrase_self = _phrase_or_joke(match, player_key, SELF_KILL)
+                phrase_enemy = _phrase_or_joke(match, enemy, ENEMY_KILL)
+                parts_self.append(f"{enemy}: уничтожен! {phrase_self}")
+                await context.bot.send_message(match.players[enemy].chat_id, f"{coord_str} - ваш корабль уничтожен. {phrase_enemy}")
+                if match.boards[enemy].alive_cells == 0:
+                    await context.bot.send_message(match.players[enemy].chat_id, 'Все ваши корабли уничтожены. Вы выбыли.')
+        if not hit_any:
+            order = [k for k in ('A', 'B', 'C') if k in match.players and match.boards[k].alive_cells > 0]
+            idx = order.index(player_key)
+            next_player = order[(idx + 1) % len(order)]
+            match.turn = next_player
+            await context.bot.send_message(match.players[next_player].chat_id, 'Ваш ход.')
+        else:
+            match.turn = player_key
+        storage.save_match(match)
+        result_self = f"{coord_str} - {' '.join(parts_self)}" + (' Ваш ход.' if match.turn == player_key else f" Ход {next_player}.")
+        await query.message.reply_text(result_self)
+        state.board = [row[:] for row in match.boards[player_key].grid]
+        state.selected = None
+        alive_players = [k for k, b in match.boards.items() if b.alive_cells > 0]
+        if len(alive_players) == 1:
+            winner = alive_players[0]
+            storage.finish(match, winner)
+            await context.bot.send_message(match.players[winner].chat_id, 'Вы победили!')
+            for k in match.players:
+                if k != winner:
+                    await context.bot.send_message(match.players[k].chat_id, 'Игра окончена. Победил соперник.')
+    elif data[1] == "act" and data[2] == "cancel":
+        state.selected = None
+    buf = render_board(state)
+    try:
+        await query.edit_message_media(InputMediaPhoto(buf))
+    except Exception:
+        pass
+    await query.edit_message_reply_markup(_keyboard())
+    await query.answer()

--- a/game_board15/models.py
+++ b/game_board15/models.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import List, Tuple, Dict
+from datetime import datetime
+import uuid
+import random
+
+Coord = Tuple[int, int]
+
+
+@dataclass
+class Ship:
+    cells: List[Coord]
+    alive: bool = True
+
+
+@dataclass
+class Board15:
+    grid: List[List[int]] = field(default_factory=lambda: [[0] * 15 for _ in range(15)])
+    ships: List[Ship] = field(default_factory=list)
+    alive_cells: int = 20
+    highlight: List[Coord] = field(default_factory=list)
+
+
+@dataclass
+class Player:
+    user_id: int
+    chat_id: int
+    ready: bool = False
+
+
+@dataclass
+class Match15:
+    match_id: str
+    status: str = "waiting"  # waiting|placing|playing|finished
+    created_at: str = field(default_factory=lambda: datetime.utcnow().isoformat())
+    players: Dict[str, Player] = field(default_factory=dict)
+    turn: str = "A"
+    boards: Dict[str, Board15] = field(default_factory=dict)
+    shots: Dict[str, Dict[str, object]] = field(
+        default_factory=lambda: {
+            k: {
+                "history": [],
+                "last_result": None,
+                "move_count": 0,
+                "joke_start": random.randint(1, 10),
+            }
+            for k in ("A", "B", "C")
+        }
+    )
+    messages: Dict[str, Dict[str, int]] = field(default_factory=dict)
+
+    @staticmethod
+    def new(a_user_id: int, a_chat_id: int) -> "Match15":
+        match_id = uuid.uuid4().hex
+        match = Match15(match_id=match_id)
+        match.players["A"] = Player(user_id=a_user_id, chat_id=a_chat_id)
+        for k in ("A", "B", "C"):
+            match.boards[k] = Board15()
+        return match

--- a/game_board15/parser.py
+++ b/game_board15/parser.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+import re
+from typing import Optional, Tuple
+
+ROWS = 'абвгдежзиклмнопр'
+LATIN = 'abcdefghijklmnopr'
+
+
+def normalize(cell: str) -> str:
+    return cell.strip().lower()
+
+
+def parse_coord(cell: str) -> Optional[Tuple[int, int]]:
+    cell = normalize(cell)
+    if len(cell) < 2:
+        return None
+    letter = cell[0]
+    rest = cell[1:]
+    if letter in LATIN:
+        letter = ROWS[LATIN.index(letter)]
+    if letter not in ROWS:
+        return None
+    try:
+        row = int(rest)
+    except ValueError:
+        return None
+    if not 1 <= row <= 15:
+        return None
+    col = ROWS.index(letter)
+    return row - 1, col
+
+
+def format_coord(coord: Tuple[int, int]) -> str:
+    r, c = coord
+    return f"{ROWS[c]}{r+1}"

--- a/game_board15/placement.py
+++ b/game_board15/placement.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+import random
+from typing import List, Tuple
+
+from .models import Board15, Ship
+
+SHIP_SIZES = [4, 3, 3, 2, 2, 2, 1, 1, 1, 1]
+
+
+def can_place(grid: List[List[int]], ship_cells: List[Tuple[int, int]]) -> bool:
+    for r, c in ship_cells:
+        if not (0 <= r < 15 and 0 <= c < 15):
+            return False
+        if grid[r][c] != 0:
+            return False
+        for dr in (-1, 0, 1):
+            for dc in (-1, 0, 1):
+                nr, nc = r + dr, c + dc
+                if 0 <= nr < 15 and 0 <= nc < 15:
+                    if grid[nr][nc] != 0:
+                        return False
+    return True
+
+
+def place_ship(board: Board15, size: int) -> None:
+    placed = False
+    while not placed:
+        orient = random.choice(['h', 'v'])
+        if orient == 'h':
+            r = random.randint(0, 14)
+            c = random.randint(0, 15 - size)
+        else:
+            r = random.randint(0, 15 - size)
+            c = random.randint(0, 14)
+        cells = []
+        for i in range(size):
+            rr = r + (i if orient == 'v' else 0)
+            cc = c + (i if orient == 'h' else 0)
+            cells.append((rr, cc))
+        if can_place(board.grid, cells):
+            ship = Ship(cells=cells)
+            board.ships.append(ship)
+            for rr, cc in cells:
+                board.grid[rr][cc] = 1
+            placed = True
+
+
+def random_board() -> Board15:
+    board = Board15()
+    for size in SHIP_SIZES:
+        place_ship(board, size)
+    return board

--- a/game_board15/renderer.py
+++ b/game_board15/renderer.py
@@ -1,0 +1,94 @@
+from __future__ import annotations
+
+import os
+from io import BytesIO
+from typing import Tuple
+
+from PIL import Image, ImageDraw, ImageFont
+
+from .state import Board15State
+
+TILE_PX = int(os.getenv("BOARD15_TILE_PX", "44"))
+VIEW = int(os.getenv("BOARD15_VIEW", "5"))
+FONT_PATH = os.getenv(
+    "BOARD15_FONT_PATH", "/usr/share/fonts/truetype/dejavu/DejaVuSans.ttf"
+)
+THEME = os.getenv("BOARD15_THEME", "light")
+
+COLORS = {
+    "light": {
+        "bg": (255, 255, 255, 255),
+        "grid": (200, 200, 200, 255),
+        "window": (0, 120, 215, 80),
+        "mark": (0, 0, 0, 255),
+    },
+    "dark": {
+        "bg": (0, 0, 0, 255),
+        "grid": (80, 80, 80, 255),
+        "window": (0, 120, 215, 120),
+        "mark": (220, 220, 220, 255),
+    },
+}
+
+
+def render_board(state: Board15State) -> BytesIO:
+    """Render the 15x15 board into a PNG image.
+
+    Only a 5x5 window is highlighted to guide the user's current view.
+    """
+
+    margin = TILE_PX
+    size = 15 * TILE_PX
+    width = margin * 2 + size
+    height = margin * 2 + size
+    img = Image.new("RGBA", (width, height), COLORS[THEME]["bg"])
+    draw = ImageDraw.Draw(img)
+
+    # grid
+    for i in range(16):
+        offset = margin + i * TILE_PX
+        draw.line((margin, offset, margin + size, offset), fill=COLORS[THEME]["grid"])
+        draw.line((offset, margin, offset, margin + size), fill=COLORS[THEME]["grid"])
+
+    # marks
+    for r in range(15):
+        for c in range(15):
+            if state.board[r][c]:
+                x0 = margin + c * TILE_PX
+                y0 = margin + r * TILE_PX
+                draw.rectangle(
+                    (x0 + 4, y0 + 4, x0 + TILE_PX - 4, y0 + TILE_PX - 4),
+                    fill=COLORS[THEME]["mark"],
+                )
+
+    # window rectangle
+    wt, wl = state.window_top, state.window_left
+    draw.rectangle(
+        (
+            margin + wl * TILE_PX,
+            margin + wt * TILE_PX,
+            margin + (wl + VIEW) * TILE_PX,
+            margin + (wt + VIEW) * TILE_PX,
+        ),
+        outline=COLORS[THEME]["window"],
+        width=3,
+    )
+
+    # axis labels
+    try:
+        font = ImageFont.truetype(FONT_PATH, int(TILE_PX * 0.6))
+    except OSError:
+        font = ImageFont.load_default()
+
+    letters = [chr(ord("A") + i) for i in range(15)]
+    for idx, ch in enumerate(letters):
+        x = margin + idx * TILE_PX + TILE_PX // 2
+        draw.text((x, margin // 2), ch, fill=COLORS[THEME]["grid"], anchor="mm", font=font)
+    for idx in range(15):
+        y = margin + idx * TILE_PX + TILE_PX // 2
+        draw.text((margin // 2, y), str(idx + 1), fill=COLORS[THEME]["grid"], anchor="mm", font=font)
+
+    buf = BytesIO()
+    img.save(buf, format="PNG")
+    buf.seek(0)
+    return buf

--- a/game_board15/router.py
+++ b/game_board15/router.py
@@ -1,0 +1,137 @@
+from __future__ import annotations
+import random
+from telegram import Update
+from telegram.ext import ContextTypes
+
+from . import storage
+from . import placement, battle, parser
+from logic.phrases import (
+    ENEMY_HIT,
+    ENEMY_KILL,
+    ENEMY_MISS,
+    SELF_HIT,
+    SELF_KILL,
+    SELF_MISS,
+    random_phrase,
+    random_joke,
+)
+
+
+def _phrase_or_joke(match, player_key: str, phrases: list[str]) -> str:
+    shots = match.shots[player_key]
+    start = shots.get("joke_start")
+    if start is None:
+        start = shots["joke_start"] = random.randint(1, 10)
+    count = shots.get("move_count", 0)
+    if count >= start and (count - start) % 10 == 0:
+        return f"Слушай анекдот:\n{random_joke()}\n\n"
+    return f"{random_phrase(phrases)} "
+
+
+async def router_text(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+    user_id = update.effective_user.id
+    text = update.message.text.strip()
+    match = storage.find_match_by_user(user_id)
+    if not match:
+        await update.message.reply_text('Вы не участвуете в матче. Используйте /board15 <id>.')
+        return
+    for key, p in match.players.items():
+        if p.user_id == user_id:
+            player_key = key
+            break
+    enemy_keys = [k for k in match.players if k != player_key]
+
+    if text.startswith('@'):
+        parts = text[1:].split(maxsplit=1)
+        if len(parts) == 2:
+            target, msg = parts
+            target = target.upper()[0]
+            if target in match.players and target != player_key:
+                await context.bot.send_message(match.players[target].chat_id, msg)
+        return
+
+    if match.status == 'placing':
+        if text.lower() == 'авто':
+            board = placement.random_board()
+            storage.save_board(match, player_key, board)
+            if match.status == 'playing':
+                for k in match.players:
+                    await context.bot.send_message(
+                        match.players[k].chat_id,
+                        'Все готовы. Бой начинается! ' + ('Ваш ход.' if match.turn == k else 'Ждём хода соперника.'),
+                    )
+            else:
+                await update.message.reply_text('Корабли расставлены. Ожидаем остальных.')
+            return
+        await update.message.reply_text('Введите "авто" для расстановки.')
+        return
+
+    if match.status != 'playing':
+        await update.message.reply_text('Матч ещё не начался.')
+        return
+
+    if match.turn != player_key:
+        await update.message.reply_text('Сейчас ход другого игрока.')
+        return
+
+    coord = parser.parse_coord(text)
+    if coord is None:
+        await update.message.reply_text('Не понял клетку. Пример: e5.')
+        return
+
+    results = {}
+    hit_any = False
+    for enemy in enemy_keys:
+        res = battle.apply_shot(match.boards[enemy], coord)
+        results[enemy] = res
+        if res in (battle.HIT, battle.KILL):
+            hit_any = True
+    for k in match.shots:
+        shots = match.shots[k]
+        shots.setdefault('move_count', 0)
+        shots.setdefault('joke_start', random.randint(1, 10))
+        shots['move_count'] += 1
+    storage.save_match(match)
+
+    coord_str = parser.format_coord(coord)
+    parts_self = []
+    next_player = player_key
+    for enemy, res in results.items():
+        if res == battle.MISS:
+            phrase_self = _phrase_or_joke(match, player_key, SELF_MISS)
+            phrase_enemy = _phrase_or_joke(match, enemy, ENEMY_MISS)
+            parts_self.append(f"{enemy}: мимо. {phrase_self}")
+            await context.bot.send_message(match.players[enemy].chat_id, f"{coord_str} - соперник промахнулся. {phrase_enemy}")
+        elif res == battle.HIT:
+            phrase_self = _phrase_or_joke(match, player_key, SELF_HIT)
+            phrase_enemy = _phrase_or_joke(match, enemy, ENEMY_HIT)
+            parts_self.append(f"{enemy}: ранил. {phrase_self}")
+            await context.bot.send_message(match.players[enemy].chat_id, f"{coord_str} - ваш корабль ранен. {phrase_enemy}")
+        elif res == battle.KILL:
+            phrase_self = _phrase_or_joke(match, player_key, SELF_KILL)
+            phrase_enemy = _phrase_or_joke(match, enemy, ENEMY_KILL)
+            parts_self.append(f"{enemy}: уничтожен! {phrase_self}")
+            await context.bot.send_message(match.players[enemy].chat_id, f"{coord_str} - ваш корабль уничтожен. {phrase_enemy}")
+            if match.boards[enemy].alive_cells == 0:
+                await context.bot.send_message(match.players[enemy].chat_id, 'Все ваши корабли уничтожены. Вы выбыли.')
+    if not hit_any:
+        order = [k for k in ('A', 'B', 'C') if k in match.players and match.boards[k].alive_cells > 0]
+        idx = order.index(player_key)
+        next_player = order[(idx + 1) % len(order)]
+        match.turn = next_player
+        storage.save_match(match)
+        await context.bot.send_message(match.players[next_player].chat_id, 'Ваш ход.')
+    else:
+        match.turn = player_key
+        storage.save_match(match)
+    result_self = f"{coord_str} - {' '.join(parts_self)}" + (' Ваш ход.' if match.turn == player_key else f" Ход {next_player}.")
+    await update.message.reply_text(result_self)
+
+    alive_players = [k for k, b in match.boards.items() if b.alive_cells > 0]
+    if len(alive_players) == 1:
+        winner = alive_players[0]
+        storage.finish(match, winner)
+        await context.bot.send_message(match.players[winner].chat_id, 'Вы победили!')
+        for k in match.players:
+            if k != winner:
+                await context.bot.send_message(match.players[k].chat_id, 'Игра окончена. Победил соперник.')

--- a/game_board15/state.py
+++ b/game_board15/state.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import List, Optional, Tuple
+
+
+@dataclass
+class Board15State:
+    """State of a 15x15 board with a movable 5x5 window.
+
+    This simplified state container keeps only the data required for
+    rendering the board and tracking user interactions.  The board is a
+    15x15 matrix of integers where ``0`` represents an empty cell.  Other
+    values may be used by the game logic to indicate various markers.
+    """
+
+    board: List[List[int]] = field(
+        default_factory=lambda: [[0] * 15 for _ in range(15)]
+    )
+    window_top: int = 0
+    window_left: int = 0
+    phase: str = "aim"
+    last_img_hash: str = ""
+    chat_id: Optional[int] = None
+    message_id: Optional[int] = None
+    selected: Optional[Tuple[int, int]] = None

--- a/game_board15/storage.py
+++ b/game_board15/storage.py
@@ -1,0 +1,150 @@
+from __future__ import annotations
+import json
+from pathlib import Path
+import logging
+from threading import Lock
+from typing import Dict
+from datetime import datetime
+
+from .models import Match15, Board15, Player, Ship
+
+DATA_FILE = Path("data15.json")
+_lock = Lock()
+logger = logging.getLogger(__name__)
+
+
+def _load_all() -> Dict[str, dict]:
+    if DATA_FILE.exists():
+        try:
+            with DATA_FILE.open("r", encoding="utf-8") as f:
+                return json.load(f)
+        except json.JSONDecodeError:
+            return {}
+    return {}
+
+
+def _save_all(data: Dict[str, dict]) -> str | None:
+    tmp = DATA_FILE.with_suffix('.tmp')
+    try:
+        with tmp.open("w", encoding="utf-8") as f:
+            json.dump(data, f, ensure_ascii=False, indent=2)
+        tmp.replace(DATA_FILE)
+    except OSError as e:
+        logger.exception("Failed to save data15")
+        return str(e)
+    return None
+
+
+def create_match(a_user_id: int, a_chat_id: int) -> Match15:
+    match = Match15.new(a_user_id, a_chat_id)
+    save_match(match)
+    return match
+
+
+def get_match(match_id: str) -> Match15 | None:
+    with _lock:
+        data = _load_all()
+    m = data.get(match_id)
+    if not m:
+        return None
+    match = Match15(match_id=m['match_id'], status=m['status'], created_at=m['created_at'])
+    match.turn = m.get('turn', 'A')
+    match.players = {k: Player(**p) for k, p in m.get('players', {}).items()}
+    match.boards = {}
+    for key, b in m.get('boards', {}).items():
+        ships = [Ship(cells=[tuple(cell) for cell in s.get('cells', [])], alive=s.get('alive', True)) for s in b.get('ships', [])]
+        match.boards[key] = Board15(grid=b.get('grid', [[0]*15 for _ in range(15)]), ships=ships, alive_cells=b.get('alive_cells', 20))
+    match.shots = m.get('shots', match.shots)
+    match.messages = m.get('messages', {})
+    return match
+
+
+def join_match(match_id: str, user_id: int, chat_id: int) -> Match15 | None:
+    match = get_match(match_id)
+    if not match:
+        return None
+    if user_id in [p.user_id for p in match.players.values()]:
+        return None
+    if 'B' not in match.players:
+        match.players['B'] = Player(user_id=user_id, chat_id=chat_id)
+    elif 'C' not in match.players:
+        match.players['C'] = Player(user_id=user_id, chat_id=chat_id)
+    else:
+        return None
+    if len(match.players) == 3:
+        match.status = 'placing'
+    save_match(match)
+    return match
+
+
+def save_board(match: Match15, player_key: str, board: Board15) -> None:
+    with _lock:
+        data = _load_all()
+        m = data.get(match.match_id)
+        if m:
+            current = get_match(match.match_id)
+        else:
+            current = match
+        current.boards[player_key] = board
+        current.players[player_key].ready = True
+        if len(current.players) == 3 and all(p.ready for p in current.players.values()) and current.status != 'playing':
+            current.status = 'playing'
+            current.turn = 'A'
+        data[current.match_id] = {
+            'match_id': current.match_id,
+            'status': current.status,
+            'created_at': current.created_at,
+            'players': {k: vars(p) for k, p in current.players.items()},
+            'turn': current.turn,
+            'boards': {k: {'grid': b.grid, 'ships': [{'cells': s.cells, 'alive': s.alive} for s in b.ships], 'alive_cells': b.alive_cells} for k, b in current.boards.items()},
+            'shots': current.shots,
+            'messages': current.messages,
+        }
+        _save_all(data)
+    match.status = current.status
+    match.turn = current.turn
+    match.players = current.players
+    match.boards = current.boards
+    match.shots = current.shots
+    match.messages = current.messages
+
+
+def save_match(match: Match15) -> str | None:
+    with _lock:
+        data = _load_all()
+        data[match.match_id] = {
+            'match_id': match.match_id,
+            'status': match.status,
+            'created_at': match.created_at,
+            'players': {k: vars(p) for k, p in match.players.items()},
+            'turn': match.turn,
+            'boards': {k: {'grid': b.grid, 'ships': [{'cells': s.cells, 'alive': s.alive} for s in b.ships], 'alive_cells': b.alive_cells} for k, b in match.boards.items()},
+            'shots': match.shots,
+            'messages': match.messages,
+        }
+        return _save_all(data)
+
+
+def finish(match: Match15, winner: str) -> str | None:
+    match.status = 'finished'
+    match.shots[winner]['last_result'] = 'win'
+    return save_match(match)
+
+
+def find_match_by_user(user_id: int) -> Match15 | None:
+    with _lock:
+        data = _load_all()
+    active = {'waiting', 'placing', 'playing'}
+    candidates = []
+    for m in data.values():
+        if m.get('status') not in active:
+            continue
+        players = m.get('players', {})
+        for p in players.values():
+            if p.get('user_id') == user_id:
+                candidates.append(m)
+                break
+    if not candidates:
+        return None
+    latest = max(candidates, key=lambda m: datetime.fromisoformat(m['created_at']))
+    return get_match(latest['match_id'])

--- a/handlers/commands.py
+++ b/handlers/commands.py
@@ -80,6 +80,15 @@ async def start(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
             'Если вы переходили по ссылке-приглашению, отправьте её текст '
             'вручную: /start inv_<id>.'
         )
+        keyboard = InlineKeyboardMarkup(
+            [
+                [
+                    InlineKeyboardButton('Игра вдвоем', callback_data='mode_2'),
+                    InlineKeyboardButton('Игра втроем', callback_data='mode_3'),
+                ]
+            ]
+        )
+        await update.message.reply_text('Выберите режим игры:', reply_markup=keyboard)
 
 
 async def newgame(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
@@ -144,3 +153,13 @@ async def board(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
         f"Ваше поле:\n{own}\nПоле соперника:\n{enemy}",
         parse_mode='HTML',
     )
+
+
+async def choose_mode(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+    """Handle game mode selection from start menu."""
+    query = update.callback_query
+    await query.answer()
+    if query.data == 'mode_2':
+        await query.message.reply_text('Используйте /newgame для классической игры вдвоем.')
+    elif query.data == 'mode_3':
+        await query.message.reply_text('Используйте /board15 для игры втроем на поле 15×15.')

--- a/handlers/router.py
+++ b/handlers/router.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 import random
+import os
 from telegram import Update, ReplyKeyboardMarkup
 from telegram.ext import ContextTypes
 
@@ -58,6 +59,12 @@ async def router_text(update: Update, context: ContextTypes.DEFAULT_TYPE) -> Non
         await newgame(update, context)
         return
     match = storage.find_match_by_user(user_id)
+    if not match and os.getenv("BOARD15_ENABLED") == "1":
+        from game_board15 import storage as storage15, router as router15
+        match15 = storage15.find_match_by_user(user_id)
+        if match15:
+            await router15.router_text(update, context)
+            return
     if not match:
         await update.message.reply_text('Вы не участвуете в матче. Используйте /newgame.')
         return

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ python-telegram-bot>=20
 fastapi
 uvicorn[standard]
 wcwidth
+pillow==10.*


### PR DESCRIPTION
## Summary
- add full three-player 15x15 match models and JSON persistence
- enable joke phrases and direct messaging in new router and board handlers
- update main router to dispatch text commands to three-player mode
- exclude bundled font from version control to avoid binary in repo

## Testing
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ab3ff359348326a6140e35bd0a7f23