### PR TITLE
Show welcome logo and send newgame info after mode selection

### DIFF
--- a/handlers/commands.py
+++ b/handlers/commands.py
@@ -104,11 +104,8 @@ async def start(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
         else:
             await update.message.reply_text('Матч не найден или заполнен.')
     else:
-        await update.message.reply_text(
-            'Привет! Используйте /newgame чтобы создать матч. '
-            'Если вы переходили по ссылке-приглашению, отправьте её текст '
-            'вручную: /start inv_<id>.'
-        )
+        with welcome_photo() as img:
+            await update.message.reply_photo(img, caption='Добро пожаловать в игру!')
         buttons = [
             [
                 InlineKeyboardButton('Игра вдвоем', callback_data='mode_2'),
@@ -190,7 +187,11 @@ async def choose_mode(update: Update, context: ContextTypes.DEFAULT_TYPE) -> Non
     query = update.callback_query
     await query.answer()
     if query.data == 'mode_2':
-        await query.message.reply_text('Используйте /newgame для классической игры вдвоем.')
+        await query.message.reply_text(
+            'Используйте /newgame чтобы создать матч. '
+            'Если вы переходили по ссылке-приглашению, отправьте её текст '
+            'вручную: /start inv_<id>.'
+        )
     elif query.data == 'mode_3':
         await query.message.reply_text('Используйте /board15 для игры втроем на поле 15×15.')
     elif query.data == 'mode_test3':

--- a/tests/test_start.py
+++ b/tests/test_start.py
@@ -1,0 +1,52 @@
+import asyncio
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, call, ANY
+
+from handlers.commands import start, choose_mode
+
+
+def test_start_shows_logo_and_menu(monkeypatch):
+    async def run_test():
+        reply_photo = AsyncMock()
+        reply_text = AsyncMock()
+        update = SimpleNamespace(
+            message=SimpleNamespace(reply_photo=reply_photo, reply_text=reply_text),
+            effective_user=SimpleNamespace(id=1),
+            effective_chat=SimpleNamespace(id=1),
+        )
+        context = SimpleNamespace()
+
+        await start(update, context)
+
+        assert reply_photo.call_args_list == [call(ANY, caption='Добро пожаловать в игру!')]
+        assert reply_text.call_args_list == [call('Выберите режим игры:', reply_markup=ANY)]
+
+        texts = [reply_photo.call_args_list[0].kwargs.get('caption', '')]
+        texts.append(reply_text.call_args_list[0].args[0])
+        assert all('/newgame' not in t for t in texts)
+
+    asyncio.run(run_test())
+
+
+def test_choose_mode_two_players():
+    async def run_test():
+        reply_text = AsyncMock()
+        query = SimpleNamespace(
+            data='mode_2',
+            message=SimpleNamespace(reply_text=reply_text),
+            answer=AsyncMock(),
+        )
+        update = SimpleNamespace(callback_query=query)
+        context = SimpleNamespace()
+
+        await choose_mode(update, context)
+
+        expected = (
+            'Используйте /newgame чтобы создать матч. '
+            'Если вы переходили по ссылке-приглашению, отправьте её текст '
+            'вручную: /start inv_<id>.'
+        )
+        assert reply_text.call_args_list == [call(expected)]
+        assert query.answer.call_count == 1
+
+    asyncio.run(run_test())


### PR DESCRIPTION
## Summary
- Show welcome image and mode selection when /start is used without arguments
- Move /newgame instructions to mode selection handler for 2-player games
- Add tests for new /start flow and two-player instructions

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68ad72107fb08326958a641b0a45befe