### PR TITLE
Separate board image and text result in game state updates

### DIFF
--- a/tests/test_board15_keyboard.py
+++ b/tests/test_board15_keyboard.py
@@ -1,9 +1,7 @@
 import asyncio
 from io import BytesIO
 from types import SimpleNamespace
-from io import BytesIO
-from types import SimpleNamespace
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, call
 
 from game_board15 import router
 from game_board15.models import Board15
@@ -24,19 +22,24 @@ def test_send_state_sends_board_without_keyboard(monkeypatch):
 
         bot = SimpleNamespace(
             edit_message_media=AsyncMock(),
-            edit_message_reply_markup=AsyncMock(),
-            edit_message_text=AsyncMock(),
             send_photo=AsyncMock(return_value=SimpleNamespace(message_id=50)),
+            send_message=AsyncMock(return_value=SimpleNamespace(message_id=60)),
+            delete_message=AsyncMock(),
         )
         context = SimpleNamespace(bot=bot, bot_data={}, chat_data={})
 
         await router._send_state(context, match, 'A', 'msg')
 
+        bot.edit_message_media.assert_awaited_once()
         bot.send_photo.assert_awaited_once()
-        call = bot.send_photo.await_args
-        assert call.args[0] == 1
-        assert 'reply_markup' not in call.kwargs
-        assert bot.edit_message_reply_markup.await_count == 0
+        bot.send_message.assert_awaited_once()
+        call_photo = bot.send_photo.await_args
+        assert call_photo.args[0] == 1
+        assert 'caption' not in call_photo.kwargs
+        assert 'reply_markup' not in call_photo.kwargs
+        assert bot.delete_message.await_count == 0
+        assert match.messages['A']['board'] == 50
+        assert match.messages['A']['text'] == 60
 
     asyncio.run(run_test())
 
@@ -47,7 +50,7 @@ def test_send_state_updates_without_keyboard(monkeypatch):
             players={'A': SimpleNamespace(chat_id=1)},
             boards={'A': Board15()},
             history=[[0] * 15 for _ in range(15)],
-            messages={'A': {'board': 10}},
+            messages={'A': {'board': 10, 'player': 20, 'text': 30}},
         )
 
         monkeypatch.setattr(router, 'render_board', lambda state, player_key=None: BytesIO(b'img'))
@@ -56,19 +59,19 @@ def test_send_state_updates_without_keyboard(monkeypatch):
 
         bot = SimpleNamespace(
             edit_message_media=AsyncMock(),
-            edit_message_reply_markup=AsyncMock(),
-            edit_message_text=AsyncMock(),
-            send_photo=AsyncMock(return_value=SimpleNamespace(message_id=50)),
+            send_photo=AsyncMock(return_value=SimpleNamespace(message_id=40)),
+            send_message=AsyncMock(return_value=SimpleNamespace(message_id=41)),
+            delete_message=AsyncMock(),
         )
         context = SimpleNamespace(bot=bot, bot_data={}, chat_data={})
 
         await router._send_state(context, match, 'A', 'msg')
 
         bot.edit_message_media.assert_awaited_once()
-        kwargs = bot.edit_message_media.await_args.kwargs
-        assert kwargs['chat_id'] == 1
-        assert kwargs['message_id'] == 10
-        assert 'reply_markup' not in kwargs
-        assert bot.edit_message_reply_markup.await_count == 0
+        assert bot.delete_message.await_args_list == [call(1, 10), call(1, 30)]
+        bot.send_photo.assert_awaited_once()
+        bot.send_message.assert_awaited_once()
+        assert match.messages['A']['board'] == 40
+        assert match.messages['A']['text'] == 41
 
     asyncio.run(run_test())

--- a/tests/test_router_text.py
+++ b/tests/test_router_text.py
@@ -36,7 +36,8 @@ def test_router_invalid_cell_shows_board(monkeypatch):
         )
         await router.router_text(update, context)
         assert send_message.call_args_list == [
-            call(10, 'Ваше поле:\nown\nПоле соперника:\nenemy\nНе понял клетку. Пример: е5 или д10.', parse_mode='HTML', reply_markup=kb)
+            call(10, 'Ваше поле:\nown\nПоле соперника:\nenemy', parse_mode='HTML', reply_markup=kb),
+            call(10, 'Не понял клетку. Пример: е5 или д10.', parse_mode='HTML'),
         ]
     asyncio.run(run_test())
 
@@ -69,7 +70,8 @@ def test_router_wrong_turn_shows_board(monkeypatch):
         )
         await router.router_text(update, context)
         assert send_message.call_args_list == [
-            call(10, 'Ваше поле:\nown\nПоле соперника:\nenemy\nСейчас ход соперника.', parse_mode='HTML', reply_markup=kb)
+            call(10, 'Ваше поле:\nown\nПоле соперника:\nenemy', parse_mode='HTML', reply_markup=kb),
+            call(10, 'Сейчас ход соперника.', parse_mode='HTML'),
         ]
     asyncio.run(run_test())
 
@@ -110,8 +112,10 @@ def test_router_auto_shows_board(monkeypatch):
         )
         await router.router_text(update, context)
         assert send_message.call_args_list == [
-            call(10, 'Ваше поле:\nown\nПоле соперника:\nenemy\nКорабли расставлены. Бой начинается! Ваш ход.', parse_mode='HTML', reply_markup=kb),
-            call(20, 'Ваше поле:\nown\nПоле соперника:\nenemy\nСоперник готов. Бой начинается! Ход соперника.', parse_mode='HTML', reply_markup=kb),
+            call(10, 'Ваше поле:\nown\nПоле соперника:\nenemy', parse_mode='HTML', reply_markup=kb),
+            call(10, 'Корабли расставлены. Бой начинается! Ваш ход.', parse_mode='HTML'),
+            call(20, 'Ваше поле:\nown\nПоле соперника:\nenemy', parse_mode='HTML', reply_markup=kb),
+            call(20, 'Соперник готов. Бой начинается! Ход соперника.', parse_mode='HTML'),
         ]
     asyncio.run(run_test())
 
@@ -154,8 +158,10 @@ def test_router_auto_waits_and_sends_instruction(monkeypatch):
         )
         await router.router_text(update, context)
         assert send_message.call_args_list == [
-            call(10, 'Ваше поле:\nown\nПоле соперника:\nenemy\nКорабли расставлены. Ожидаем соперника.', parse_mode='HTML', reply_markup=kb),
-            call(20, 'Ваше поле:\nown\nПоле соперника:\nenemy\nСоперник готов. Отправьте "авто" для расстановки кораблей.', parse_mode='HTML', reply_markup=kb),
+            call(10, 'Ваше поле:\nown\nПоле соперника:\nenemy', parse_mode='HTML', reply_markup=kb),
+            call(10, 'Корабли расставлены. Ожидаем соперника.', parse_mode='HTML'),
+            call(20, 'Ваше поле:\nown\nПоле соперника:\nenemy', parse_mode='HTML', reply_markup=kb),
+            call(20, 'Соперник готов. Отправьте "авто" для расстановки кораблей.', parse_mode='HTML'),
             call(20, 'Используйте @ в начале сообщения, чтобы отправить сообщение соперникам в чат игры.'),
         ]
 
@@ -197,9 +203,9 @@ def test_router_kill_message(monkeypatch):
         )
         await router.router_text(update, context)
         calls = send_message.call_args_list
-        assert len(calls) == 2
-        msg_self = calls[0].args[1]
-        msg_enemy = calls[1].args[1]
+        assert len(calls) == 4
+        msg_self = calls[1].args[1]
+        msg_enemy = calls[3].args[1]
         assert 'a1 - Корабль соперника уничтожен!' in msg_self
         assert any(p in msg_self for p in phrases.SELF_KILL)
         assert msg_self.strip().endswith('Ваш ход.')
@@ -267,7 +273,7 @@ def test_router_joke_format(monkeypatch):
             effective_chat=SimpleNamespace(id=10),
         )
         await router.router_text(update, context)
-        msg_self = send_message.call_args_list[0].args[1]
+        msg_self = send_message.call_args_list[1].args[1]
         assert 'Слушай анекдот по этому поводу:\nJOKE\n\nХод соперника.' in msg_self
 
     asyncio.run(run_test())
@@ -310,10 +316,10 @@ def test_router_game_over_messages(monkeypatch):
         )
         await router.router_text(update, context)
         calls = send_message.call_args_list
-        assert 'Вы победили. 🏆🎉' in calls[0].args[1]
-        assert 'Все ваши корабли уничтожены' in calls[1].args[1]
-        assert calls[2].args[1] == 'Игра завершена!'
-        assert calls[3].args[1] == 'Игра завершена!'
-        assert calls[2].kwargs['reply_markup'].keyboard[0][0].text == 'Начать новую игру'
-        assert calls[3].kwargs['reply_markup'].keyboard[0][0].text == 'Начать новую игру'
+        assert 'Вы победили. 🏆🎉' in calls[1].args[1]
+        assert 'Все ваши корабли уничтожены' in calls[3].args[1]
+        assert calls[4].args[1] == 'Игра завершена!'
+        assert calls[5].args[1] == 'Игра завершена!'
+        assert calls[4].kwargs['reply_markup'].keyboard[0][0].text == 'Начать новую игру'
+        assert calls[5].kwargs['reply_markup'].keyboard[0][0].text == 'Начать новую игру'
     asyncio.run(run_test())


### PR DESCRIPTION
## Summary
- Render and send board images without captions, then deliver move results via separate messages in 15x15 and two-player modes
- Track and clean up previous board/text messages to keep chats tidy
- Update tests for the new messaging flow

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68ae1980b13483268294fb27b9870d07