### PR TITLE
Add small delay between bot moves

### DIFF
--- a/game_board15/handlers.py
+++ b/game_board15/handlers.py
@@ -236,6 +236,8 @@ async def _auto_play_bots(
                     await context.bot.send_message(match.players[k].chat_id, 'Игра окончена. Победил соперник.')
             break
 
+        await asyncio.sleep(1)
+
 
 async def board15_test(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
     """Start a three-player test match with two dummy opponents."""


### PR DESCRIPTION
## Summary
- pause after each bot move to give time for message display

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68adb358b9d88326a9db07b09451c63c