### PR TITLE
feat: render and send player board in board15 mode

### DIFF
--- a/game_board15/renderer.py
+++ b/game_board15/renderer.py
@@ -7,6 +7,7 @@ from typing import Tuple
 from PIL import Image, ImageDraw, ImageFont
 
 from .state import Board15State
+from .models import Board15
 
 TILE_PX = int(os.getenv("BOARD15_TILE_PX", "44"))
 VIEW = int(os.getenv("BOARD15_VIEW", "5"))
@@ -73,6 +74,58 @@ def render_board(state: Board15State) -> BytesIO:
         outline=COLORS[THEME]["window"],
         width=3,
     )
+
+    # axis labels
+    try:
+        font = ImageFont.truetype(FONT_PATH, int(TILE_PX * 0.6))
+    except OSError:
+        font = ImageFont.load_default()
+
+    letters = [chr(ord("A") + i) for i in range(15)]
+    for idx, ch in enumerate(letters):
+        x = margin + idx * TILE_PX + TILE_PX // 2
+        draw.text((x, margin // 2), ch, fill=COLORS[THEME]["grid"], anchor="mm", font=font)
+    for idx in range(15):
+        y = margin + idx * TILE_PX + TILE_PX // 2
+        draw.text((margin // 2, y), str(idx + 1), fill=COLORS[THEME]["grid"], anchor="mm", font=font)
+
+    buf = BytesIO()
+    img.save(buf, format="PNG")
+    buf.seek(0)
+    return buf
+
+
+def render_player_board(board: Board15) -> BytesIO:
+    """Render player's own board with their ships.
+
+    Unlike :func:`render_board`, this version shows the full board without a
+    movable window and marks every non-zero cell which represents the player's
+    fleet and any shots made by the opponent.
+    """
+
+    margin = TILE_PX
+    size = 15 * TILE_PX
+    width = margin * 2 + size
+    height = margin * 2 + size
+    img = Image.new("RGBA", (width, height), COLORS[THEME]["bg"])
+    draw = ImageDraw.Draw(img)
+
+    # grid
+    for i in range(16):
+        offset = margin + i * TILE_PX
+        draw.line((margin, offset, margin + size, offset), fill=COLORS[THEME]["grid"])
+        draw.line((offset, margin, offset, margin + size), fill=COLORS[THEME]["grid"])
+
+    # ship and shot markers
+    for r in range(15):
+        for c in range(15):
+            if board.grid[r][c]:
+                x0 = margin + c * TILE_PX
+                y0 = margin + r * TILE_PX
+                draw.rectangle(
+                    (x0 + 4, y0 + 4, x0 + TILE_PX - 4, y0 + TILE_PX - 4),
+                    fill=COLORS[THEME]["mark"],
+                )
 
     # axis labels
     try:

--- a/game_board15/router.py
+++ b/game_board15/router.py
@@ -6,7 +6,7 @@ from telegram.ext import ContextTypes
 from . import storage
 from . import placement, battle, parser
 from .handlers import _keyboard, STATE_KEY
-from .renderer import render_board
+from .renderer import render_board, render_player_board
 from .state import Board15State
 from logic.phrases import (
     ENEMY_HIT,
@@ -63,6 +63,24 @@ async def _send_state(context: ContextTypes.DEFAULT_TYPE, match, player_key: str
         board_id = msg.message_id
         msgs['board'] = board_id
         state.message_id = board_id
+
+    # player's own board with ships
+    player_buf = render_player_board(match.boards[player_key])
+    player_id = msgs.get('player')
+    if player_id:
+        try:
+            await context.bot.edit_message_media(
+                chat_id=chat_id,
+                message_id=player_id,
+                media=InputMediaPhoto(player_buf),
+            )
+        except Exception:
+            msg = await context.bot.send_photo(chat_id, player_buf)
+            msgs['player'] = msg.message_id
+    else:
+        msg = await context.bot.send_photo(chat_id, player_buf)
+        msgs['player'] = msg.message_id
+
     if status_id:
         try:
             await context.bot.edit_message_text(

--- a/tests/test_board15_router.py
+++ b/tests/test_board15_router.py
@@ -43,7 +43,8 @@ def test_router_auto_sends_boards(monkeypatch):
         monkeypatch.setattr(storage, 'save_board', fake_save_board)
         monkeypatch.setattr(storage, 'save_match', lambda m: None)
         monkeypatch.setattr(router.placement, 'random_board', lambda: SimpleNamespace(grid=[[0] * 15 for _ in range(15)]))
-        monkeypatch.setattr(router, 'render_board', lambda state: BytesIO(b'test'))
+        monkeypatch.setattr(router, 'render_board', lambda state: BytesIO(b'target'))
+        monkeypatch.setattr(router, 'render_player_board', lambda board: BytesIO(b'own'))
         monkeypatch.setattr(router, '_keyboard', lambda: 'kb')
 
         send_photo = AsyncMock()
@@ -58,12 +59,64 @@ def test_router_auto_sends_boards(monkeypatch):
 
         assert send_photo.call_args_list == [
             call(10, ANY, reply_markup='kb'),
+            call(10, ANY),
             call(20, ANY, reply_markup='kb'),
+            call(20, ANY),
         ]
         assert send_message.call_args_list == [
             call(10, 'Соперник готов. Бой начинается! Ваш ход.'),
             call(20, 'Корабли расставлены. Бой начинается! Ход соперника.'),
         ]
+
+    asyncio.run(run_test())
+
+
+def test_router_move_sends_player_board(monkeypatch):
+    async def run_test():
+        match = SimpleNamespace(
+            status='playing',
+            players={
+                'A': SimpleNamespace(user_id=1, chat_id=10, name='Alice'),
+                'B': SimpleNamespace(user_id=2, chat_id=20, name='Bob'),
+            },
+            boards={'A': Board15(), 'B': Board15()},
+            turn='A',
+            shots={'A': {}, 'B': {}},
+            messages={'A': {'board': 1, 'status': 2}, 'B': {'board': 3, 'status': 4}},
+        )
+
+        monkeypatch.setattr(storage, 'find_match_by_user', lambda uid: match)
+        monkeypatch.setattr(storage, 'save_match', lambda m: None)
+        monkeypatch.setattr(router.parser, 'parse_coord', lambda text: (0, 0))
+        monkeypatch.setattr(router.parser, 'format_coord', lambda coord: 'a1')
+        monkeypatch.setattr(router.battle, 'apply_shot', lambda board, coord: router.battle.MISS)
+        monkeypatch.setattr(router, '_phrase_or_joke', lambda m, pk, ph: '')
+        monkeypatch.setattr(router, 'render_board', lambda state: BytesIO(b'target'))
+        called = []
+
+        def fake_render_player_board(board):
+            called.append(board)
+            return BytesIO(b'own')
+
+        monkeypatch.setattr(router, 'render_player_board', fake_render_player_board)
+        monkeypatch.setattr(router, '_keyboard', lambda: 'kb')
+
+        edit_media = AsyncMock()
+        send_photo = AsyncMock()
+        context = SimpleNamespace(
+            bot=SimpleNamespace(
+                edit_message_media=edit_media,
+                edit_message_text=AsyncMock(),
+                send_photo=send_photo,
+                send_message=AsyncMock(),
+            ),
+            chat_data={},
+        )
+        update = SimpleNamespace(message=SimpleNamespace(text='a1', reply_text=AsyncMock()), effective_user=SimpleNamespace(id=1))
+
+        await router.router_text(update, context)
+
+        assert called  # render_player_board was used
 
     asyncio.run(run_test())
 


### PR DESCRIPTION
## Summary
- draw dedicated player board showing ships
- send both targeting and player boards after each move
- cover auto-placement and moves with tests for player board images

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ac4eb51720832698589c26cb136b06