### PR TITLE
Ensure Board15 history persists across moves

### DIFF
--- a/game_board15/battle.py
+++ b/game_board15/battle.py
@@ -69,8 +69,10 @@ def update_history(
                     if val == 4:
                         history[rr][cc] = 4
                     elif val == 5:
-                        # Mark contour cells as shot-through for everyone.
-                        history[rr][cc] = 5
+                        # Mark contour cells as shot-through for everyone without
+                        # overwriting prior shot information.
+                        if history[rr][cc] == 0:
+                            history[rr][cc] = 5
         history[r][c] = 4
     elif any(res == HIT for res in results.values()):
         history[r][c] = 3


### PR DESCRIPTION
## Summary
- Prevent overwriting prior shot info when updating kill contours
- Render boards from deep-copied history and log when history doesn't change
- Move match persistence after sending state to all players and add cumulative-history test

## Testing
- `pytest tests/test_board15_history.py tests/test_board15_send_state.py tests/test_board15_router.py tests/test_router_text.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68aeee77221c8326a58e77a689d42949