### PR TITLE
Ensure 15x15 opponents receive board updates

### DIFF
--- a/game_board15/router.py
+++ b/game_board15/router.py
@@ -173,17 +173,32 @@ async def router_text(update: Update, context: ContextTypes.DEFAULT_TYPE) -> Non
             phrase_self = _phrase_or_joke(match, player_key, SELF_MISS)
             phrase_enemy = _phrase_or_joke(match, enemy, ENEMY_MISS)
             parts_self.append(f"{enemy_label}: мимо. {phrase_self}")
-            await context.bot.send_message(match.players[enemy].chat_id, f"{coord_str} - соперник промахнулся. {phrase_enemy}")
+            await _send_state(
+                context,
+                match,
+                enemy,
+                f"{coord_str} - соперник промахнулся. {phrase_enemy}",
+            )
         elif res == battle.HIT:
             phrase_self = _phrase_or_joke(match, player_key, SELF_HIT)
             phrase_enemy = _phrase_or_joke(match, enemy, ENEMY_HIT)
             parts_self.append(f"{enemy_label}: ранил. {phrase_self}")
-            await context.bot.send_message(match.players[enemy].chat_id, f"{coord_str} - ваш корабль ранен. {phrase_enemy}")
+            await _send_state(
+                context,
+                match,
+                enemy,
+                f"{coord_str} - ваш корабль ранен. {phrase_enemy}",
+            )
         elif res == battle.KILL:
             phrase_self = _phrase_or_joke(match, player_key, SELF_KILL)
             phrase_enemy = _phrase_or_joke(match, enemy, ENEMY_KILL)
             parts_self.append(f"{enemy_label}: уничтожен! {phrase_self}")
-            await context.bot.send_message(match.players[enemy].chat_id, f"{coord_str} - ваш корабль уничтожен. {phrase_enemy}")
+            await _send_state(
+                context,
+                match,
+                enemy,
+                f"{coord_str} - ваш корабль уничтожен. {phrase_enemy}",
+            )
             if match.boards[enemy].alive_cells == 0:
                 await context.bot.send_message(match.players[enemy].chat_id, 'Все ваши корабли уничтожены. Вы выбыли.')
     if not hit_any:

--- a/tests/test_board15_send_state.py
+++ b/tests/test_board15_send_state.py
@@ -1,0 +1,49 @@
+import asyncio
+from types import SimpleNamespace
+
+from game_board15 import router, storage, placement
+
+class DummyBot:
+    async def send_message(self, *args, **kwargs):
+        pass
+    async def send_photo(self, *args, **kwargs):
+        pass
+    async def edit_message_media(self, *args, **kwargs):
+        pass
+    async def edit_message_text(self, *args, **kwargs):
+        pass
+
+class DummyMessage:
+    def __init__(self, text):
+        self.text = text
+    async def reply_text(self, *args, **kwargs):
+        pass
+
+async def run_router(update):
+    context = SimpleNamespace(bot=DummyBot(), chat_data={})
+    await router.router_text(update, context)
+
+
+def test_send_state_for_all_players(tmp_path, monkeypatch):
+    monkeypatch.setattr(storage, "DATA_FILE", tmp_path / "data15.json")
+
+    match = storage.create_match(1, 1, "A")
+    storage.join_match(match.match_id, 2, 2, "B")
+    storage.join_match(match.match_id, 3, 3, "C")
+    storage.save_board(match, "A", placement.random_board())
+    storage.save_board(match, "B", placement.random_board())
+    storage.save_board(match, "C", placement.random_board())
+
+    called = []
+    async def fake_send_state(context, match_obj, player_key, message):
+        called.append(player_key)
+    monkeypatch.setattr(router, "_send_state", fake_send_state)
+
+    update = SimpleNamespace(
+        effective_user=SimpleNamespace(id=1),
+        message=DummyMessage("a1"),
+    )
+
+    asyncio.run(run_router(update))
+
+    assert set(called) == {"A", "B", "C"}


### PR DESCRIPTION
## Summary
- Update 15x15 router to send board updates to every affected player after a shot
- Add regression test verifying `_send_state` runs for shooter and opponents

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ac4233b1ac8326ab5b64f836661418