### PR TITLE
Fix bot elimination notification

### DIFF
--- a/game_board15/handlers.py
+++ b/game_board15/handlers.py
@@ -419,12 +419,13 @@ async def board15_on_click(update: Update, context: ContextTypes.DEFAULT_TYPE) -
                         enemy,
                         f"{coord_str} - ваш корабль уничтожен. {phrase_enemy}",
                     )
-                    if match.boards[enemy].alive_cells == 0:
-                        enemy_label = getattr(match.players.get(enemy), 'name', '') or enemy
-                        await context.bot.send_message(
-                            match.players[enemy].chat_id,
-                            f"⛔ Игрок {enemy_label} выбыл (флот уничтожен)",
-                        )
+                if match.boards[enemy].alive_cells == 0:
+                    enemy_label = getattr(match.players.get(enemy), 'name', '') or enemy
+                    target = enemy if match.players[enemy].user_id != 0 else player_key
+                    await context.bot.send_message(
+                        match.players[target].chat_id,
+                        f"⛔ Игрок {enemy_label} выбыл (флот уничтожен)",
+                    )
 
         storage.save_match(match)
         next_label = match.players.get(next_player)

--- a/tests/test_board15_bot_elimination.py
+++ b/tests/test_board15_bot_elimination.py
@@ -1,0 +1,57 @@
+import asyncio
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+from game_board15 import handlers, storage
+from game_board15.models import Match15, Player, Ship
+
+
+def test_board15_notifies_on_bot_elimination(monkeypatch):
+    async def run():
+        match = Match15.new(1, 1, 'A')
+        match.players['B'] = Player(user_id=0, chat_id=1, name='B')
+        match.status = 'playing'
+        ship = Ship(cells=[(0, 0)])
+        match.boards['B'].ships = [ship]
+        match.boards['B'].grid[0][0] = 1
+        match.boards['B'].alive_cells = 1
+
+        state = handlers.Board15State(chat_id=1)
+        state.selected = (0, 0)
+        state.player_key = 'A'
+
+        monkeypatch.setattr(storage, 'find_match_by_user', lambda uid, chat_id=None: match)
+        monkeypatch.setattr(storage, 'save_match', lambda m: None)
+        monkeypatch.setattr(storage, 'finish', lambda m, w: None)
+
+        from game_board15 import router
+        monkeypatch.setattr(router, '_send_state', AsyncMock())
+        monkeypatch.setattr(handlers.parser, 'format_coord', lambda coord: 'a1')
+        monkeypatch.setattr(handlers, '_phrase_or_joke', lambda m, pk, ph: '')
+
+        def fake_apply_shot(board, coord):
+            board.alive_cells = 0
+            return handlers.battle.KILL
+
+        monkeypatch.setattr(handlers.battle, 'apply_shot', fake_apply_shot)
+        monkeypatch.setattr(handlers.battle, 'update_history', lambda h, b, c, r: None)
+
+        context = SimpleNamespace(
+            bot=SimpleNamespace(send_message=AsyncMock()),
+            bot_data={handlers.STATE_KEY: {1: state}},
+        )
+
+        query = SimpleNamespace(
+            data='b15|act|confirm',
+            answer=AsyncMock(),
+            from_user=SimpleNamespace(id=1),
+            message=SimpleNamespace(),
+        )
+        update = SimpleNamespace(callback_query=query, effective_chat=SimpleNamespace(id=1))
+
+        await handlers.board15_on_click(update, context)
+
+        calls = [(c.args[0], c.args[1]) for c in context.bot.send_message.call_args_list]
+        assert (1, '⛔ Игрок B выбыл (флот уничтожен)') in calls
+
+    asyncio.run(run())


### PR DESCRIPTION
## Summary
- Always send elimination message when a fleet is destroyed and notify current player if opponent is a bot
- Add regression test ensuring humans see bot elimination message

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68adad04f890832693e84257dc48026f