### PR TITLE
Prevent duplicate Board15 text messages

### DIFF
--- a/tests/test_board15_keyboard.py
+++ b/tests/test_board15_keyboard.py
@@ -41,7 +41,8 @@ def test_send_state_sends_board_without_keyboard(monkeypatch):
         assert 'reply_markup' not in call_photo.kwargs
         assert bot.delete_message.await_count == 0
         assert match.messages['A']['board'] == 50
-        assert match.messages['A']['text'] == 60
+        assert match.messages['A']['text'] == 'msg'
+        assert match.messages['A']['text_id'] == 60
         assert match.messages['A']['text_history'] == [60]
 
     asyncio.run(run_test())
@@ -52,7 +53,7 @@ def test_send_state_edits_existing_messages(monkeypatch):
             players={'A': SimpleNamespace(chat_id=1)},
             boards={'A': Board15()},
             history=[[0] * 15 for _ in range(15)],
-            messages={'A': {'board': 10, 'player': 20, 'text': 30}},
+            messages={'A': {'board': 10, 'player': 20, 'text': 'old', 'text_id': 30, 'text_history': [30]}},
         )
 
         monkeypatch.setattr(router, 'render_board', lambda state, player_key=None: BytesIO(b'img'))
@@ -63,7 +64,7 @@ def test_send_state_edits_existing_messages(monkeypatch):
             edit_message_media=AsyncMock(),
             edit_message_text=AsyncMock(),
             send_photo=AsyncMock(),
-            send_message=AsyncMock(return_value=SimpleNamespace(message_id=31)),
+            send_message=AsyncMock(),
             delete_message=AsyncMock(),
         )
         context = SimpleNamespace(bot=bot, bot_data={}, chat_data={})
@@ -71,13 +72,14 @@ def test_send_state_edits_existing_messages(monkeypatch):
         await router._send_state(context, match, 'A', 'msg')
 
         assert bot.edit_message_media.await_count == 2
-        bot.edit_message_text.assert_not_called()
+        bot.edit_message_text.assert_awaited_once()
         bot.send_photo.assert_not_called()
-        bot.send_message.assert_awaited_once()
+        bot.send_message.assert_not_called()
         bot.delete_message.assert_not_called()
         assert match.messages['A']['board'] == 10
-        assert match.messages['A']['text'] == 31
-        assert match.messages['A']['text_history'] == [31]
+        assert match.messages['A']['text'] == 'msg'
+        assert match.messages['A']['text_id'] == 30
+        assert match.messages['A']['text_history'] == [30]
 
     asyncio.run(run_test())
 
@@ -88,7 +90,7 @@ def test_send_state_recreates_messages_on_edit_failure(monkeypatch):
             players={'A': SimpleNamespace(chat_id=1)},
             boards={'A': Board15()},
             history=[[0] * 15 for _ in range(15)],
-            messages={'A': {'board': 10, 'player': 20, 'text': 30}},
+            messages={'A': {'board': 10, 'player': 20, 'text': 'old', 'text_id': 30, 'text_history': [30]}},
         )
 
         board_buf = BytesIO(b'img')
@@ -110,7 +112,7 @@ def test_send_state_recreates_messages_on_edit_failure(monkeypatch):
             edit_message_media=AsyncMock(side_effect=edit_media),
             edit_message_text=AsyncMock(),
             send_photo=AsyncMock(return_value=SimpleNamespace(message_id=40)),
-            send_message=AsyncMock(return_value=SimpleNamespace(message_id=41)),
+            send_message=AsyncMock(),
             delete_message=AsyncMock(),
         )
         context = SimpleNamespace(bot=bot, bot_data={}, chat_data={})
@@ -118,14 +120,15 @@ def test_send_state_recreates_messages_on_edit_failure(monkeypatch):
         await router._send_state(context, match, 'A', 'msg')
 
         assert bot.edit_message_media.await_count == 2
-        bot.edit_message_text.assert_not_called()
+        bot.edit_message_text.assert_awaited_once()
         assert bot.delete_message.await_args_list == [call(1, 10)]
         bot.send_photo.assert_awaited_once()
-        bot.send_message.assert_awaited_once()
+        bot.send_message.assert_not_called()
         assert board_buf.tell() == 0
         assert match.messages['A']['board'] == 40
-        assert match.messages['A']['text'] == 41
-        assert match.messages['A']['text_history'] == [41]
+        assert match.messages['A']['text'] == 'msg'
+        assert match.messages['A']['text_id'] == 30
+        assert match.messages['A']['text_history'] == [30]
 
     asyncio.run(run_test())
 
@@ -136,7 +139,7 @@ def test_send_state_recreates_player_board_on_edit_failure(monkeypatch):
             players={'A': SimpleNamespace(chat_id=1)},
             boards={'A': Board15()},
             history=[[0] * 15 for _ in range(15)],
-            messages={'A': {'board': 10, 'player': 20, 'text': 30}},
+            messages={'A': {'board': 10, 'player': 20, 'text': 'old', 'text_id': 30, 'text_history': [30]}},
         )
 
         board_buf = BytesIO(b'img')
@@ -158,7 +161,7 @@ def test_send_state_recreates_player_board_on_edit_failure(monkeypatch):
             edit_message_media=AsyncMock(side_effect=edit_media),
             edit_message_text=AsyncMock(),
             send_photo=AsyncMock(return_value=SimpleNamespace(message_id=40)),
-            send_message=AsyncMock(return_value=SimpleNamespace(message_id=41)),
+            send_message=AsyncMock(),
             delete_message=AsyncMock(),
         )
         context = SimpleNamespace(bot=bot, bot_data={}, chat_data={})
@@ -166,15 +169,50 @@ def test_send_state_recreates_player_board_on_edit_failure(monkeypatch):
         await router._send_state(context, match, 'A', 'msg')
 
         assert bot.edit_message_media.await_count == 2
-        bot.edit_message_text.assert_not_called()
+        bot.edit_message_text.assert_awaited_once()
         assert bot.delete_message.await_args_list == [call(1, 20)]
         bot.send_photo.assert_awaited_once()
         assert bot.send_photo.await_args.args[1] is player_buf
         assert player_buf.tell() == 0
-        bot.send_message.assert_awaited_once()
+        bot.send_message.assert_not_called()
         assert match.messages['A']['player'] == 40
         assert match.messages['A']['board'] == 10
-        assert match.messages['A']['text'] == 41
-        assert match.messages['A']['text_history'] == [41]
+        assert match.messages['A']['text'] == 'msg'
+        assert match.messages['A']['text_id'] == 30
+        assert match.messages['A']['text_history'] == [30]
+
+
+def test_send_state_avoids_duplicate_text(monkeypatch):
+    async def run_test():
+        match = SimpleNamespace(
+            players={'A': SimpleNamespace(chat_id=1)},
+            boards={'A': Board15()},
+            history=[[0] * 15 for _ in range(15)],
+            messages={'A': {}},
+        )
+
+        board_buf = BytesIO(b'img')
+        player_buf = BytesIO(b'own')
+        monkeypatch.setattr(router, 'render_board', lambda state, player_key=None: board_buf)
+        monkeypatch.setattr(router, 'render_player_board', lambda board, player_key=None: player_buf)
+        monkeypatch.setattr(router.storage, 'save_match', lambda m: None)
+
+        bot = SimpleNamespace(
+            edit_message_media=AsyncMock(),
+            edit_message_text=AsyncMock(),
+            send_photo=AsyncMock(side_effect=[SimpleNamespace(message_id=40), SimpleNamespace(message_id=50)]),
+            send_message=AsyncMock(return_value=SimpleNamespace(message_id=60)),
+            delete_message=AsyncMock(),
+        )
+        context = SimpleNamespace(bot=bot, bot_data={}, chat_data={})
+
+        await router._send_state(context, match, 'A', 'msg')
+        await router._send_state(context, match, 'A', 'msg')
+
+        assert bot.send_message.await_count == 1
+        bot.edit_message_text.assert_not_called()
+        assert match.messages['A']['text'] == 'msg'
+        assert match.messages['A']['text_id'] == 60
+        assert match.messages['A']['text_history'] == [60]
 
     asyncio.run(run_test())

--- a/tests/test_board15_message_order.py
+++ b/tests/test_board15_message_order.py
@@ -94,8 +94,8 @@ def test_board15_message_order(tmp_path, monkeypatch):
 
     asyncio.run(play_moves())
 
-    expected = ['photo', 'photo', 'text_send', 'photo', 'photo', 'text_send', 'photo', 'photo', 'text_send']
-    extra = expected + ['photo', 'photo', 'text_send']
+    expected = ['photo', 'photo', 'text_send', 'photo', 'photo', 'text_edit', 'photo', 'photo', 'text_edit']
+    extra = ['photo', 'photo', 'text_send', 'photo', 'photo', 'text_edit', 'photo', 'photo', 'text_edit', 'photo', 'photo', 'text_edit']
     assert bot.logs[1] == expected
     assert bot.logs[2] == expected
     assert bot.logs[3] == extra


### PR DESCRIPTION
## Summary
- Avoid resending identical Board15 status texts by comparing with last saved text and editing previous message when needed
- Track message IDs separately from text content to maintain history
- Add regression tests to ensure repeated _send_state calls do not duplicate messages

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68af0cd402bc8326a6205991a17da53d