### PR TITLE
Ensure inline keyboard updated via edit_message_media

### DIFF
--- a/game_board15/router.py
+++ b/game_board15/router.py
@@ -81,16 +81,13 @@ async def _send_state(context: ContextTypes.DEFAULT_TYPE, match, player_key: str
                 chat_id=chat_id,
                 message_id=board_id,
                 media=InputMediaPhoto(buf),
-            )
-            await context.bot.edit_message_reply_markup(
-                chat_id=chat_id,
-                message_id=board_id,
                 reply_markup=_keyboard(),
             )
         except Exception:
             msg = await context.bot.send_photo(chat_id, buf, reply_markup=_keyboard())
             board_id = msg.message_id
             msgs['board'] = board_id
+            state.message_id = board_id
         else:
             state.message_id = board_id
     else:

--- a/tests/test_board15_keyboard.py
+++ b/tests/test_board15_keyboard.py
@@ -1,7 +1,7 @@
 import asyncio
 from io import BytesIO
 from types import SimpleNamespace
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, ANY
 
 from game_board15 import router
 from game_board15.models import Board15
@@ -32,8 +32,45 @@ def test_send_state_updates_inline_keyboard(monkeypatch):
 
         await router._send_state(context, match, 'A', 'msg')
 
-        bot.edit_message_reply_markup.assert_awaited_once_with(
-            chat_id=1, message_id=10, reply_markup=kb
+        bot.edit_message_media.assert_awaited_once_with(
+            chat_id=1, message_id=10, media=ANY, reply_markup=kb
         )
+        bot.edit_message_reply_markup.assert_not_awaited()
+
+    asyncio.run(run_test())
+
+
+def test_send_state_resends_keyboard_on_error(monkeypatch):
+    async def run_test():
+        match = SimpleNamespace(
+            players={'A': SimpleNamespace(chat_id=1)},
+            boards={'A': Board15()},
+            history=[[0] * 15 for _ in range(15)],
+            messages={'A': {'board': 10, 'status': 11}},
+        )
+
+        monkeypatch.setattr(router, 'render_board', lambda state, player_key=None: BytesIO(b'img'))
+        monkeypatch.setattr(router, 'render_player_board', lambda board, player_key=None: BytesIO(b'own'))
+        kb = object()
+        monkeypatch.setattr(router, '_keyboard', lambda: kb)
+        monkeypatch.setattr(router.storage, 'save_match', lambda m: None)
+
+        bot = SimpleNamespace(
+            edit_message_media=AsyncMock(side_effect=Exception()),
+            edit_message_text=AsyncMock(),
+            send_photo=AsyncMock(return_value=SimpleNamespace(message_id=50)),
+        )
+        context = SimpleNamespace(bot=bot, bot_data={}, chat_data={})
+
+        await router._send_state(context, match, 'A', 'msg')
+
+        assert bot.edit_message_media.await_count == 1
+        assert bot.edit_message_media.await_args.kwargs['reply_markup'] is kb
+
+        assert bot.send_photo.await_count == 2
+        assert bot.send_photo.await_args_list[1].kwargs['reply_markup'] is kb
+
+        state = context.bot_data[router.STATE_KEY][1]
+        assert state.message_id == 50
 
     asyncio.run(run_test())


### PR DESCRIPTION
## Summary
- Update `_send_state` to set `state.message_id` when resending board photo after edit failures
- Expand keyboard tests to verify `state.message_id` persistence in resend scenario

## Testing
- `pytest tests/test_board15_keyboard.py -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68adddc6b9f083268248014ff9b379ab