### PR TITLE
Show turn result below 15x15 board

### DIFF
--- a/game_board15/handlers.py
+++ b/game_board15/handlers.py
@@ -69,14 +69,13 @@ async def board15(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
     state.board = merged
     state.player_key = player_key
     buf = render_board(state, player_key)
-    msg = await update.message.reply_photo(buf)
-    status = await update.message.reply_text('Выберите клетку или введите ход текстом.')
+    msg = await update.message.reply_photo(
+        buf, caption='Выберите клетку или введите ход текстом.'
+    )
     state.message_id = msg.message_id
-    state.status_message_id = status.message_id
     context.bot_data.setdefault(STATE_KEY, {})[update.effective_chat.id] = state
     match.messages[player_key] = {
         'board': msg.message_id,
-        'status': status.message_id,
     }
     storage.save_match(match)
 
@@ -255,21 +254,19 @@ async def board15_test(update: Update, context: ContextTypes.DEFAULT_TYPE) -> No
     reply_photo = getattr(update.message, "reply_photo", None)
     board_msg_id = None
     if reply_photo is not None:
-        msg = await reply_photo(buf)
+        msg = await reply_photo(buf, caption='Выберите клетку или введите ход текстом.')
         board_msg_id = msg.message_id
     else:
         msg = await context.bot.send_photo(
             chat_id=update.effective_chat.id,
             photo=buf,
+            caption='Выберите клетку или введите ход текстом.',
         )
         board_msg_id = msg.message_id
-    status = await update.message.reply_text('Выберите клетку или введите ход текстом.')
     state.message_id = board_msg_id
-    state.status_message_id = status.message_id
     context.bot_data.setdefault(STATE_KEY, {})[update.effective_chat.id] = state
     match.messages['A'] = {
         'board': board_msg_id,
-        'status': status.message_id,
     }
     storage.save_match(match)
     asyncio.create_task(_auto_play_bots(match, context, update.effective_chat.id, human='A'))

--- a/game_board15/state.py
+++ b/game_board15/state.py
@@ -19,5 +19,4 @@ class Board15State:
     )
     chat_id: Optional[int] = None
     message_id: Optional[int] = None
-    status_message_id: Optional[int] = None
     player_key: Optional[str] = None

--- a/tests/test_board15_invite.py
+++ b/tests/test_board15_invite.py
@@ -45,9 +45,10 @@ def test_board15_invite_flow(monkeypatch):
         assert reply_text.call_args_list == [
             call('Выберите способ приглашения соперников:', reply_markup=ANY),
             call('Матч создан. Ожидаем подключения соперников.'),
-            call('Выберите клетку или введите ход текстом.'),
         ]
-        assert reply_photo.call_args_list == [call(ANY)]
+        assert reply_photo.call_args_list == [
+            call(ANY, caption='Выберите клетку или введите ход текстом.')
+        ]
 
     asyncio.run(run_test())
 

--- a/tests/test_board15_keyboard.py
+++ b/tests/test_board15_keyboard.py
@@ -15,7 +15,7 @@ def test_send_state_sends_board_without_keyboard(monkeypatch):
             players={'A': SimpleNamespace(chat_id=1)},
             boards={'A': Board15()},
             history=[[0] * 15 for _ in range(15)],
-            messages={'A': {'player': 20, 'status': 11}},
+            messages={'A': {'player': 20}},
         )
 
         monkeypatch.setattr(router, 'render_board', lambda state, player_key=None: BytesIO(b'img'))
@@ -47,7 +47,7 @@ def test_send_state_updates_without_keyboard(monkeypatch):
             players={'A': SimpleNamespace(chat_id=1)},
             boards={'A': Board15()},
             history=[[0] * 15 for _ in range(15)],
-            messages={'A': {'board': 10, 'status': 11}},
+            messages={'A': {'board': 10}},
         )
 
         monkeypatch.setattr(router, 'render_board', lambda state, player_key=None: BytesIO(b'img'))


### PR DESCRIPTION
## Summary
- Render 15x15 board updates with the move result as the photo caption
- Drop extra status message handling and simplify state tracking
- Adjust tests to expect captions instead of separate messages

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ae13d5b2f88326bb4b6dcf73cee610