### PR TITLE
feat: announce eliminated players

### DIFF
--- a/game_board15/handlers.py
+++ b/game_board15/handlers.py
@@ -213,9 +213,10 @@ async def _auto_play_bots(
                         f"{coord_str} - ваш корабль уничтожен. {phrase_enemy}",
                     )
                 if match.boards[enemy].alive_cells == 0:
+                    enemy_label = getattr(match.players.get(enemy), 'name', '') or enemy
                     await context.bot.send_message(
                         match.players[enemy].chat_id,
-                        'Все ваши корабли уничтожены. Вы выбыли.',
+                        f"⛔ Игрок {enemy_label} выбыл (флот уничтожен)",
                     )
 
         storage.save_match(match)
@@ -411,9 +412,10 @@ async def board15_on_click(update: Update, context: ContextTypes.DEFAULT_TYPE) -
                         f"{coord_str} - ваш корабль уничтожен. {phrase_enemy}",
                     )
                     if match.boards[enemy].alive_cells == 0:
+                        enemy_label = getattr(match.players.get(enemy), 'name', '') or enemy
                         await context.bot.send_message(
                             match.players[enemy].chat_id,
-                            'Все ваши корабли уничтожены. Вы выбыли.',
+                            f"⛔ Игрок {enemy_label} выбыл (флот уничтожен)",
                         )
 
         storage.save_match(match)

--- a/game_board15/router.py
+++ b/game_board15/router.py
@@ -231,7 +231,7 @@ async def router_text(update: Update, context: ContextTypes.DEFAULT_TYPE) -> Non
             if match.boards[enemy].alive_cells == 0:
                 await context.bot.send_message(
                     match.players[enemy].chat_id,
-                    "Все ваши корабли уничтожены. Вы выбыли.",
+                    f"⛔ Игрок {enemy_label} выбыл (флот уничтожен)",
                 )
 
     others = [


### PR DESCRIPTION
## Summary
- Notify when a player's fleet is destroyed with a new message
- Include the eliminated player's name in notifications

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ada904ad7c8326a63aa8d2aea5605a