### PR TITLE
feat: share links for board15 matches

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -20,7 +20,11 @@ from handlers.router import router_text
 
 BOARD15_ENABLED = os.getenv("BOARD15_ENABLED") == "1"
 if BOARD15_ENABLED:
-    from game_board15.handlers import board15, board15_on_click
+    from game_board15.handlers import (
+        board15,
+        board15_on_click,
+        send_board15_invite_link,
+    )
 
 
 token = os.getenv("BOT_TOKEN")
@@ -60,6 +64,7 @@ bot_app.add_handler(CallbackQueryHandler(choose_mode, pattern="^mode_"))
 if BOARD15_ENABLED:
     bot_app.add_handler(CommandHandler("board15", board15))
     bot_app.add_handler(CallbackQueryHandler(board15_on_click, pattern=r"^b15\|"))
+    bot_app.add_handler(CallbackQueryHandler(send_board15_invite_link, pattern="^b15_get_link$"))
 bot_app.add_handler(MessageHandler(filters.TEXT & ~filters.COMMAND, router_text))
 
 

--- a/tests/test_board15_invite.py
+++ b/tests/test_board15_invite.py
@@ -1,0 +1,103 @@
+import asyncio
+import sys
+import types
+from io import BytesIO
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, call, ANY
+
+# Provide minimal Pillow stub to satisfy imports in game_board15.renderer
+pil = types.ModuleType('PIL')
+pil.Image = types.SimpleNamespace()
+pil.ImageDraw = types.SimpleNamespace()
+pil.ImageFont = types.SimpleNamespace()
+sys.modules.setdefault('PIL', pil)
+
+from handlers.commands import start
+from game_board15 import handlers as h
+from game_board15 import storage as storage15
+
+
+def test_board15_invite_flow(monkeypatch):
+    async def run_test():
+        match = SimpleNamespace(
+            match_id='m1',
+            players={'A': SimpleNamespace(user_id=1, chat_id=1)},
+            boards={'A': SimpleNamespace(grid=[[0] * 15 for _ in range(15)])},
+        )
+        monkeypatch.setattr(storage15, 'create_match', lambda uid, cid: match)
+        monkeypatch.setattr(h, 'render_board', lambda state: BytesIO(b'test'))
+        reply_text = AsyncMock()
+        reply_photo = AsyncMock(return_value=SimpleNamespace(message_id=1))
+        update = SimpleNamespace(
+            message=SimpleNamespace(reply_text=reply_text, reply_photo=reply_photo),
+            effective_user=SimpleNamespace(id=1),
+            effective_chat=SimpleNamespace(id=1),
+        )
+        bot = SimpleNamespace(get_me=AsyncMock(return_value=SimpleNamespace(username='TestBot')))
+        context = SimpleNamespace(bot=bot, chat_data={})
+
+        await h.board15(update, context)
+
+        link = f"https://t.me/TestBot?start=b15_{match.match_id}"
+        assert reply_text.call_args_list == [
+            call('Выберите способ приглашения соперников:', reply_markup=ANY),
+            call('Матч создан. Ожидаем подключения соперников.'),
+        ]
+        assert reply_photo.call_args_list == [call(ANY, reply_markup=ANY)]
+
+    asyncio.run(run_test())
+
+
+def test_send_board15_invite_link(monkeypatch):
+    async def run_test():
+        match = SimpleNamespace(match_id='m1')
+        monkeypatch.setattr(storage15, 'find_match_by_user', lambda uid: match)
+        reply_text = AsyncMock()
+        query = SimpleNamespace(
+            from_user=SimpleNamespace(id=1),
+            message=SimpleNamespace(reply_text=reply_text),
+            answer=AsyncMock(),
+        )
+        update = SimpleNamespace(callback_query=query)
+        bot = SimpleNamespace(get_me=AsyncMock(return_value=SimpleNamespace(username='TestBot')))
+        context = SimpleNamespace(bot=bot)
+
+        await h.send_board15_invite_link(update, context)
+
+        link = f"https://t.me/TestBot?start=b15_{match.match_id}"
+        assert reply_text.call_args_list == [call(f'Пригласите друга: {link}')]
+        assert query.answer.call_count == 1
+
+    asyncio.run(run_test())
+
+
+def test_start_board15_join(monkeypatch):
+    async def run_test():
+        match = SimpleNamespace(
+            players={'A': SimpleNamespace(user_id=1, chat_id=1, ready=False)},
+        )
+        monkeypatch.setattr(storage15, 'join_match', lambda mid, uid, cid: match)
+        reply_text = AsyncMock()
+        reply_photo = AsyncMock()
+        update = SimpleNamespace(
+            message=SimpleNamespace(reply_text=reply_text, reply_photo=reply_photo),
+            effective_user=SimpleNamespace(id=2),
+            effective_chat=SimpleNamespace(id=2),
+        )
+        bot = SimpleNamespace(send_message=AsyncMock())
+        context = SimpleNamespace(args=['b15_m1'], bot=bot)
+
+        await start(update, context)
+
+        assert reply_photo.call_count == 1
+        assert reply_text.call_args_list == [
+            call('Вы присоединились к матчу. Отправьте "авто" для расстановки.'),
+            call('Используйте @<буква> <сообщение>, чтобы отправить сообщение сопернику.'),
+        ]
+        assert bot.send_message.call_args_list == [
+            call(1, 'Соперник присоединился. Отправьте "авто" для расстановки.'),
+            call(1, 'Используйте @<буква> <сообщение>, чтобы отправить сообщение сопернику.'),
+        ]
+
+    asyncio.run(run_test())
+


### PR DESCRIPTION
## Summary
- add shareable invite links for 15x15 mode
- handle `/start b15_<id>` joins and notify existing players
- register 15x15 invite callbacks and tests

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68ab59f2d578832685b22d55839f92ed