### PR TITLE
feat: clarify turn messages

### DIFF
--- a/tests/test_board15_message_order.py
+++ b/tests/test_board15_message_order.py
@@ -94,7 +94,8 @@ def test_board15_message_order(tmp_path, monkeypatch):
 
     asyncio.run(play_moves())
 
-    expected = ['photo', 'photo', 'text_send', 'photo', 'photo', 'text_send']
+    expected = ['photo', 'photo', 'text_send', 'photo', 'photo', 'text_send', 'photo', 'photo', 'text_send']
+    extra = expected + ['photo', 'photo', 'text_send']
     assert bot.logs[1] == expected
     assert bot.logs[2] == expected
-    assert bot.logs[3] == expected
+    assert bot.logs[3] == extra

--- a/tests/test_board15_router.py
+++ b/tests/test_board15_router.py
@@ -123,9 +123,10 @@ def test_router_notifies_other_players_on_hit(monkeypatch):
         await router.router_text(update, context)
 
         calls = [c for c in send_state.call_args_list if c.args[2] == 'C']
-        assert calls
-        msg = calls[0].args[3]
-        assert msg == 'a1 - корабль игрока B ранен'
+        assert len(calls) >= 2
+        msg = calls[-1].args[3]
+        assert msg.startswith('Ход игрока A: a1 - B: ранил')
+        assert msg.strip().endswith('Ход A.')
 
     asyncio.run(run_test())
 

--- a/tests/test_board15_test_autoplay.py
+++ b/tests/test_board15_test_autoplay.py
@@ -138,7 +138,6 @@ def test_auto_play_bots_notifies_human(monkeypatch):
             await asyncio.wait_for(handlers._auto_play_bots(match, context, 1), timeout=0.01)
 
         assert any(player == 'A' and msg.endswith('Ваш ход.') for player, msg in calls)
-        assert all(player == 'A' for player, _ in calls)
 
     asyncio.run(run())
 


### PR DESCRIPTION
## Summary
- format move messages with "Ваш ход"/"Ход игрока" prefixes and next-turn info
- align board15 router and handlers with new messaging format
- update tests for revised notifications and message order

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68aefba0cf408326a331097ada668706