### PR TITLE
Color-code ships per player in test mode

### DIFF
--- a/game_board15/handlers.py
+++ b/game_board15/handlers.py
@@ -98,7 +98,8 @@ async def board15(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
         storage.save_match(match)
     state = Board15State(chat_id=update.effective_chat.id)
     state.board = [row[:] for row in match.boards[player_key].grid]
-    buf = render_board(state)
+    state.player_key = player_key
+    buf = render_board(state, player_key)
     msg = await update.message.reply_photo(buf, reply_markup=_keyboard())
     status = await update.message.reply_text('Выберите клетку или введите ход текстом.')
     state.message_id = msg.message_id
@@ -240,8 +241,9 @@ async def board15_test(update: Update, context: ContextTypes.DEFAULT_TYPE) -> No
     storage.save_match(match)
     state = Board15State(chat_id=update.effective_chat.id)
     state.board = [row[:] for row in match.boards['A'].grid]
+    state.player_key = 'A'
     try:
-        buf = render_board(state)
+        buf = render_board(state, 'A')
     except Exception:
         from io import BytesIO
         buf = BytesIO()
@@ -291,7 +293,7 @@ async def board15_on_click(update: Update, context: ContextTypes.DEFAULT_TYPE) -
     elif data[1] == "pick":
         r, c = int(data[2]), int(data[3])
         state.selected = (state.window_top + r, state.window_left + c)
-        buf = render_board(state)
+        buf = render_board(state, state.player_key)
         try:
             await query.edit_message_media(InputMediaPhoto(buf))
         except Exception:
@@ -401,7 +403,7 @@ async def board15_on_click(update: Update, context: ContextTypes.DEFAULT_TYPE) -
         return
     elif data[1] == "act" and data[2] == "cancel":
         state.selected = None
-    buf = render_board(state)
+    buf = render_board(state, state.player_key)
     try:
         await query.edit_message_media(InputMediaPhoto(buf))
     except Exception:

--- a/game_board15/renderer.py
+++ b/game_board15/renderer.py
@@ -42,6 +42,19 @@ COLORS = {
     },
 }
 
+PLAYER_SHIP_COLORS = {
+    "light": {
+        "A": (173, 216, 230, 255),  # light blue
+        "B": (144, 238, 144, 255),  # light green
+        "C": (255, 200, 140, 255),  # light orange
+    },
+    "dark": {
+        "A": (173, 216, 230, 255),
+        "B": (144, 238, 144, 255),
+        "C": (255, 200, 140, 255),
+    },
+}
+
 
 CELL_STYLE = {
     1: ("square", "ship"),
@@ -52,7 +65,7 @@ CELL_STYLE = {
 }
 
 
-def render_board(state: Board15State) -> BytesIO:
+def render_board(state: Board15State, player_key: str | None = None) -> BytesIO:
     """Render the 15x15 board into a PNG image.
 
     Only a 5x5 window is highlighted to guide the user's current view.
@@ -80,7 +93,10 @@ def render_board(state: Board15State) -> BytesIO:
             x0 = margin + c * TILE_PX
             y0 = margin + r * TILE_PX
             shape, color_key = CELL_STYLE.get(val, ("square", "ship"))
-            color = COLORS[THEME][color_key]
+            if val == 1 and player_key:
+                color = PLAYER_SHIP_COLORS.get(THEME, {}).get(player_key, COLORS[THEME]["ship"])
+            else:
+                color = COLORS[THEME][color_key]
             if shape == "square":
                 draw.rectangle(
                     (x0 + 4, y0 + 4, x0 + TILE_PX - 4, y0 + TILE_PX - 4),
@@ -147,7 +163,7 @@ def render_board(state: Board15State) -> BytesIO:
     return buf
 
 
-def render_player_board(board: Board15) -> BytesIO:
+def render_player_board(board: Board15, player_key: str | None = None) -> BytesIO:
     """Render player's own board with their ships.
 
     Unlike :func:`render_board`, this version shows the full board without a
@@ -177,7 +193,10 @@ def render_player_board(board: Board15) -> BytesIO:
             x0 = margin + c * TILE_PX
             y0 = margin + r * TILE_PX
             shape, color_key = CELL_STYLE.get(val, ("square", "ship"))
-            color = COLORS[THEME][color_key]
+            if val == 1 and player_key:
+                color = PLAYER_SHIP_COLORS.get(THEME, {}).get(player_key, COLORS[THEME]["ship"])
+            else:
+                color = COLORS[THEME][color_key]
             if shape == "square":
                 draw.rectangle(
                     (x0 + 4, y0 + 4, x0 + TILE_PX - 4, y0 + TILE_PX - 4),

--- a/game_board15/router.py
+++ b/game_board15/router.py
@@ -41,7 +41,8 @@ async def _send_state(context: ContextTypes.DEFAULT_TYPE, match, player_key: str
         state = Board15State(chat_id=chat_id)
         states[chat_id] = state
     state.board = [row[:] for row in match.boards[player_key].grid]
-    buf = render_board(state)
+    state.player_key = player_key
+    buf = render_board(state, player_key)
     msgs = match.messages.setdefault(player_key, {})
     board_id = msgs.get('board')
     status_id = msgs.get('status')
@@ -66,7 +67,7 @@ async def _send_state(context: ContextTypes.DEFAULT_TYPE, match, player_key: str
         state.message_id = board_id
 
     # player's own board with ships
-    player_buf = render_player_board(match.boards[player_key])
+    player_buf = render_player_board(match.boards[player_key], player_key)
     player_id = msgs.get('player')
     if player_id:
         try:

--- a/game_board15/state.py
+++ b/game_board15/state.py
@@ -25,3 +25,4 @@ class Board15State:
     message_id: Optional[int] = None
     status_message_id: Optional[int] = None
     selected: Optional[Tuple[int, int]] = None
+    player_key: Optional[str] = None

--- a/tests/test_board15_invite.py
+++ b/tests/test_board15_invite.py
@@ -27,7 +27,7 @@ def test_board15_invite_flow(monkeypatch):
         )
         monkeypatch.setattr(storage15, 'create_match', lambda uid, cid, name=None: match)
         monkeypatch.setattr(storage15, 'save_match', lambda m: None)
-        monkeypatch.setattr(h, 'render_board', lambda state: BytesIO(b'test'))
+        monkeypatch.setattr(h, 'render_board', lambda state, player_key=None: BytesIO(b'test'))
         reply_text = AsyncMock()
         reply_photo = AsyncMock(return_value=SimpleNamespace(message_id=1))
         update = SimpleNamespace(

--- a/tests/test_board15_router.py
+++ b/tests/test_board15_router.py
@@ -43,8 +43,8 @@ def test_router_auto_sends_boards(monkeypatch):
         monkeypatch.setattr(storage, 'save_board', fake_save_board)
         monkeypatch.setattr(storage, 'save_match', lambda m: None)
         monkeypatch.setattr(router.placement, 'random_board', lambda: SimpleNamespace(grid=[[0] * 15 for _ in range(15)]))
-        monkeypatch.setattr(router, 'render_board', lambda state: BytesIO(b'target'))
-        monkeypatch.setattr(router, 'render_player_board', lambda board: BytesIO(b'own'))
+        monkeypatch.setattr(router, 'render_board', lambda state, player_key=None: BytesIO(b'target'))
+        monkeypatch.setattr(router, 'render_player_board', lambda board, player_key=None: BytesIO(b'own'))
         monkeypatch.setattr(router, '_keyboard', lambda: 'kb')
 
         send_photo = AsyncMock()
@@ -91,10 +91,10 @@ def test_router_move_sends_player_board(monkeypatch):
         monkeypatch.setattr(router.parser, 'format_coord', lambda coord: 'a1')
         monkeypatch.setattr(router.battle, 'apply_shot', lambda board, coord: router.battle.MISS)
         monkeypatch.setattr(router, '_phrase_or_joke', lambda m, pk, ph: '')
-        monkeypatch.setattr(router, 'render_board', lambda state: BytesIO(b'target'))
+        monkeypatch.setattr(router, 'render_board', lambda state, player_key=None: BytesIO(b'target'))
         called = []
 
-        def fake_render_player_board(board):
+        def fake_render_player_board(board, player_key=None):
             called.append(board)
             return BytesIO(b'own')
 


### PR DESCRIPTION
## Summary
- Render 15×15 boards with distinct ship colors per player (light blue, green, orange)
- Track player key in board state and pass to rendering utilities
- Adjust tests for new rendering signatures

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ad3571f9788326ad0465c75577cc83