### PR TITLE
Handle repeated shots in board15 and update history

### DIFF
--- a/game_board15/handlers.py
+++ b/game_board15/handlers.py
@@ -356,6 +356,10 @@ async def board15_on_click(update: Update, context: ContextTypes.DEFAULT_TYPE) -
             results[enemy] = res
             if res in (battle.HIT, battle.KILL):
                 hit_any = True
+        if battle.REPEAT in results.values():
+            await query.answer("Эта клетка уже открыта")
+            return
+        battle.update_history(match.history, match.boards, coord, results)
         for k in match.shots:
             shots = match.shots[k]
             shots.setdefault('move_count', 0)


### PR DESCRIPTION
## Summary
- Prevent firing at already-opened cells by detecting `battle.REPEAT` results and informing the player
- Update match history before tracking shot counts

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68ada8412e7083269ff822a648d3bac6