### PR TITLE
Add automated three-player test match

### DIFF
--- a/tests/test_board15_test_autoplay.py
+++ b/tests/test_board15_test_autoplay.py
@@ -1,0 +1,25 @@
+import asyncio
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+from game_board15 import handlers, storage
+from game_board15.models import Board15
+
+
+def test_board15_test_autoplay(monkeypatch):
+    async def run():
+        boards = [Board15(), Board15(alive_cells=0), Board15(alive_cells=0)]
+        def fake_random_board():
+            return boards.pop(0)
+        monkeypatch.setattr(handlers.placement, 'random_board', fake_random_board)
+        monkeypatch.setattr(storage, 'save_match', lambda m: None)
+        monkeypatch.setattr(storage, 'finish', lambda m, w: None)
+        update = SimpleNamespace(
+            message=SimpleNamespace(reply_text=AsyncMock()),
+            effective_user=SimpleNamespace(id=1, first_name='Tester'),
+            effective_chat=SimpleNamespace(id=100)
+        )
+        context = SimpleNamespace(bot=SimpleNamespace(send_message=AsyncMock()))
+        await handlers.board15_test(update, context)
+        assert 'Победил игрок A' in context.bot.send_message.call_args_list[-1][0][1]
+    asyncio.run(run())


### PR DESCRIPTION
## Summary
- automate a full three-player test match with dummy opponents
- cover the new test mode with unit test

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ac7e66c7a88326bcf6b980037f664f