### PR TITLE
Use bot_data for board state cache

### DIFF
--- a/game_board15/handlers.py
+++ b/game_board15/handlers.py
@@ -27,7 +27,7 @@ import random
 
 WELCOME_TEXT = 'Выберите способ приглашения соперников:'
 
-STATE_KEY = "board15_state"
+STATE_KEY = "board15_states"
 
 
 def _keyboard() -> InlineKeyboardMarkup:
@@ -102,7 +102,7 @@ async def board15(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
     status = await update.message.reply_text('Выберите клетку или введите ход текстом.')
     state.message_id = msg.message_id
     state.status_message_id = status.message_id
-    context.chat_data[STATE_KEY] = state
+    context.bot_data.setdefault(STATE_KEY, {})[update.effective_chat.id] = state
     match.messages[player_key] = {
         'board': msg.message_id,
         'status': status.message_id,
@@ -129,7 +129,7 @@ async def board15_test(update: Update, context: ContextTypes.DEFAULT_TYPE) -> No
     status = await update.message.reply_text('Тестовый матч начат. Ход игрока A.')
     state.message_id = msg.message_id
     state.status_message_id = status.message_id
-    context.chat_data[STATE_KEY] = state
+    context.bot_data.setdefault(STATE_KEY, {})[update.effective_chat.id] = state
     match.messages = {
         'A': {'board': msg.message_id, 'status': status.message_id},
         'B': {'board': msg.message_id, 'status': status.message_id},
@@ -154,7 +154,8 @@ async def send_board15_invite_link(update: Update, context: ContextTypes.DEFAULT
 async def board15_on_click(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
     query = update.callback_query
     data = query.data.split("|")
-    state: Board15State = context.chat_data.get(STATE_KEY)
+    states = context.bot_data.get(STATE_KEY, {})
+    state: Board15State | None = states.get(update.effective_chat.id)
     if not state:
         await query.answer()
         return

--- a/game_board15/router.py
+++ b/game_board15/router.py
@@ -35,10 +35,11 @@ async def _send_state(context: ContextTypes.DEFAULT_TYPE, match, player_key: str
     """Render player's board and update their messages."""
 
     chat_id = match.players[player_key].chat_id
-    state: Board15State | None = context.chat_data.get(STATE_KEY)
-    if not state or state.chat_id != chat_id:
+    states = context.bot_data.setdefault(STATE_KEY, {})
+    state: Board15State | None = states.get(chat_id)
+    if not state:
         state = Board15State(chat_id=chat_id)
-        context.chat_data[STATE_KEY] = state
+        states[chat_id] = state
     state.board = [row[:] for row in match.boards[player_key].grid]
     buf = render_board(state)
     msgs = match.messages.setdefault(player_key, {})

--- a/tests/test_board15_invite.py
+++ b/tests/test_board15_invite.py
@@ -36,7 +36,7 @@ def test_board15_invite_flow(monkeypatch):
             effective_chat=SimpleNamespace(id=1),
         )
         bot = SimpleNamespace(get_me=AsyncMock(return_value=SimpleNamespace(username='TestBot')))
-        context = SimpleNamespace(bot=bot, chat_data={})
+        context = SimpleNamespace(bot=bot, chat_data={}, bot_data={})
 
         await h.board15(update, context)
 
@@ -63,7 +63,7 @@ def test_send_board15_invite_link(monkeypatch):
         )
         update = SimpleNamespace(callback_query=query)
         bot = SimpleNamespace(get_me=AsyncMock(return_value=SimpleNamespace(username='TestBot')))
-        context = SimpleNamespace(bot=bot)
+        context = SimpleNamespace(bot=bot, bot_data={})
 
         await h.send_board15_invite_link(update, context)
 
@@ -88,7 +88,7 @@ def test_start_board15_join(monkeypatch):
             effective_chat=SimpleNamespace(id=2),
         )
         bot = SimpleNamespace(send_message=AsyncMock())
-        context = SimpleNamespace(args=['b15_m1'], bot=bot)
+        context = SimpleNamespace(args=['b15_m1'], bot=bot, bot_data={})
 
         await start(update, context)
 

--- a/tests/test_board15_router.py
+++ b/tests/test_board15_router.py
@@ -49,7 +49,7 @@ def test_router_auto_sends_boards(monkeypatch):
 
         send_photo = AsyncMock()
         send_message = AsyncMock()
-        context = SimpleNamespace(bot=SimpleNamespace(send_photo=send_photo, send_message=send_message), chat_data={})
+        context = SimpleNamespace(bot=SimpleNamespace(send_photo=send_photo, send_message=send_message), chat_data={}, bot_data={})
         update = SimpleNamespace(
             message=SimpleNamespace(text='авто', reply_text=AsyncMock()),
             effective_user=SimpleNamespace(id=2, first_name='Bob'),
@@ -111,6 +111,7 @@ def test_router_move_sends_player_board(monkeypatch):
                 send_message=AsyncMock(),
             ),
             chat_data={},
+            bot_data={},
         )
         update = SimpleNamespace(message=SimpleNamespace(text='a1', reply_text=AsyncMock()), effective_user=SimpleNamespace(id=1))
 
@@ -150,7 +151,7 @@ def test_router_uses_player_names(monkeypatch):
         monkeypatch.setattr(router, '_send_state', send_state)
 
         update = SimpleNamespace(message=SimpleNamespace(text='a1'), effective_user=SimpleNamespace(id=1))
-        context = SimpleNamespace(chat_data={}, bot=SimpleNamespace(send_message=AsyncMock()))
+        context = SimpleNamespace(chat_data={}, bot=SimpleNamespace(send_message=AsyncMock()), bot_data={})
 
         await router.router_text(update, context)
 
@@ -185,7 +186,7 @@ def test_router_repeat_shot(monkeypatch):
             message=SimpleNamespace(text='a1', reply_text=AsyncMock()),
             effective_user=SimpleNamespace(id=1),
         )
-        context = SimpleNamespace(bot=SimpleNamespace(send_message=AsyncMock()), chat_data={})
+        context = SimpleNamespace(bot=SimpleNamespace(send_message=AsyncMock()), chat_data={}, bot_data={})
         send_state = AsyncMock()
         monkeypatch.setattr(router, '_send_state', send_state)
 
@@ -239,7 +240,7 @@ def test_router_skips_eliminated_players(monkeypatch):
         monkeypatch.setattr(router, '_send_state', send_state)
 
         send_message = AsyncMock()
-        context = SimpleNamespace(bot=SimpleNamespace(send_message=send_message), chat_data={})
+        context = SimpleNamespace(bot=SimpleNamespace(send_message=send_message), chat_data={}, bot_data={})
         update = SimpleNamespace(message=SimpleNamespace(text='a1'), effective_user=SimpleNamespace(id=1))
 
         await router.router_text(update, context)

--- a/tests/test_board15_send_state.py
+++ b/tests/test_board15_send_state.py
@@ -20,7 +20,7 @@ class DummyMessage:
         pass
 
 async def run_router(update):
-    context = SimpleNamespace(bot=DummyBot(), chat_data={})
+    context = SimpleNamespace(bot=DummyBot(), chat_data={}, bot_data={})
     await router.router_text(update, context)
 
 


### PR DESCRIPTION
## Summary
- Maintain board15 states in a global `bot_data` cache keyed by chat id
- Retrieve/update `Board15State` from this cache in `_send_state` and handlers
- Adjust tests for the new per-chat cache

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ac55f29ad883268934af54fb0981db