### PR TITLE
Use latin letters for coordinates

### DIFF
--- a/game_board15/parser.py
+++ b/game_board15/parser.py
@@ -2,6 +2,13 @@ from __future__ import annotations
 import re
 from typing import Optional, Tuple
 
+"""Parsing utilities for 15x15 board.
+
+Historically the project used Cyrillic letters to label columns.  The modern
+board displays latin letters instead, therefore outgoing coordinates and
+rendered boards must also use them.  ``ROWS`` keeps the Cyrillic sequence for
+backwards compatible parsing while ``LATIN`` is the user-facing counterpart."""
+
 ROWS = 'абвгдежзиклмнопр'
 LATIN = 'abcdefghijklmnopr'
 
@@ -31,5 +38,6 @@ def parse_coord(cell: str) -> Optional[Tuple[int, int]]:
 
 
 def format_coord(coord: Tuple[int, int]) -> str:
+    """Convert internal (row, col) into user-facing string with latin letters."""
     r, c = coord
-    return f"{ROWS[c]}{r+1}"
+    return f"{LATIN[c]}{r+1}"

--- a/logic/parser.py
+++ b/logic/parser.py
@@ -2,6 +2,11 @@ from __future__ import annotations
 import re
 from typing import Optional, Tuple
 
+# Columns on the board are identified by latin letters when rendered for
+# users, while internally we still support both latin and Cyrillic inputs.
+# ``ROWS`` keeps the Cyrillic representation to remain backward compatible
+# with existing games, and ``LATIN`` mirrors it with latin characters so that
+# outbound messages and rendered boards use latin coordinates.
 ROWS = 'абвгдежзик'
 LATIN = 'abcdefghik'
 
@@ -33,6 +38,11 @@ def parse_coord(cell: str) -> Optional[Tuple[int, int]]:
 
 
 def format_coord(coord: Tuple[int, int]) -> str:
-    """Convert internal (row, col) into user-facing string."""
+    """Convert internal (row, col) into user-facing string.
+
+    Even though we accept both latin and Cyrillic letters as input, users see
+    the board labelled with latin letters.  Therefore coordinates in outgoing
+    messages must also use latin letters.
+    """
     r, c = coord
-    return f"{ROWS[c]}{r+1}"
+    return f"{LATIN[c]}{r+1}"

--- a/logic/render.py
+++ b/logic/render.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 from typing import List
 
 from models import Board
-from logic.parser import ROWS
+from logic.parser import LATIN
 from wcwidth import wcswidth
 
 
@@ -22,7 +22,13 @@ def format_cell(symbol: str) -> str:
     return symbol + FIGURE_SPACE * pad
 
 
-COL_HEADER = ''.join(format_cell(ch) for ch in ROWS)
+"""Letters on the top of the board are rendered using latin characters.
+
+The project historically used Cyrillic letters internally, but players now see
+latin columns on the board.  ``LATIN`` mirrors the internal set and is used for
+display purposes.
+"""
+COL_HEADER = ''.join(format_cell(ch) for ch in LATIN)
 
 
 def _render_line(cells: List[str]) -> str:

--- a/tests/test_router_text.py
+++ b/tests/test_router_text.py
@@ -181,10 +181,10 @@ def test_router_kill_message(monkeypatch):
         assert len(calls) == 2
         msg_self = calls[0].args[1]
         msg_enemy = calls[1].args[1]
-        assert 'а1 - Корабль соперника уничтожен!' in msg_self
+        assert 'a1 - Корабль соперника уничтожен!' in msg_self
         assert any(p in msg_self for p in phrases.SELF_KILL)
         assert msg_self.strip().endswith('Ваш ход.')
-        assert 'а1 - Соперник уничтожил ваш корабль.' in msg_enemy
+        assert 'a1 - Соперник уничтожил ваш корабль.' in msg_enemy
         assert any(p in msg_enemy for p in phrases.ENEMY_KILL)
         assert msg_enemy.strip().endswith('Ход соперника.')
     asyncio.run(run_test())
@@ -232,7 +232,7 @@ def test_router_joke_format(monkeypatch):
         monkeypatch.setattr(router, 'render_board_enemy', lambda b: 'enemy')
         monkeypatch.setattr(router, 'apply_shot', lambda board, coord: router.MISS)
         monkeypatch.setattr(router, 'parse_coord', lambda text: (0, 0))
-        monkeypatch.setattr(router, 'format_coord', lambda coord: 'а1')
+        monkeypatch.setattr(router, 'format_coord', lambda coord: 'a1')
         monkeypatch.setattr(router, 'random_phrase', lambda phrases: phrases[0])
         monkeypatch.setattr(router, 'random_joke', lambda: 'JOKE')
         monkeypatch.setattr(storage, 'save_match', lambda m: None)


### PR DESCRIPTION
## Summary
- Render board headers with latin letters
- Output coordinates in latin letters so messages match the board
- Adjust tests for latin coordinate format

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68ad82170b6483269d2501700a8ac7ee