### PR TITLE
Handle board message ID when reply_photo unavailable

### DIFF
--- a/game_board15/handlers.py
+++ b/game_board15/handlers.py
@@ -280,6 +280,13 @@ async def board15_test(update: Update, context: ContextTypes.DEFAULT_TYPE) -> No
     if reply_photo is not None:
         msg = await reply_photo(buf, reply_markup=_keyboard())
         board_msg_id = msg.message_id
+    else:
+        msg = await context.bot.send_photo(
+            chat_id=update.effective_chat.id,
+            photo=buf,
+            reply_markup=_keyboard(),
+        )
+        board_msg_id = msg.message_id
     status = await update.message.reply_text('Выберите клетку или введите ход текстом.')
     state.message_id = board_msg_id
     state.status_message_id = status.message_id

--- a/tests/test_board15_test_autoplay.py
+++ b/tests/test_board15_test_autoplay.py
@@ -28,7 +28,11 @@ def test_board15_test_autoplay(monkeypatch):
             effective_user=SimpleNamespace(id=1, first_name='Tester'),
             effective_chat=SimpleNamespace(id=100)
         )
-        context = SimpleNamespace(bot=SimpleNamespace(send_message=AsyncMock()), bot_data={})
+        context = SimpleNamespace(
+            bot=SimpleNamespace(send_message=AsyncMock(), send_photo=AsyncMock()),
+            bot_data={},
+        )
+        context.bot.send_photo.return_value = SimpleNamespace(message_id=1)
         await handlers.board15_test(update, context)
         await asyncio.gather(*tasks)
         messages = [c.args[1] for c in context.bot.send_message.call_args_list]

--- a/tests/test_board15_test_manual.py
+++ b/tests/test_board15_test_manual.py
@@ -52,11 +52,18 @@ def test_board15_test_manual(monkeypatch):
             effective_user=SimpleNamespace(id=1, first_name='Tester'),
             effective_chat=SimpleNamespace(id=100),
         )
-        context = SimpleNamespace(bot=SimpleNamespace(send_message=AsyncMock()), bot_data={})
+        context = SimpleNamespace(
+            bot=SimpleNamespace(send_message=AsyncMock(), send_photo=AsyncMock()),
+            bot_data={},
+        )
+        context.bot.send_photo.return_value = SimpleNamespace(message_id=1)
         await handlers.board15_test(update, context)
         await asyncio.sleep(0.1)
         assert context.bot.send_message.call_count == 0
         states = context.bot_data.setdefault(handlers.STATE_KEY, {})
+        saved_state = states[update.effective_chat.id]
+        assert saved_state.message_id == 1
+        assert created_match.messages['A']['board'] == 1
         state = handlers.Board15State(chat_id=update.effective_chat.id)
         state.selected = (0, 0)
         states[update.effective_chat.id] = state


### PR DESCRIPTION
## Summary
- fall back to `context.bot.send_photo` in `board15_test` when `reply_photo` is absent and record the board message ID
- adjust tests to mock `send_photo` and verify board message tracking

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68adb35cc6548326a8b4432a4137e24f