### PR TITLE
Improve board15 UI with persistent board and status messages

### DIFF
--- a/game_board15/state.py
+++ b/game_board15/state.py
@@ -23,4 +23,5 @@ class Board15State:
     last_img_hash: str = ""
     chat_id: Optional[int] = None
     message_id: Optional[int] = None
+    status_message_id: Optional[int] = None
     selected: Optional[Tuple[int, int]] = None

--- a/tests/test_board15_invite.py
+++ b/tests/test_board15_invite.py
@@ -23,8 +23,10 @@ def test_board15_invite_flow(monkeypatch):
             match_id='m1',
             players={'A': SimpleNamespace(user_id=1, chat_id=1)},
             boards={'A': SimpleNamespace(grid=[[0] * 15 for _ in range(15)])},
+            messages={},
         )
         monkeypatch.setattr(storage15, 'create_match', lambda uid, cid: match)
+        monkeypatch.setattr(storage15, 'save_match', lambda m: None)
         monkeypatch.setattr(h, 'render_board', lambda state: BytesIO(b'test'))
         reply_text = AsyncMock()
         reply_photo = AsyncMock(return_value=SimpleNamespace(message_id=1))
@@ -42,6 +44,7 @@ def test_board15_invite_flow(monkeypatch):
         assert reply_text.call_args_list == [
             call('Выберите способ приглашения соперников:', reply_markup=ANY),
             call('Матч создан. Ожидаем подключения соперников.'),
+            call('Выберите клетку или введите ход текстом.'),
         ]
         assert reply_photo.call_args_list == [call(ANY, reply_markup=ANY)]
 

--- a/tests/test_board15_router.py
+++ b/tests/test_board15_router.py
@@ -19,6 +19,7 @@ def test_router_auto_sends_boards(monkeypatch):
                 'B': SimpleNamespace(grid=[[0] * 15 for _ in range(15)]),
             },
             turn='A',
+            messages={},
         )
 
         def fake_save_board(m, key, board):
@@ -30,12 +31,14 @@ def test_router_auto_sends_boards(monkeypatch):
 
         monkeypatch.setattr(storage, 'find_match_by_user', lambda uid: match)
         monkeypatch.setattr(storage, 'save_board', fake_save_board)
+        monkeypatch.setattr(storage, 'save_match', lambda m: None)
         monkeypatch.setattr(router.placement, 'random_board', lambda: SimpleNamespace(grid=[[0] * 15 for _ in range(15)]))
         monkeypatch.setattr(router, 'render_board', lambda state: BytesIO(b'test'))
         monkeypatch.setattr(router, '_keyboard', lambda: 'kb')
 
         send_photo = AsyncMock()
-        context = SimpleNamespace(bot=SimpleNamespace(send_photo=send_photo))
+        send_message = AsyncMock()
+        context = SimpleNamespace(bot=SimpleNamespace(send_photo=send_photo, send_message=send_message), chat_data={})
         update = SimpleNamespace(
             message=SimpleNamespace(text='авто', reply_text=AsyncMock()),
             effective_user=SimpleNamespace(id=2),
@@ -44,8 +47,12 @@ def test_router_auto_sends_boards(monkeypatch):
         await router.router_text(update, context)
 
         assert send_photo.call_args_list == [
-            call(10, ANY, caption='Соперник готов. Бой начинается! Ваш ход.', reply_markup='kb'),
-            call(20, ANY, caption='Корабли расставлены. Бой начинается! Ход соперника.', reply_markup='kb'),
+            call(10, ANY, reply_markup='kb'),
+            call(20, ANY, reply_markup='kb'),
+        ]
+        assert send_message.call_args_list == [
+            call(10, 'Соперник готов. Бой начинается! Ваш ход.'),
+            call(20, 'Корабли расставлены. Бой начинается! Ход соперника.'),
         ]
 
     asyncio.run(run_test())


### PR DESCRIPTION
## Summary
- Keep a single 15x15 board message and replace status text instead of spamming new messages
- Track board and status message IDs in state and storage for reuse
- Update router to refresh board on button presses and text moves

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ab646045108326b0907d431abdfebe