### PR TITLE
Refresh match before each auto-play round

### DIFF
--- a/game_board15/handlers.py
+++ b/game_board15/handlers.py
@@ -132,6 +132,9 @@ async def _auto_play_bots(
     from . import router as router_module
 
     while True:
+        match = storage.get_match(match.match_id)
+        if not match:
+            break
         alive = [k for k, b in match.boards.items() if b.alive_cells > 0 and k in match.players]
         if len(alive) == 1:
             winner = alive[0]


### PR DESCRIPTION
## Summary
- reload match from storage before each bot turn in 15x15 mode
- test that auto-play bots see human moves after refresh

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ae5390f48483269bf3eb7eb2c0ad61