### PR TITLE
Skip played cells in bot autoplay

### DIFF
--- a/game_board15/handlers.py
+++ b/game_board15/handlers.py
@@ -146,6 +146,9 @@ async def _auto_play_bots(
             continue
 
         current = match.turn
+        # find next untried cell starting from current index
+        while idx < len(coords) and match.history[coords[idx][0]][coords[idx][1]] != 0:
+            idx += 1
         if idx >= len(coords):
             break
         coord = coords[idx]


### PR DESCRIPTION
## Summary
- ensure bot auto-play skips non-empty history cells and resumes search from last index
- test bot auto-play starts from first available cell

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ad7d9c0ae88326babb1ea2269f6169