### PR TITLE
Use player nicknames in 15x15 battleship

### DIFF
--- a/game_board15/models.py
+++ b/game_board15/models.py
@@ -27,6 +27,7 @@ class Board15:
 class Player:
     user_id: int
     chat_id: int
+    name: str = ""
     ready: bool = False
 
 
@@ -52,10 +53,10 @@ class Match15:
     messages: Dict[str, Dict[str, int]] = field(default_factory=dict)
 
     @staticmethod
-    def new(a_user_id: int, a_chat_id: int) -> "Match15":
+    def new(a_user_id: int, a_chat_id: int, a_name: str) -> "Match15":
         match_id = uuid.uuid4().hex
         match = Match15(match_id=match_id)
-        match.players["A"] = Player(user_id=a_user_id, chat_id=a_chat_id)
+        match.players["A"] = Player(user_id=a_user_id, chat_id=a_chat_id, name=a_name)
         for k in ("A", "B", "C"):
             match.boards[k] = Board15()
         return match

--- a/game_board15/router.py
+++ b/game_board15/router.py
@@ -152,20 +152,22 @@ async def router_text(update: Update, context: ContextTypes.DEFAULT_TYPE) -> Non
     parts_self = []
     next_player = player_key
     for enemy, res in results.items():
+        enemy_obj = match.players.get(enemy)
+        enemy_label = getattr(enemy_obj, 'name', '') or enemy
         if res == battle.MISS:
             phrase_self = _phrase_or_joke(match, player_key, SELF_MISS)
             phrase_enemy = _phrase_or_joke(match, enemy, ENEMY_MISS)
-            parts_self.append(f"{enemy}: мимо. {phrase_self}")
+            parts_self.append(f"{enemy_label}: мимо. {phrase_self}")
             await context.bot.send_message(match.players[enemy].chat_id, f"{coord_str} - соперник промахнулся. {phrase_enemy}")
         elif res == battle.HIT:
             phrase_self = _phrase_or_joke(match, player_key, SELF_HIT)
             phrase_enemy = _phrase_or_joke(match, enemy, ENEMY_HIT)
-            parts_self.append(f"{enemy}: ранил. {phrase_self}")
+            parts_self.append(f"{enemy_label}: ранил. {phrase_self}")
             await context.bot.send_message(match.players[enemy].chat_id, f"{coord_str} - ваш корабль ранен. {phrase_enemy}")
         elif res == battle.KILL:
             phrase_self = _phrase_or_joke(match, player_key, SELF_KILL)
             phrase_enemy = _phrase_or_joke(match, enemy, ENEMY_KILL)
-            parts_self.append(f"{enemy}: уничтожен! {phrase_self}")
+            parts_self.append(f"{enemy_label}: уничтожен! {phrase_self}")
             await context.bot.send_message(match.players[enemy].chat_id, f"{coord_str} - ваш корабль уничтожен. {phrase_enemy}")
             if match.boards[enemy].alive_cells == 0:
                 await context.bot.send_message(match.players[enemy].chat_id, 'Все ваши корабли уничтожены. Вы выбыли.')
@@ -179,7 +181,9 @@ async def router_text(update: Update, context: ContextTypes.DEFAULT_TYPE) -> Non
     else:
         match.turn = player_key
         storage.save_match(match)
-    result_self = f"{coord_str} - {' '.join(parts_self)}" + (' Ваш ход.' if match.turn == player_key else f" Ход {next_player}.")
+    next_obj = match.players.get(next_player)
+    next_name = getattr(next_obj, 'name', '') or next_player
+    result_self = f"{coord_str} - {' '.join(parts_self)}" + (' Ваш ход.' if match.turn == player_key else f" Ход {next_name}.")
     await _send_state(context, match, player_key, result_self)
 
     alive_players = [k for k, b in match.boards.items() if b.alive_cells > 0]

--- a/game_board15/storage.py
+++ b/game_board15/storage.py
@@ -35,8 +35,8 @@ def _save_all(data: Dict[str, dict]) -> str | None:
     return None
 
 
-def create_match(a_user_id: int, a_chat_id: int) -> Match15:
-    match = Match15.new(a_user_id, a_chat_id)
+def create_match(a_user_id: int, a_chat_id: int, a_name: str = "") -> Match15:
+    match = Match15.new(a_user_id, a_chat_id, a_name)
     save_match(match)
     return match
 
@@ -59,16 +59,16 @@ def get_match(match_id: str) -> Match15 | None:
     return match
 
 
-def join_match(match_id: str, user_id: int, chat_id: int) -> Match15 | None:
+def join_match(match_id: str, user_id: int, chat_id: int, name: str = "") -> Match15 | None:
     match = get_match(match_id)
     if not match:
         return None
     if user_id in [p.user_id for p in match.players.values()]:
         return None
     if 'B' not in match.players:
-        match.players['B'] = Player(user_id=user_id, chat_id=chat_id)
+        match.players['B'] = Player(user_id=user_id, chat_id=chat_id, name=name)
     elif 'C' not in match.players:
-        match.players['C'] = Player(user_id=user_id, chat_id=chat_id)
+        match.players['C'] = Player(user_id=user_id, chat_id=chat_id, name=name)
     else:
         return None
     if len(match.players) == 3:

--- a/handlers/commands.py
+++ b/handlers/commands.py
@@ -77,7 +77,8 @@ async def start(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
     elif args and args[0].startswith('b15_'):
         match_id = args[0][4:]
         from game_board15 import storage as storage15
-        match = storage15.join_match(match_id, update.effective_user.id, update.effective_chat.id)
+        name = getattr(update.effective_user, 'first_name', '') or ''
+        match = storage15.join_match(match_id, update.effective_user.id, update.effective_chat.id, name)
         if match:
             with welcome_photo() as img:
                 await update.message.reply_photo(img, caption='Добро пожаловать в игру!')

--- a/tests/test_board15_invite.py
+++ b/tests/test_board15_invite.py
@@ -21,18 +21,18 @@ def test_board15_invite_flow(monkeypatch):
     async def run_test():
         match = SimpleNamespace(
             match_id='m1',
-            players={'A': SimpleNamespace(user_id=1, chat_id=1)},
+            players={'A': SimpleNamespace(user_id=1, chat_id=1, name='Alice')},
             boards={'A': SimpleNamespace(grid=[[0] * 15 for _ in range(15)])},
             messages={},
         )
-        monkeypatch.setattr(storage15, 'create_match', lambda uid, cid: match)
+        monkeypatch.setattr(storage15, 'create_match', lambda uid, cid, name=None: match)
         monkeypatch.setattr(storage15, 'save_match', lambda m: None)
         monkeypatch.setattr(h, 'render_board', lambda state: BytesIO(b'test'))
         reply_text = AsyncMock()
         reply_photo = AsyncMock(return_value=SimpleNamespace(message_id=1))
         update = SimpleNamespace(
             message=SimpleNamespace(reply_text=reply_text, reply_photo=reply_photo),
-            effective_user=SimpleNamespace(id=1),
+            effective_user=SimpleNamespace(id=1, first_name='Alice'),
             effective_chat=SimpleNamespace(id=1),
         )
         bot = SimpleNamespace(get_me=AsyncMock(return_value=SimpleNamespace(username='TestBot')))
@@ -77,14 +77,14 @@ def test_send_board15_invite_link(monkeypatch):
 def test_start_board15_join(monkeypatch):
     async def run_test():
         match = SimpleNamespace(
-            players={'A': SimpleNamespace(user_id=1, chat_id=1, ready=False)},
+            players={'A': SimpleNamespace(user_id=1, chat_id=1, ready=False, name='Alice')},
         )
-        monkeypatch.setattr(storage15, 'join_match', lambda mid, uid, cid: match)
+        monkeypatch.setattr(storage15, 'join_match', lambda mid, uid, cid, name=None: match)
         reply_text = AsyncMock()
         reply_photo = AsyncMock()
         update = SimpleNamespace(
             message=SimpleNamespace(reply_text=reply_text, reply_photo=reply_photo),
-            effective_user=SimpleNamespace(id=2),
+            effective_user=SimpleNamespace(id=2, first_name='Bob'),
             effective_chat=SimpleNamespace(id=2),
         )
         bot = SimpleNamespace(send_message=AsyncMock())

--- a/tests/test_board15_router.py
+++ b/tests/test_board15_router.py
@@ -11,8 +11,8 @@ def test_router_auto_sends_boards(monkeypatch):
         match = SimpleNamespace(
             status='placing',
             players={
-                'A': SimpleNamespace(user_id=1, chat_id=10, ready=True),
-                'B': SimpleNamespace(user_id=2, chat_id=20, ready=False),
+                'A': SimpleNamespace(user_id=1, chat_id=10, ready=True, name='Alice'),
+                'B': SimpleNamespace(user_id=2, chat_id=20, ready=False, name='Bob'),
             },
             boards={
                 'A': SimpleNamespace(grid=[[0] * 15 for _ in range(15)]),
@@ -41,7 +41,7 @@ def test_router_auto_sends_boards(monkeypatch):
         context = SimpleNamespace(bot=SimpleNamespace(send_photo=send_photo, send_message=send_message), chat_data={})
         update = SimpleNamespace(
             message=SimpleNamespace(text='авто', reply_text=AsyncMock()),
-            effective_user=SimpleNamespace(id=2),
+            effective_user=SimpleNamespace(id=2, first_name='Bob'),
         )
 
         await router.router_text(update, context)
@@ -54,6 +54,47 @@ def test_router_auto_sends_boards(monkeypatch):
             call(10, 'Соперник готов. Бой начинается! Ваш ход.'),
             call(20, 'Корабли расставлены. Бой начинается! Ход соперника.'),
         ]
+
+    asyncio.run(run_test())
+
+
+def test_router_uses_player_names(monkeypatch):
+    async def run_test():
+        match = SimpleNamespace(
+            status='playing',
+            players={
+                'A': SimpleNamespace(user_id=1, chat_id=10, name='Alice'),
+                'B': SimpleNamespace(user_id=2, chat_id=20, name='Bob'),
+                'C': SimpleNamespace(user_id=3, chat_id=30, name='Carl'),
+            },
+            boards={
+                'A': SimpleNamespace(alive_cells=20),
+                'B': SimpleNamespace(alive_cells=20),
+                'C': SimpleNamespace(alive_cells=20),
+            },
+            turn='A',
+            shots={'A': {}, 'B': {}, 'C': {}},
+            messages={'A': {}},
+        )
+
+        monkeypatch.setattr(storage, 'find_match_by_user', lambda uid: match)
+        monkeypatch.setattr(storage, 'save_match', lambda m: None)
+        monkeypatch.setattr(router.parser, 'parse_coord', lambda text: (0, 0))
+        monkeypatch.setattr(router.parser, 'format_coord', lambda coord: 'a1')
+        monkeypatch.setattr(router.battle, 'apply_shot', lambda board, coord: router.battle.MISS)
+        monkeypatch.setattr(router, '_phrase_or_joke', lambda m, pk, ph: '')
+        send_state = AsyncMock()
+        monkeypatch.setattr(router, '_send_state', send_state)
+
+        update = SimpleNamespace(message=SimpleNamespace(text='a1'), effective_user=SimpleNamespace(id=1))
+        context = SimpleNamespace(chat_data={}, bot=SimpleNamespace(send_message=AsyncMock()))
+
+        await router.router_text(update, context)
+
+        msg = send_state.call_args[0][3]
+        assert 'Bob' in msg and 'Carl' in msg
+        assert 'B:' not in msg and 'C:' not in msg
+        assert msg.strip().endswith('Ход Bob.')
 
     asyncio.run(run_test())
 


### PR DESCRIPTION
## Summary
- store a `name` for each player in 15x15 mode
- capture and persist player names when creating or joining matches
- show nicknames instead of A/B/C in shot and turn messages

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68ab76b1da088326b7fc81f1b97ca3f3