### PR TITLE
Highlight selected board15 cell

### DIFF
--- a/game_board15/handlers.py
+++ b/game_board15/handlers.py
@@ -291,6 +291,14 @@ async def board15_on_click(update: Update, context: ContextTypes.DEFAULT_TYPE) -
     elif data[1] == "pick":
         r, c = int(data[2]), int(data[3])
         state.selected = (state.window_top + r, state.window_left + c)
+        buf = render_board(state)
+        try:
+            await query.edit_message_media(InputMediaPhoto(buf))
+        except Exception:
+            pass
+        await query.edit_message_reply_markup(_keyboard())
+        await query.answer()
+        return
     elif data[1] == "act" and data[2] == "confirm":
         if state.selected is None:
             await query.answer("Клетка не выбрана")

--- a/game_board15/renderer.py
+++ b/game_board15/renderer.py
@@ -22,12 +22,14 @@ COLORS = {
         "grid": (200, 200, 200, 255),
         "window": (0, 120, 215, 80),
         "mark": (0, 0, 0, 255),
+        "selected": (255, 0, 0, 255),
     },
     "dark": {
         "bg": (0, 0, 0, 255),
         "grid": (80, 80, 80, 255),
         "window": (0, 120, 215, 120),
         "mark": (220, 220, 220, 255),
+        "selected": (255, 0, 0, 255),
     },
 }
 
@@ -74,6 +76,17 @@ def render_board(state: Board15State) -> BytesIO:
         outline=COLORS[THEME]["window"],
         width=3,
     )
+
+    # selected cell
+    if state.selected is not None:
+        sr, sc = state.selected
+        x0 = margin + sc * TILE_PX
+        y0 = margin + sr * TILE_PX
+        draw.ellipse(
+            (x0 + 4, y0 + 4, x0 + TILE_PX - 4, y0 + TILE_PX - 4),
+            outline=COLORS[THEME]["selected"],
+            width=3,
+        )
 
     # axis labels
     try:


### PR DESCRIPTION
## Summary
- add red selection highlight to board15 renderer
- refresh board image when a cell is picked, remove highlight on cancel

## Testing
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_68acac3227ac8326800751cf8ba551bc