### PR TITLE
Handle missing storage in auto-play bots

### DIFF
--- a/game_board15/handlers.py
+++ b/game_board15/handlers.py
@@ -132,9 +132,9 @@ async def _auto_play_bots(
     from . import router as router_module
 
     while True:
-        match = storage.get_match(match.match_id)
-        if not match:
-            break
+        refreshed = storage.get_match(match.match_id)
+        if refreshed is not None:
+            match = refreshed
         alive = [k for k, b in match.boards.items() if b.alive_cells > 0 and k in match.players]
         if len(alive) == 1:
             winner = alive[0]


### PR DESCRIPTION
## Summary
- ensure `_auto_play_bots` keeps using in-memory match when storage lookup returns `None`

## Testing
- `pytest tests/test_render.py -q`
- `pytest tests/test_board15_send_state.py -q`
- `pytest tests/test_board15_test_manual.py::test_board15_test_manual -q`


------
https://chatgpt.com/codex/tasks/task_e_68aee91bff5c83269ba0ba21a293dff5