### PR TITLE
Track second place in board15 matches

### DIFF
--- a/game_board15/models.py
+++ b/game_board15/models.py
@@ -50,6 +50,8 @@ class Match15:
         }
     )
     messages: Dict[str, Dict[str, int]] = field(default_factory=dict)
+    eliminated: List[str] = field(default_factory=list)
+    eliminated_segments: Dict[str, int] = field(default_factory=dict)
 
     @staticmethod
     def new(a_user_id: int, a_chat_id: int) -> "Match15":

--- a/game_board15/router.py
+++ b/game_board15/router.py
@@ -136,10 +136,15 @@ async def router_text(update: Update, context: ContextTypes.DEFAULT_TYPE) -> Non
 
     results = {}
     hit_any = False
+    repeat = False
+    alive_before: dict[str, int] = {}
     for enemy in enemy_keys:
+        alive_before[enemy] = match.boards[enemy].alive_cells
         res = battle.apply_shot(match.boards[enemy], coord)
         results[enemy] = res
-        if res in (battle.HIT, battle.KILL):
+        if res == battle.REPEAT:
+            repeat = True
+        elif res in (battle.HIT, battle.KILL):
             hit_any = True
     for k in match.shots:
         shots = match.shots[k]
@@ -149,6 +154,20 @@ async def router_text(update: Update, context: ContextTypes.DEFAULT_TYPE) -> Non
     storage.save_match(match)
 
     coord_str = parser.format_coord(coord)
+    if repeat:
+        for enemy in enemy_keys:
+            await context.bot.send_message(
+                match.players[enemy].chat_id,
+                f"{coord_str} - соперник стрелял по уже обстрелянной клетке. Ход соперника.",
+            )
+        await _send_state(
+            context,
+            match,
+            player_key,
+            f"{coord_str} - клетка уже обстреляна. Ваш ход.",
+        )
+        return
+
     parts_self = []
     next_player = player_key
     for enemy, res in results.items():
@@ -168,6 +187,9 @@ async def router_text(update: Update, context: ContextTypes.DEFAULT_TYPE) -> Non
             parts_self.append(f"{enemy}: уничтожен! {phrase_self}")
             await context.bot.send_message(match.players[enemy].chat_id, f"{coord_str} - ваш корабль уничтожен. {phrase_enemy}")
             if match.boards[enemy].alive_cells == 0:
+                if enemy not in match.eliminated:
+                    match.eliminated.append(enemy)
+                    match.eliminated_segments[enemy] = alive_before.get(enemy, 0)
                 await context.bot.send_message(match.players[enemy].chat_id, 'Все ваши корабли уничтожены. Вы выбыли.')
     if not hit_any:
         order = [k for k in ('A', 'B', 'C') if k in match.players and match.boards[k].alive_cells > 0]
@@ -186,7 +208,22 @@ async def router_text(update: Update, context: ContextTypes.DEFAULT_TYPE) -> Non
     if len(alive_players) == 1:
         winner = alive_players[0]
         storage.finish(match, winner)
-        await context.bot.send_message(match.players[winner].chat_id, 'Вы победили!')
+        eliminated = [k for k in match.eliminated if k != winner]
+        second = None
+        if eliminated:
+            second = eliminated[0]
+            for p in eliminated[1:]:
+                if match.eliminated_segments.get(p, 0) > match.eliminated_segments.get(second, 0):
+                    second = p
         for k in match.players:
-            if k != winner:
-                await context.bot.send_message(match.players[k].chat_id, 'Игра окончена. Победил соперник.')
+            if k == winner:
+                if second:
+                    msg = f'Вы победили! Второе место занял игрок {second}.'
+                else:
+                    msg = 'Вы победили!'
+            else:
+                if second:
+                    msg = f'Игра окончена. Победил игрок {winner}. Второе место занял игрок {second}.'
+                else:
+                    msg = f'Игра окончена. Победил игрок {winner}.'
+            await context.bot.send_message(match.players[k].chat_id, msg)

--- a/game_board15/storage.py
+++ b/game_board15/storage.py
@@ -56,6 +56,8 @@ def get_match(match_id: str) -> Match15 | None:
         match.boards[key] = Board15(grid=b.get('grid', [[0]*15 for _ in range(15)]), ships=ships, alive_cells=b.get('alive_cells', 20))
     match.shots = m.get('shots', match.shots)
     match.messages = m.get('messages', {})
+    match.eliminated = m.get('eliminated', [])
+    match.eliminated_segments = m.get('eliminated_segments', {})
     return match
 
 
@@ -115,6 +117,8 @@ def save_board(match: Match15, player_key: str, board: Board15) -> None:
                 )
             current.shots = m_dict.get('shots', current.shots)
             current.messages = m_dict.get('messages', {})
+            current.eliminated = m_dict.get('eliminated', [])
+            current.eliminated_segments = m_dict.get('eliminated_segments', {})
         else:
             current = match
 
@@ -146,6 +150,8 @@ def save_board(match: Match15, player_key: str, board: Board15) -> None:
             },
             'shots': current.shots,
             'messages': current.messages,
+            'eliminated': current.eliminated,
+            'eliminated_segments': current.eliminated_segments,
         }
         _save_all(data)
 
@@ -156,6 +162,8 @@ def save_board(match: Match15, player_key: str, board: Board15) -> None:
     match.boards = current.boards
     match.shots = current.shots
     match.messages = current.messages
+    match.eliminated = current.eliminated
+    match.eliminated_segments = current.eliminated_segments
 
 
 def save_match(match: Match15) -> str | None:
@@ -170,6 +178,8 @@ def save_match(match: Match15) -> str | None:
             'boards': {k: {'grid': b.grid, 'ships': [{'cells': s.cells, 'alive': s.alive} for s in b.ships], 'alive_cells': b.alive_cells} for k, b in match.boards.items()},
             'shots': match.shots,
             'messages': match.messages,
+            'eliminated': match.eliminated,
+            'eliminated_segments': match.eliminated_segments,
         }
         return _save_all(data)
 

--- a/tests/test_board15_router.py
+++ b/tests/test_board15_router.py
@@ -57,3 +57,60 @@ def test_router_auto_sends_boards(monkeypatch):
 
     asyncio.run(run_test())
 
+
+def test_router_announces_second_place(monkeypatch):
+    async def run_test():
+        board_b = SimpleNamespace(grid=[[0] * 15 for _ in range(15)], ships=[], alive_cells=0)
+        board_c = SimpleNamespace(
+            grid=[[0] * 15 for _ in range(15)],
+            ships=[SimpleNamespace(cells=[(0, 0)], alive=True)],
+            alive_cells=1,
+        )
+        board_c.grid[0][0] = 1
+        match = SimpleNamespace(
+            status='playing',
+            players={
+                'A': SimpleNamespace(user_id=1, chat_id=10),
+                'B': SimpleNamespace(user_id=2, chat_id=20),
+                'C': SimpleNamespace(user_id=3, chat_id=30),
+            },
+            boards={'A': SimpleNamespace(alive_cells=20), 'B': board_b, 'C': board_c},
+            turn='A',
+            shots={
+                'A': {'history': [], 'move_count': 0, 'joke_start': 10},
+                'B': {'history': [], 'move_count': 0, 'joke_start': 10},
+                'C': {'history': [], 'move_count': 0, 'joke_start': 10},
+            },
+            messages={},
+            eliminated=['B'],
+            eliminated_segments={'B': 0},
+        )
+
+        monkeypatch.setattr(storage, 'find_match_by_user', lambda uid: match)
+        monkeypatch.setattr(storage, 'save_match', lambda m: None)
+        monkeypatch.setattr(storage, 'finish', lambda m, w: None)
+        monkeypatch.setattr(router, '_send_state', AsyncMock())
+        monkeypatch.setattr(router, '_phrase_or_joke', lambda *args: '')
+        monkeypatch.setattr(router.parser, 'parse_coord', lambda t: (0, 0))
+        monkeypatch.setattr(router.parser, 'format_coord', lambda c: 'a1')
+
+        send_message = AsyncMock()
+        context = SimpleNamespace(bot=SimpleNamespace(send_message=send_message), chat_data={})
+        update = SimpleNamespace(
+            message=SimpleNamespace(text='a1', reply_text=AsyncMock()),
+            effective_user=SimpleNamespace(id=1),
+        )
+
+        await router.router_text(update, context)
+
+        assert send_message.call_args_list == [
+            call(20, 'a1 - соперник промахнулся. '),
+            call(30, 'a1 - ваш корабль уничтожен. '),
+            call(30, 'Все ваши корабли уничтожены. Вы выбыли.'),
+            call(10, 'Вы победили! Второе место занял игрок C.'),
+            call(20, 'Игра окончена. Победил игрок A. Второе место занял игрок C.'),
+            call(30, 'Игра окончена. Победил игрок A. Второе место занял игрок C.'),
+        ]
+
+    asyncio.run(run_test())
+


### PR DESCRIPTION
## Summary
- track elimination order and remaining segments in board15 matches
- report winner and runner-up to all players
- handle repeated shots without switching turns
- cover second-place announcement with tests
- avoid marking repeated shots as hits

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ab76b42fd883268acfc014c9e188da