### PR TITLE
Add highlight rendering for 15x15 boards

### DIFF
--- a/game_board15/renderer.py
+++ b/game_board15/renderer.py
@@ -18,7 +18,7 @@ COLORS = {
     "light": {
         "bg": (255, 255, 255, 255),
         "grid": (200, 200, 200, 255),
-        "mark": (0, 0, 0, 255),
+        "mark": (220, 0, 0, 255),
         "ship": (0, 0, 0, 255),
         "miss": (0, 0, 0, 255),
         "hit": (220, 0, 0, 255),
@@ -28,7 +28,7 @@ COLORS = {
     "dark": {
         "bg": (0, 0, 0, 255),
         "grid": (80, 80, 80, 255),
-        "mark": (220, 220, 220, 255),
+        "mark": (255, 0, 0, 255),
         "ship": (220, 220, 220, 255),
         "miss": (220, 220, 220, 255),
         "hit": (255, 0, 0, 255),
@@ -78,6 +78,8 @@ def render_board(state: Board15State, player_key: str | None = None) -> BytesIO:
         draw.line((margin, offset, margin + size, offset), fill=COLORS[THEME]["grid"])
         draw.line((offset, margin, offset, margin + size), fill=COLORS[THEME]["grid"])
 
+    highlight = set(state.highlight)
+
     # marks
     for r in range(15):
         for c in range(15):
@@ -86,11 +88,16 @@ def render_board(state: Board15State, player_key: str | None = None) -> BytesIO:
                 continue
             x0 = margin + c * TILE_PX
             y0 = margin + r * TILE_PX
+            coord = (r, c)
             shape, color_key = CELL_STYLE.get(val, ("square", "ship"))
-            if val == 1 and player_key:
-                color = PLAYER_SHIP_COLORS.get(THEME, {}).get(player_key, COLORS[THEME]["ship"])
+            if coord in highlight:
+                color = COLORS[THEME]["mark"]
+                shape = "cross" if val in (2, 5) else "square"
             else:
-                color = COLORS[THEME][color_key]
+                if val == 1 and player_key:
+                    color = PLAYER_SHIP_COLORS.get(THEME, {}).get(player_key, COLORS[THEME]["ship"])
+                else:
+                    color = COLORS[THEME][color_key]
             if shape == "square":
                 draw.rectangle(
                     (x0 + 4, y0 + 4, x0 + TILE_PX - 4, y0 + TILE_PX - 4),
@@ -153,6 +160,7 @@ def render_player_board(board: Board15, player_key: str | None = None) -> BytesI
         offset = margin + i * TILE_PX
         draw.line((margin, offset, margin + size, offset), fill=COLORS[THEME]["grid"])
         draw.line((offset, margin, offset, margin + size), fill=COLORS[THEME]["grid"])
+    highlight = set(board.highlight)
 
     # ship and shot markers
     for r in range(15):
@@ -162,11 +170,16 @@ def render_player_board(board: Board15, player_key: str | None = None) -> BytesI
                 continue
             x0 = margin + c * TILE_PX
             y0 = margin + r * TILE_PX
+            coord = (r, c)
             shape, color_key = CELL_STYLE.get(val, ("square", "ship"))
-            if val == 1 and player_key:
-                color = PLAYER_SHIP_COLORS.get(THEME, {}).get(player_key, COLORS[THEME]["ship"])
+            if coord in highlight:
+                color = COLORS[THEME]["mark"]
+                shape = "cross" if val in (2, 5) else "square"
             else:
-                color = COLORS[THEME][color_key]
+                if val == 1 and player_key:
+                    color = PLAYER_SHIP_COLORS.get(THEME, {}).get(player_key, COLORS[THEME]["ship"])
+                else:
+                    color = COLORS[THEME][color_key]
             if shape == "square":
                 draw.rectangle(
                     (x0 + 4, y0 + 4, x0 + TILE_PX - 4, y0 + TILE_PX - 4),

--- a/game_board15/router.py
+++ b/game_board15/router.py
@@ -42,6 +42,7 @@ async def _send_state(context: ContextTypes.DEFAULT_TYPE, match, player_key: str
                 merged[r][c] = 1
     state.board = merged
     state.player_key = player_key
+    state.highlight = match.boards[player_key].highlight.copy()
     buf = render_board(state, player_key)
     player_buf = render_player_board(match.boards[player_key], player_key)
 

--- a/game_board15/state.py
+++ b/game_board15/state.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import List, Optional, Tuple
+from typing import List, Optional
+
+from .models import Coord
 
 
 @dataclass
@@ -20,3 +22,4 @@ class Board15State:
     chat_id: Optional[int] = None
     message_id: Optional[int] = None
     player_key: Optional[str] = None
+    highlight: List[Coord] = field(default_factory=list)

--- a/tests/test_board15_invite.py
+++ b/tests/test_board15_invite.py
@@ -22,7 +22,7 @@ def test_board15_invite_flow(monkeypatch):
         match = SimpleNamespace(
             match_id='m1',
             players={'A': SimpleNamespace(user_id=1, chat_id=1, name='Alice')},
-            boards={'A': SimpleNamespace(grid=[[0] * 15 for _ in range(15)])},
+            boards={'A': SimpleNamespace(grid=[[0] * 15 for _ in range(15)], highlight=[])},
             messages={},
             history=[[0] * 15 for _ in range(15)],
         )

--- a/tests/test_board15_router.py
+++ b/tests/test_board15_router.py
@@ -25,8 +25,8 @@ def test_router_auto_sends_boards(monkeypatch):
                 'B': SimpleNamespace(user_id=2, chat_id=20, ready=False, name='Bob'),
             },
             boards={
-                'A': SimpleNamespace(grid=[[0] * 15 for _ in range(15)]),
-                'B': SimpleNamespace(grid=[[0] * 15 for _ in range(15)]),
+                'A': SimpleNamespace(grid=[[0] * 15 for _ in range(15)], highlight=[]),
+                'B': SimpleNamespace(grid=[[0] * 15 for _ in range(15)], highlight=[]),
             },
             turn='A',
             messages={},


### PR DESCRIPTION
## Summary
- track highlight cells on 15x15 boards via `Board15State.highlight`
- propagate board highlights to rendering and show them using mark color
- adjust tests for new board state handling

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68ae2b8105f4832698bb797625a79d5a