### PR TITLE
Track shot history on 15x15 board

### DIFF
--- a/game_board15/battle.py
+++ b/game_board15/battle.py
@@ -1,5 +1,5 @@
 from __future__ import annotations
-from typing import Tuple
+from typing import Tuple, Dict, List
 
 from .models import Board15, Ship
 
@@ -47,3 +47,32 @@ def apply_shot(board: Board15, coord: Tuple[int, int]) -> str:
         board.highlight = [coord]
         return HIT
     return MISS
+
+
+def update_history(
+    history: List[List[int]],
+    boards: Dict[str, Board15],
+    coord: Tuple[int, int],
+    results: Dict[str, str],
+) -> None:
+    """Update global shot history grid based on results for the shot."""
+
+    r, c = coord
+    if any(res == KILL for res in results.values()):
+        for key, res in results.items():
+            if res != KILL:
+                continue
+            board = boards[key]
+            for rr in range(15):
+                for cc in range(15):
+                    val = board.grid[rr][cc]
+                    if val == 4:
+                        history[rr][cc] = 4
+                    elif val == 5 and history[rr][cc] == 0:
+                        history[rr][cc] = 5
+        history[r][c] = 4
+    elif any(res == HIT for res in results.values()):
+        history[r][c] = 3
+    elif all(res == MISS for res in results.values()):
+        if history[r][c] == 0:
+            history[r][c] = 2

--- a/game_board15/models.py
+++ b/game_board15/models.py
@@ -39,6 +39,8 @@ class Match15:
     players: Dict[str, Player] = field(default_factory=dict)
     turn: str = "A"
     boards: Dict[str, Board15] = field(default_factory=dict)
+    # global shot history for rendering target board
+    history: List[List[int]] = field(default_factory=lambda: [[0] * 15 for _ in range(15)])
     shots: Dict[str, Dict[str, object]] = field(
         default_factory=lambda: {
             k: {

--- a/game_board15/router.py
+++ b/game_board15/router.py
@@ -40,7 +40,13 @@ async def _send_state(context: ContextTypes.DEFAULT_TYPE, match, player_key: str
     if not state:
         state = Board15State(chat_id=chat_id)
         states[chat_id] = state
-    state.board = [row[:] for row in match.boards[player_key].grid]
+    merged = [row[:] for row in match.history]
+    own_grid = match.boards[player_key].grid
+    for r in range(15):
+        for c in range(15):
+            if merged[r][c] == 0 and own_grid[r][c] == 1:
+                merged[r][c] = 1
+    state.board = merged
     state.player_key = player_key
     buf = render_board(state, player_key)
     msgs = match.messages.setdefault(player_key, {})
@@ -176,6 +182,7 @@ async def router_text(update: Update, context: ContextTypes.DEFAULT_TYPE) -> Non
     if repeat:
         await update.message.reply_text('Эта клетка уже открыта')
         return
+    battle.update_history(match.history, match.boards, coord, results)
     for k in match.shots:
         shots = match.shots[k]
         shots.setdefault('move_count', 0)

--- a/game_board15/storage.py
+++ b/game_board15/storage.py
@@ -54,6 +54,7 @@ def get_match(match_id: str) -> Match15 | None:
     for key, b in m.get('boards', {}).items():
         ships = [Ship(cells=[tuple(cell) for cell in s.get('cells', [])], alive=s.get('alive', True)) for s in b.get('ships', [])]
         match.boards[key] = Board15(grid=b.get('grid', [[0]*15 for _ in range(15)]), ships=ships, alive_cells=b.get('alive_cells', 20))
+    match.history = m.get('history', [[0] * 15 for _ in range(15)])
     match.shots = m.get('shots', match.shots)
     match.messages = m.get('messages', {})
     return match
@@ -115,6 +116,7 @@ def save_board(match: Match15, player_key: str, board: Board15) -> None:
                 )
             current.shots = m_dict.get('shots', current.shots)
             current.messages = m_dict.get('messages', {})
+            current.history = m_dict.get('history', [[0] * 15 for _ in range(15)])
         else:
             current = match
 
@@ -146,6 +148,7 @@ def save_board(match: Match15, player_key: str, board: Board15) -> None:
             },
             'shots': current.shots,
             'messages': current.messages,
+            'history': current.history,
         }
         _save_all(data)
 
@@ -155,6 +158,7 @@ def save_board(match: Match15, player_key: str, board: Board15) -> None:
     match.players = current.players
     match.boards = current.boards
     match.shots = current.shots
+    match.history = current.history
     match.messages = current.messages
 
 
@@ -170,6 +174,7 @@ def save_match(match: Match15) -> str | None:
             'boards': {k: {'grid': b.grid, 'ships': [{'cells': s.cells, 'alive': s.alive} for s in b.ships], 'alive_cells': b.alive_cells} for k, b in match.boards.items()},
             'shots': match.shots,
             'messages': match.messages,
+            'history': match.history,
         }
         return _save_all(data)
 

--- a/tests/test_board15_history.py
+++ b/tests/test_board15_history.py
@@ -1,0 +1,62 @@
+import asyncio
+from io import BytesIO
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+from game_board15 import router
+from game_board15.battle import apply_shot, update_history, KILL
+from game_board15.models import Board15, Ship
+
+
+def test_update_history_records_kill_and_contour():
+    history = [[0] * 15 for _ in range(15)]
+    boards = {'B': Board15()}
+    ship = Ship(cells=[(1, 1)])
+    boards['B'].ships = [ship]
+    boards['B'].grid[1][1] = 1
+    res = apply_shot(boards['B'], (1, 1))
+    assert res == KILL
+    update_history(history, boards, (1, 1), {'B': res})
+    assert history[1][1] == 4
+    assert history[0][0] == 5
+
+
+def test_send_state_uses_history(monkeypatch):
+    async def run_test():
+        match = SimpleNamespace(
+            players={'A': SimpleNamespace(chat_id=1)},
+            boards={'A': Board15()},
+            history=[[0] * 15 for _ in range(15)],
+            messages={'A': {}},
+        )
+        match.boards['A'].grid[2][2] = 1
+        match.history[0][0] = 2
+
+        captured = {}
+
+        def fake_render_board(state, player_key=None):
+            captured['board'] = [row[:] for row in state.board]
+            return BytesIO(b'img')
+
+        monkeypatch.setattr(router, 'render_board', fake_render_board)
+        monkeypatch.setattr(router, 'render_player_board', lambda board, player_key=None: BytesIO(b'own'))
+        monkeypatch.setattr(router, '_keyboard', lambda: None)
+        monkeypatch.setattr(router.storage, 'save_match', lambda m: None)
+
+        context = SimpleNamespace(
+            bot=SimpleNamespace(
+                edit_message_media=AsyncMock(),
+                send_photo=AsyncMock(return_value=SimpleNamespace(message_id=1)),
+                edit_message_text=AsyncMock(),
+                send_message=AsyncMock(return_value=SimpleNamespace(message_id=2)),
+            ),
+            bot_data={},
+            chat_data={},
+        )
+
+        await router._send_state(context, match, 'A', 'msg')
+
+        assert captured['board'][0][0] == 2
+        assert captured['board'][2][2] == 1
+
+    asyncio.run(run_test())

--- a/tests/test_board15_invite.py
+++ b/tests/test_board15_invite.py
@@ -24,6 +24,7 @@ def test_board15_invite_flow(monkeypatch):
             players={'A': SimpleNamespace(user_id=1, chat_id=1, name='Alice')},
             boards={'A': SimpleNamespace(grid=[[0] * 15 for _ in range(15)])},
             messages={},
+            history=[[0] * 15 for _ in range(15)],
         )
         monkeypatch.setattr(storage15, 'create_match', lambda uid, cid, name=None: match)
         monkeypatch.setattr(storage15, 'save_match', lambda m: None)

--- a/tests/test_board15_router.py
+++ b/tests/test_board15_router.py
@@ -30,6 +30,7 @@ def test_router_auto_sends_boards(monkeypatch):
             },
             turn='A',
             messages={},
+            history=[[0] * 15 for _ in range(15)],
         )
 
         def fake_save_board(m, key, board):
@@ -83,6 +84,7 @@ def test_router_move_sends_player_board(monkeypatch):
             turn='A',
             shots={'A': {}, 'B': {}},
             messages={'A': {'board': 1, 'status': 2}, 'B': {'board': 3, 'status': 4}},
+            history=[[0] * 15 for _ in range(15)],
         )
 
         monkeypatch.setattr(storage, 'find_match_by_user', lambda uid: match)
@@ -132,13 +134,14 @@ def test_router_uses_player_names(monkeypatch):
                 'C': SimpleNamespace(user_id=3, chat_id=30, name='Carl'),
             },
             boards={
-                'A': SimpleNamespace(alive_cells=20),
-                'B': SimpleNamespace(alive_cells=20),
-                'C': SimpleNamespace(alive_cells=20),
+                'A': Board15(),
+                'B': Board15(),
+                'C': Board15(),
             },
             turn='A',
             shots={'A': {}, 'B': {}, 'C': {}},
             messages={'A': {}},
+            history=[[0] * 15 for _ in range(15)],
         )
 
         monkeypatch.setattr(storage, 'find_match_by_user', lambda uid: match)
@@ -176,6 +179,7 @@ def test_router_repeat_shot(monkeypatch):
             shots={'A': {'move_count': 0, 'joke_start': 10},
                    'B': {'move_count': 0, 'joke_start': 10}},
             messages={},
+            history=[[0] * 15 for _ in range(15)],
         )
 
         monkeypatch.setattr(storage, 'find_match_by_user', lambda uid: match)
@@ -212,15 +216,13 @@ def test_router_skips_eliminated_players(monkeypatch):
                 'B': SimpleNamespace(user_id=2, chat_id=20),
                 'C': SimpleNamespace(user_id=3, chat_id=30),
             },
-            boards={
-                'A': SimpleNamespace(alive_cells=20),
-                'B': SimpleNamespace(alive_cells=0),
-                'C': SimpleNamespace(alive_cells=20),
-            },
+            boards={'A': Board15(), 'B': Board15(), 'C': Board15()},
             turn='A',
             shots={'A': {}, 'B': {}, 'C': {}},
             messages={'A': {}},
+            history=[[0] * 15 for _ in range(15)],
         )
+        match.boards['B'].alive_cells = 0
 
         monkeypatch.setattr(storage, 'find_match_by_user', lambda uid: match)
         monkeypatch.setattr(storage, 'save_match', lambda m: None)


### PR DESCRIPTION
## Summary
- keep a global shot history for each 15x15 match
- render target boards with full history overlay and players' ships
- persist history data and test new board behaviour

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ad390e10f48326868ab662834439cd