### PR TITLE
Add test mode and second-place tracking for three-player variant

### DIFF
--- a/game_board15/__init__.py
+++ b/game_board15/__init__.py
@@ -1,0 +1,10 @@
+import os
+
+# Flag to enable single-user test mode for the 15x15 three-player variant.
+# When the environment variable ``B15_TEST_MODE`` is set to ``"1"`` or
+# ``"true"`` (case-insensitive), all three players are controlled by the same
+# Telegram user.  This allows sequential testing of turns without inviting
+# additional participants.  In production the variable should be unset so that
+# three separate users are required.
+TEST_MODE = os.getenv("B15_TEST_MODE", "").lower() in {"1", "true", "yes"}
+

--- a/game_board15/models.py
+++ b/game_board15/models.py
@@ -27,6 +27,7 @@ class Board15:
 class Player:
     user_id: int
     chat_id: int
+    name: str = ""
     ready: bool = False
 
 
@@ -52,10 +53,10 @@ class Match15:
     messages: Dict[str, Dict[str, int]] = field(default_factory=dict)
 
     @staticmethod
-    def new(a_user_id: int, a_chat_id: int) -> "Match15":
+    def new(a_user_id: int, a_chat_id: int, name: str = "") -> "Match15":
         match_id = uuid.uuid4().hex
         match = Match15(match_id=match_id)
-        match.players["A"] = Player(user_id=a_user_id, chat_id=a_chat_id)
+        match.players["A"] = Player(user_id=a_user_id, chat_id=a_chat_id, name=name)
         for k in ("A", "B", "C"):
             match.boards[k] = Board15()
         return match

--- a/game_board15/router.py
+++ b/game_board15/router.py
@@ -1,10 +1,11 @@
 from __future__ import annotations
 import random
+from datetime import datetime
 from telegram import Update, InputMediaPhoto
 from telegram.ext import ContextTypes
 
 from . import storage
-from . import placement, battle, parser
+from . import placement, battle, parser, TEST_MODE
 from .handlers import _keyboard, STATE_KEY
 from .renderer import render_board
 from .state import Board15State
@@ -89,10 +90,13 @@ async def router_text(update: Update, context: ContextTypes.DEFAULT_TYPE) -> Non
     if not match:
         await update.message.reply_text('Вы не участвуете в матче. Используйте /board15 <id>.')
         return
-    for key, p in match.players.items():
-        if p.user_id == user_id:
-            player_key = key
-            break
+    if TEST_MODE:
+        player_key = context.chat_data.get('b15_active', 'A')
+    else:
+        for key, p in match.players.items():
+            if p.user_id == user_id:
+                player_key = key
+                break
     enemy_keys = [k for k in match.players if k != player_key]
 
     if text.startswith('@'):
@@ -115,8 +119,16 @@ async def router_text(update: Update, context: ContextTypes.DEFAULT_TYPE) -> Non
                     )
                     msg += 'Ваш ход.' if match.turn == k else 'Ход соперника.'
                     await _send_state(context, match, k, msg)
+                context.chat_data['b15_active'] = match.turn
             else:
                 await _send_state(context, match, player_key, 'Корабли расставлены. Ожидаем остальных.')
+                if TEST_MODE:
+                    order = ['A', 'B', 'C']
+                    idx = order.index(player_key)
+                    next_key = order[(idx + 1) % 3]
+                    context.chat_data['b15_active'] = next_key
+                    await _send_state(context, match, next_key, 'Расставьте корабли. Используйте команду "авто".')
+                return
             return
         await update.message.reply_text('Введите "авто" для расстановки.')
         return
@@ -158,22 +170,26 @@ async def router_text(update: Update, context: ContextTypes.DEFAULT_TYPE) -> Non
     parts_self = []
     next_player = player_key
     for enemy, res in results.items():
+        enemy_obj = match.players.get(enemy)
+        enemy_label = getattr(enemy_obj, 'name', '') or enemy
         if res == battle.MISS:
             phrase_self = _phrase_or_joke(match, player_key, SELF_MISS)
             phrase_enemy = _phrase_or_joke(match, enemy, ENEMY_MISS)
-            parts_self.append(f"{enemy}: мимо. {phrase_self}")
+            parts_self.append(f"{enemy_label}: мимо. {phrase_self}")
             await context.bot.send_message(match.players[enemy].chat_id, f"{coord_str} - соперник промахнулся. {phrase_enemy}")
         elif res == battle.HIT:
             phrase_self = _phrase_or_joke(match, player_key, SELF_HIT)
             phrase_enemy = _phrase_or_joke(match, enemy, ENEMY_HIT)
-            parts_self.append(f"{enemy}: ранил. {phrase_self}")
+            parts_self.append(f"{enemy_label}: ранил. {phrase_self}")
             await context.bot.send_message(match.players[enemy].chat_id, f"{coord_str} - ваш корабль ранен. {phrase_enemy}")
         elif res == battle.KILL:
             phrase_self = _phrase_or_joke(match, player_key, SELF_KILL)
             phrase_enemy = _phrase_or_joke(match, enemy, ENEMY_KILL)
-            parts_self.append(f"{enemy}: уничтожен! {phrase_self}")
+            parts_self.append(f"{enemy_label}: уничтожен! {phrase_self}")
             await context.bot.send_message(match.players[enemy].chat_id, f"{coord_str} - ваш корабль уничтожен. {phrase_enemy}")
             if match.boards[enemy].alive_cells == 0:
+                match.shots[enemy]["last_result"] = "lose"
+                match.shots[enemy]["lost_at"] = datetime.utcnow().isoformat()
                 await context.bot.send_message(match.players[enemy].chat_id, 'Все ваши корабли уничтожены. Вы выбыли.')
     if not hit_any:
         order = [k for k in ('A', 'B', 'C') if k in match.players and match.boards[k].alive_cells > 0]
@@ -181,12 +197,20 @@ async def router_text(update: Update, context: ContextTypes.DEFAULT_TYPE) -> Non
         next_player = order[(idx + 1) % len(order)]
         match.turn = next_player
         storage.save_match(match)
-        await context.bot.send_message(match.players[next_player].chat_id, 'Ваш ход.')
+        if TEST_MODE:
+            await _send_state(context, match, next_player, 'Ваш ход.')
+        else:
+            await context.bot.send_message(match.players[next_player].chat_id, 'Ваш ход.')
     else:
         match.turn = player_key
         storage.save_match(match)
-    result_self = f"{coord_str} - {' '.join(parts_self)}" + (' Ваш ход.' if match.turn == player_key else f" Ход {next_player}.")
+    next_label = match.players.get(next_player)
+    next_name = getattr(next_label, 'name', '') or next_player
+    result_self = f"{coord_str} - {' '.join(parts_self)}" + (
+        ' Ваш ход.' if match.turn == player_key else f" Ход {next_name}."
+    )
     await _send_state(context, match, player_key, result_self)
+    context.chat_data['b15_active'] = match.turn
 
     alive_players = [k for k, b in match.boards.items() if b.alive_cells > 0]
     if len(alive_players) == 1:

--- a/handlers/commands.py
+++ b/handlers/commands.py
@@ -77,7 +77,8 @@ async def start(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
     elif args and args[0].startswith('b15_'):
         match_id = args[0][4:]
         from game_board15 import storage as storage15
-        match = storage15.join_match(match_id, update.effective_user.id, update.effective_chat.id)
+        name = getattr(update.effective_user, 'first_name', '') or ''
+        match = storage15.join_match(match_id, update.effective_user.id, update.effective_chat.id, name)
         if match:
             with welcome_photo() as img:
                 await update.message.reply_photo(img, caption='Добро пожаловать в игру!')

--- a/tests/test_board15_invite.py
+++ b/tests/test_board15_invite.py
@@ -25,7 +25,7 @@ def test_board15_invite_flow(monkeypatch):
             boards={'A': SimpleNamespace(grid=[[0] * 15 for _ in range(15)])},
             messages={},
         )
-        monkeypatch.setattr(storage15, 'create_match', lambda uid, cid: match)
+        monkeypatch.setattr(storage15, 'create_match', lambda uid, cid, name: match)
         monkeypatch.setattr(storage15, 'save_match', lambda m: None)
         monkeypatch.setattr(h, 'render_board', lambda state: BytesIO(b'test'))
         reply_text = AsyncMock()
@@ -79,7 +79,7 @@ def test_start_board15_join(monkeypatch):
         match = SimpleNamespace(
             players={'A': SimpleNamespace(user_id=1, chat_id=1, ready=False)},
         )
-        monkeypatch.setattr(storage15, 'join_match', lambda mid, uid, cid: match)
+        monkeypatch.setattr(storage15, 'join_match', lambda mid, uid, cid, name: match)
         reply_text = AsyncMock()
         reply_photo = AsyncMock()
         update = SimpleNamespace(

--- a/tests/test_board15_second_place.py
+++ b/tests/test_board15_second_place.py
@@ -1,0 +1,19 @@
+from datetime import datetime, timedelta
+
+from game_board15 import storage
+from game_board15.models import Match15, Player
+
+
+def test_second_place_recorded(monkeypatch, tmp_path):
+    monkeypatch.setattr(storage, "DATA_FILE", tmp_path / "data15.json")
+    m = Match15.new(1, 1, "A")
+    m.players['B'] = Player(user_id=2, chat_id=2, name="B")
+    m.players['C'] = Player(user_id=3, chat_id=3, name="C")
+    now = datetime.utcnow()
+    m.shots['B']['last_result'] = 'lose'
+    m.shots['B']['lost_at'] = (now - timedelta(seconds=5)).isoformat()
+    m.shots['C']['last_result'] = 'lose'
+    m.shots['C']['lost_at'] = now.isoformat()
+    storage.finish(m, 'A')
+    assert m.shots['A']['last_result'] == 'win'
+    assert m.shots['C']['last_result'] == 'second'


### PR DESCRIPTION
## Summary
- allow enabling single-user test mode via `B15_TEST_MODE`
- handle move routing and board updates for sequential turns in test mode
- track second-place finisher by logging elimination order

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68abeaa9249c8326aa205adeb7385773