### PR TITLE
Notify human player during bot autoplay

### DIFF
--- a/game_board15/handlers.py
+++ b/game_board15/handlers.py
@@ -211,6 +211,12 @@ async def _auto_play_bots(
                         f"⛔ Игрок {enemy_label} выбыл (флот уничтожен)",
                     )
 
+        if current != human and human in match.players and match.players[human].user_id != 0:
+            msg_self = f"{coord_str} - {' '.join(parts_self)}"
+            if next_player == human:
+                msg_self += ' Ваш ход.'
+            await router_module._send_state(context, match, human, msg_self)
+
         storage.save_match(match)
         next_label = match.players.get(next_player)
         next_name = getattr(next_label, 'name', '') or next_player


### PR DESCRIPTION
## Summary
- Ensure bot turns notify the human player with shot results
- Append 'Ваш ход.' when the human's turn follows a bot move

## Testing
- `pytest tests/test_board15_test_autoplay.py -q`
- `pytest tests/test_board15_send_state.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68adb0fa75308326beac86650daa911a