### PR TITLE
feat: prevent multiple concurrent games

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -15,7 +15,15 @@ from telegram.ext import (
     filters,
 )
 
-from handlers.commands import start, newgame, board, send_invite_link, choose_mode
+from handlers.commands import (
+    start,
+    newgame,
+    board,
+    send_invite_link,
+    choose_mode,
+    confirm_newgame,
+    confirm_join,
+)
 from handlers.router import router_text
 
 BOARD15_ENABLED = os.getenv("BOARD15_ENABLED") == "1"
@@ -64,6 +72,8 @@ bot_app.add_handler(CommandHandler("newgame", newgame))
 bot_app.add_handler(CommandHandler("board", board))
 bot_app.add_handler(CallbackQueryHandler(send_invite_link, pattern="^get_link$"))
 bot_app.add_handler(CallbackQueryHandler(choose_mode, pattern="^mode_"))
+bot_app.add_handler(CallbackQueryHandler(confirm_newgame, pattern="^ng_"))
+bot_app.add_handler(CallbackQueryHandler(confirm_join, pattern="^join_"))
 if BOARD15_ENABLED:
     bot_app.add_handler(CommandHandler("board15", board15))
     bot_app.add_handler(CallbackQueryHandler(board15_on_click, pattern=r"^b15\|"))

--- a/storage.py
+++ b/storage.py
@@ -167,6 +167,12 @@ def finish(match: Match, winner: str) -> str | None:
     return save_match(match)
 
 
+def close_match(match: Match) -> str | None:
+    """Mark match as finished without declaring a winner."""
+    match.status = "finished"
+    return save_match(match)
+
+
 def save_match(match: Match) -> str | None:
     with _lock:
         data = _load_all()


### PR DESCRIPTION
## Summary
- prevent users from starting or joining multiple games simultaneously
- add confirmation handlers to close the old match before creating or joining a new one
- add storage helper to mark a match finished
- cover new match restriction with tests

## Testing
- `pytest tests/test_newgame.py -q`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ad79d8a0b08326a0fdb74c535291bd