### PR TITLE
Avoid overlapping fleets in board15 test mode

### DIFF
--- a/tests/test_board15_test_autoplay.py
+++ b/tests/test_board15_test_autoplay.py
@@ -9,7 +9,7 @@ from game_board15.models import Board15
 def test_board15_test_autoplay(monkeypatch):
     async def run():
         boards = [Board15(), Board15(alive_cells=0), Board15(alive_cells=0)]
-        def fake_random_board():
+        def fake_random_board(*args, **kwargs):
             return boards.pop(0)
         monkeypatch.setattr(handlers.placement, 'random_board', fake_random_board)
         monkeypatch.setattr(storage, 'save_match', lambda m: None)

--- a/tests/test_board15_test_manual.py
+++ b/tests/test_board15_test_manual.py
@@ -9,7 +9,7 @@ from game_board15.models import Board15
 def test_board15_test_manual(monkeypatch):
     async def run():
         boards = [Board15(), Board15(), Board15()]
-        monkeypatch.setattr(handlers.placement, 'random_board', lambda: boards.pop(0))
+        monkeypatch.setattr(handlers.placement, 'random_board', lambda *a, **k: boards.pop(0))
         monkeypatch.setattr(storage, 'save_match', lambda m: None)
         def fake_finish(match, winner):
             match.status = 'finished'


### PR DESCRIPTION
## Summary
- ensure board15 test matches generate non-overlapping fleets by using a shared mask
- adjust tests to accept optional mask parameter when mocking random_board

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ad6ce1acfc8326908b64489aa52acb