### PR TITLE
Track second place in board15 matches

### DIFF
--- a/game_board15/models.py
+++ b/game_board15/models.py
@@ -27,6 +27,7 @@ class Board15:
 class Player:
     user_id: int
     chat_id: int
+    name: str = ""
     ready: bool = False
 
 
@@ -50,12 +51,14 @@ class Match15:
         }
     )
     messages: Dict[str, Dict[str, int]] = field(default_factory=dict)
+    eliminated: List[str] = field(default_factory=list)
+    eliminated_segments: Dict[str, int] = field(default_factory=dict)
 
     @staticmethod
-    def new(a_user_id: int, a_chat_id: int) -> "Match15":
+    def new(a_user_id: int, a_chat_id: int, a_name: str) -> "Match15":
         match_id = uuid.uuid4().hex
         match = Match15(match_id=match_id)
-        match.players["A"] = Player(user_id=a_user_id, chat_id=a_chat_id)
+        match.players["A"] = Player(user_id=a_user_id, chat_id=a_chat_id, name=a_name)
         for k in ("A", "B", "C"):
             match.boards[k] = Board15()
         return match

--- a/handlers/commands.py
+++ b/handlers/commands.py
@@ -77,7 +77,8 @@ async def start(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
     elif args and args[0].startswith('b15_'):
         match_id = args[0][4:]
         from game_board15 import storage as storage15
-        match = storage15.join_match(match_id, update.effective_user.id, update.effective_chat.id)
+        name = getattr(update.effective_user, 'first_name', '') or ''
+        match = storage15.join_match(match_id, update.effective_user.id, update.effective_chat.id, name)
         if match:
             with welcome_photo() as img:
                 await update.message.reply_photo(img, caption='Добро пожаловать в игру!')

--- a/tests/test_board15_invite.py
+++ b/tests/test_board15_invite.py
@@ -21,18 +21,18 @@ def test_board15_invite_flow(monkeypatch):
     async def run_test():
         match = SimpleNamespace(
             match_id='m1',
-            players={'A': SimpleNamespace(user_id=1, chat_id=1)},
+            players={'A': SimpleNamespace(user_id=1, chat_id=1, name='Alice')},
             boards={'A': SimpleNamespace(grid=[[0] * 15 for _ in range(15)])},
             messages={},
         )
-        monkeypatch.setattr(storage15, 'create_match', lambda uid, cid: match)
+        monkeypatch.setattr(storage15, 'create_match', lambda uid, cid, name=None: match)
         monkeypatch.setattr(storage15, 'save_match', lambda m: None)
         monkeypatch.setattr(h, 'render_board', lambda state: BytesIO(b'test'))
         reply_text = AsyncMock()
         reply_photo = AsyncMock(return_value=SimpleNamespace(message_id=1))
         update = SimpleNamespace(
             message=SimpleNamespace(reply_text=reply_text, reply_photo=reply_photo),
-            effective_user=SimpleNamespace(id=1),
+            effective_user=SimpleNamespace(id=1, first_name='Alice'),
             effective_chat=SimpleNamespace(id=1),
         )
         bot = SimpleNamespace(get_me=AsyncMock(return_value=SimpleNamespace(username='TestBot')))
@@ -77,14 +77,14 @@ def test_send_board15_invite_link(monkeypatch):
 def test_start_board15_join(monkeypatch):
     async def run_test():
         match = SimpleNamespace(
-            players={'A': SimpleNamespace(user_id=1, chat_id=1, ready=False)},
+            players={'A': SimpleNamespace(user_id=1, chat_id=1, ready=False, name='Alice')},
         )
-        monkeypatch.setattr(storage15, 'join_match', lambda mid, uid, cid: match)
+        monkeypatch.setattr(storage15, 'join_match', lambda mid, uid, cid, name=None: match)
         reply_text = AsyncMock()
         reply_photo = AsyncMock()
         update = SimpleNamespace(
             message=SimpleNamespace(reply_text=reply_text, reply_photo=reply_photo),
-            effective_user=SimpleNamespace(id=2),
+            effective_user=SimpleNamespace(id=2, first_name='Bob'),
             effective_chat=SimpleNamespace(id=2),
         )
         bot = SimpleNamespace(send_message=AsyncMock())

--- a/tests/test_board15_router.py
+++ b/tests/test_board15_router.py
@@ -1,9 +1,19 @@
 import asyncio
+import sys
+import types
 from io import BytesIO
 from types import SimpleNamespace
-from unittest.mock import AsyncMock, call, ANY
+from unittest.mock import AsyncMock, Mock, call, ANY
+
+# Provide minimal Pillow stub to satisfy imports in game_board15.renderer
+pil = types.ModuleType('PIL')
+pil.Image = types.SimpleNamespace()
+pil.ImageDraw = types.SimpleNamespace()
+pil.ImageFont = types.SimpleNamespace()
+sys.modules.setdefault('PIL', pil)
 
 from game_board15 import router, storage
+from game_board15.models import Board15
 
 
 def test_router_auto_sends_boards(monkeypatch):
@@ -11,8 +21,8 @@ def test_router_auto_sends_boards(monkeypatch):
         match = SimpleNamespace(
             status='placing',
             players={
-                'A': SimpleNamespace(user_id=1, chat_id=10, ready=True),
-                'B': SimpleNamespace(user_id=2, chat_id=20, ready=False),
+                'A': SimpleNamespace(user_id=1, chat_id=10, ready=True, name='Alice'),
+                'B': SimpleNamespace(user_id=2, chat_id=20, ready=False, name='Bob'),
             },
             boards={
                 'A': SimpleNamespace(grid=[[0] * 15 for _ in range(15)]),
@@ -41,7 +51,7 @@ def test_router_auto_sends_boards(monkeypatch):
         context = SimpleNamespace(bot=SimpleNamespace(send_photo=send_photo, send_message=send_message), chat_data={})
         update = SimpleNamespace(
             message=SimpleNamespace(text='авто', reply_text=AsyncMock()),
-            effective_user=SimpleNamespace(id=2),
+            effective_user=SimpleNamespace(id=2, first_name='Bob'),
         )
 
         await router.router_text(update, context)
@@ -54,6 +64,150 @@ def test_router_auto_sends_boards(monkeypatch):
             call(10, 'Соперник готов. Бой начинается! Ваш ход.'),
             call(20, 'Корабли расставлены. Бой начинается! Ход соперника.'),
         ]
+
+    asyncio.run(run_test())
+
+
+def test_router_announces_second_place(monkeypatch):
+    async def run_test():
+        board_b = SimpleNamespace(grid=[[0] * 15 for _ in range(15)], ships=[], alive_cells=0)
+        board_c = SimpleNamespace(
+            grid=[[0] * 15 for _ in range(15)],
+            ships=[SimpleNamespace(cells=[(0, 0)], alive=True)],
+            alive_cells=1,
+        )
+        board_c.grid[0][0] = 1
+        match = SimpleNamespace(
+            status='playing',
+            players={
+                'A': SimpleNamespace(user_id=1, chat_id=10),
+                'B': SimpleNamespace(user_id=2, chat_id=20),
+                'C': SimpleNamespace(user_id=3, chat_id=30),
+            },
+            boards={'A': SimpleNamespace(alive_cells=20), 'B': board_b, 'C': board_c},
+            turn='A',
+            shots={
+                'A': {'history': [], 'move_count': 0, 'joke_start': 10},
+                'B': {'history': [], 'move_count': 0, 'joke_start': 10},
+                'C': {'history': [], 'move_count': 0, 'joke_start': 10},
+            },
+            messages={},
+            eliminated=['B'],
+            eliminated_segments={'B': 0},
+        )
+
+        monkeypatch.setattr(storage, 'find_match_by_user', lambda uid: match)
+        monkeypatch.setattr(storage, 'save_match', lambda m: None)
+        monkeypatch.setattr(storage, 'finish', lambda m, w: None)
+        monkeypatch.setattr(router, '_send_state', AsyncMock())
+        monkeypatch.setattr(router, '_phrase_or_joke', lambda *args: '')
+        monkeypatch.setattr(router.parser, 'parse_coord', lambda t: (0, 0))
+        monkeypatch.setattr(router.parser, 'format_coord', lambda c: 'a1')
+
+        send_message = AsyncMock()
+        context = SimpleNamespace(bot=SimpleNamespace(send_message=send_message), chat_data={})
+        update = SimpleNamespace(
+            message=SimpleNamespace(text='a1', reply_text=AsyncMock()),
+            effective_user=SimpleNamespace(id=1),
+        )
+
+        await router.router_text(update, context)
+
+        assert send_message.call_args_list == [
+            call(20, 'a1 - соперник промахнулся. '),
+            call(30, 'a1 - ваш корабль уничтожен. '),
+            call(30, 'Все ваши корабли уничтожены. Вы выбыли.'),
+            call(10, 'Вы победили! Второе место занял игрок C.'),
+            call(20, 'Игра окончена. Победил игрок A. Второе место занял игрок C.'),
+            call(30, 'Игра окончена. Победил игрок A. Второе место занял игрок C.'),
+        ]
+
+    asyncio.run(run_test())
+
+def test_router_uses_player_names(monkeypatch):
+    async def run_test():
+        match = SimpleNamespace(
+            status='playing',
+            players={
+                'A': SimpleNamespace(user_id=1, chat_id=10, name='Alice'),
+                'B': SimpleNamespace(user_id=2, chat_id=20, name='Bob'),
+                'C': SimpleNamespace(user_id=3, chat_id=30, name='Carl'),
+            },
+            boards={
+                'A': SimpleNamespace(alive_cells=20),
+                'B': SimpleNamespace(alive_cells=20),
+                'C': SimpleNamespace(alive_cells=20),
+            },
+            turn='A',
+            shots={'A': {}, 'B': {}, 'C': {}},
+            messages={'A': {}},
+        )
+
+        monkeypatch.setattr(storage, 'find_match_by_user', lambda uid: match)
+        monkeypatch.setattr(storage, 'save_match', lambda m: None)
+        monkeypatch.setattr(router.parser, 'parse_coord', lambda text: (0, 0))
+        monkeypatch.setattr(router.parser, 'format_coord', lambda coord: 'a1')
+        monkeypatch.setattr(router.battle, 'apply_shot', lambda board, coord: router.battle.MISS)
+        monkeypatch.setattr(router, '_phrase_or_joke', lambda m, pk, ph: '')
+        send_state = AsyncMock()
+        monkeypatch.setattr(router, '_send_state', send_state)
+
+        update = SimpleNamespace(message=SimpleNamespace(text='a1'), effective_user=SimpleNamespace(id=1))
+        context = SimpleNamespace(chat_data={}, bot=SimpleNamespace(send_message=AsyncMock()))
+
+        await router.router_text(update, context)
+
+        msg = send_state.call_args[0][3]
+        assert 'Bob' in msg and 'Carl' in msg
+        assert 'B:' not in msg and 'C:' not in msg
+        assert msg.strip().endswith('Ход Bob.')
+
+    asyncio.run(run_test())
+
+
+def test_router_repeat_shot(monkeypatch):
+    async def run_test():
+        board_enemy = Board15()
+        board_enemy.grid[0][0] = 2  # already opened
+        match = SimpleNamespace(
+            status='playing',
+            players={'A': SimpleNamespace(user_id=1, chat_id=10),
+                     'B': SimpleNamespace(user_id=2, chat_id=20)},
+            boards={'A': Board15(), 'B': board_enemy},
+            turn='A',
+            shots={'A': {'move_count': 0, 'joke_start': 10},
+                   'B': {'move_count': 0, 'joke_start': 10}},
+            messages={},
+        )
+
+        monkeypatch.setattr(storage, 'find_match_by_user', lambda uid: match)
+        save_match = Mock()
+        monkeypatch.setattr(storage, 'save_match', save_match)
+        send_message = AsyncMock()
+        send_state = AsyncMock()
+        monkeypatch.setattr(router, '_send_state', send_state)
+        monkeypatch.setattr(router.parser, 'parse_coord', lambda t: (0, 0))
+        monkeypatch.setattr(router.parser, 'format_coord', lambda c: 'a1')
+
+        update = SimpleNamespace(
+            message=SimpleNamespace(text='a1', reply_text=AsyncMock()),
+            effective_user=SimpleNamespace(id=1),
+        )
+        context = SimpleNamespace(bot=SimpleNamespace(send_message=send_message), chat_data={})
+
+        await router.router_text(update, context)
+
+        update.message.reply_text.assert_not_called()
+        send_state.assert_called_once()
+        assert send_message.call_args_list == [
+            call(20, 'a1 - соперник стрелял по уже обстрелянной клетке. Ход соперника.'),
+        ]
+        msg_self = send_state.call_args[0][3]
+        assert msg_self == 'a1 - клетка уже обстреляна. Ваш ход.'
+        assert match.turn == 'A'
+        assert match.shots['A']['move_count'] == 0
+        assert match.shots['B']['move_count'] == 0
+        assert save_match.call_count == 0
 
     asyncio.run(run_test())
 


### PR DESCRIPTION
## Summary
- track elimination order and remaining segments in board15 matches
- report winner and runner-up to all players
- handle repeated shots without switching turns
- cover second-place and repeat-shot announcements with tests
- avoid marking repeated shots as hits

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ab76b42fd883268acfc014c9e188da