### PR TITLE
refactor: update board15 tests for shared board

### DIFF
--- a/tests/test_board15_invite.py
+++ b/tests/test_board15_invite.py
@@ -22,7 +22,8 @@ def test_board15_invite_flow(monkeypatch):
         match = SimpleNamespace(
             match_id='m1',
             players={'A': SimpleNamespace(user_id=1, chat_id=1, name='Alice')},
-            boards={'A': SimpleNamespace(grid=[[0] * 15 for _ in range(15)], highlight=[])},
+            board=SimpleNamespace(grid=[[0] * 15 for _ in range(15)], highlight=[]),
+            cell_owner=[[None] * 15 for _ in range(15)],
             messages={},
             history=[[0] * 15 for _ in range(15)],
         )

--- a/tests/test_board15_keyboard.py
+++ b/tests/test_board15_keyboard.py
@@ -11,7 +11,8 @@ def test_send_state_sends_board_without_keyboard(monkeypatch):
     async def run_test():
         match = SimpleNamespace(
             players={'A': SimpleNamespace(chat_id=1)},
-            boards={'A': Board15()},
+            board=Board15(),
+            cell_owner=[[None] * 15 for _ in range(15)],
             history=[[0] * 15 for _ in range(15)],
             messages={'A': {'player': 20}},
         )
@@ -51,7 +52,8 @@ def test_send_state_edits_existing_messages(monkeypatch):
     async def run_test():
         match = SimpleNamespace(
             players={'A': SimpleNamespace(chat_id=1)},
-            boards={'A': Board15()},
+            board=Board15(),
+            cell_owner=[[None] * 15 for _ in range(15)],
             history=[[0] * 15 for _ in range(15)],
             messages={'A': {'board': 10, 'player': 20, 'text': 'old', 'text_id': 30, 'text_history': [30]}},
         )
@@ -88,7 +90,8 @@ def test_send_state_recreates_messages_on_edit_failure(monkeypatch):
     async def run_test():
         match = SimpleNamespace(
             players={'A': SimpleNamespace(chat_id=1)},
-            boards={'A': Board15()},
+            board=Board15(),
+            cell_owner=[[None] * 15 for _ in range(15)],
             history=[[0] * 15 for _ in range(15)],
             messages={'A': {'board': 10, 'player': 20, 'text': 'old', 'text_id': 30, 'text_history': [30]}},
         )
@@ -137,7 +140,8 @@ def test_send_state_recreates_player_board_on_edit_failure(monkeypatch):
     async def run_test():
         match = SimpleNamespace(
             players={'A': SimpleNamespace(chat_id=1)},
-            boards={'A': Board15()},
+            board=Board15(),
+            cell_owner=[[None] * 15 for _ in range(15)],
             history=[[0] * 15 for _ in range(15)],
             messages={'A': {'board': 10, 'player': 20, 'text': 'old', 'text_id': 30, 'text_history': [30]}},
         )
@@ -186,7 +190,8 @@ def test_send_state_avoids_duplicate_text(monkeypatch):
     async def run_test():
         match = SimpleNamespace(
             players={'A': SimpleNamespace(chat_id=1)},
-            boards={'A': Board15()},
+            board=Board15(),
+            cell_owner=[[None] * 15 for _ in range(15)],
             history=[[0] * 15 for _ in range(15)],
             messages={'A': {}},
         )

--- a/tests/test_board15_no_overlap.py
+++ b/tests/test_board15_no_overlap.py
@@ -1,9 +1,12 @@
 from game_board15 import storage, placement
 
 
-def mask_from_board(board):
+def mask_from_owner(board, cell_owner, owner):
     mask = [[0] * 15 for _ in range(15)]
     for ship in board.ships:
+        sr, sc = ship.cells[0]
+        if cell_owner[sr][sc] != owner:
+            continue
         for r, c in ship.cells:
             for dr in (-1, 0, 1):
                 for dc in (-1, 0, 1):
@@ -27,11 +30,11 @@ def test_bots_do_not_overlap(tmp_path, monkeypatch):
     storage.save_board(match, "B")
     storage.save_board(match, "C")
 
-    masks = {k: mask_from_board(b) for k, b in match.boards.items()}
+    masks = {k: mask_from_owner(match.board, match.cell_owner, k) for k in ("A", "B", "C")}
     for a in ("A", "B", "C"):
         for b in ("A", "B", "C"):
             if a >= b:
                 continue
-            for ship in match.boards[a].ships:
+            for ship in [s for s in match.board.ships if match.cell_owner[s.cells[0][0]][s.cells[0][1]] == a]:
                 for r, c in ship.cells:
                     assert masks[b][r][c] == 0

--- a/tests/test_board15_own_ship.py
+++ b/tests/test_board15_own_ship.py
@@ -13,14 +13,15 @@ def test_router_text_blocks_own_ship(monkeypatch):
         match = Match15.new(1, 1, 'A')
         match.players['B'] = Player(user_id=2, chat_id=2, name='B')
         match.status = 'playing'
-        match.boards['A'].grid[0][0] = 1
+        match.board.grid[0][0] = 1
+        match.cell_owner[0][0] = 'A'
 
         monkeypatch.setattr(storage, 'find_match_by_user', lambda uid, chat_id=None: match)
         monkeypatch.setattr(router.parser, 'parse_coord', lambda text: (0, 0))
 
         called = {'val': False}
 
-        def fake_apply_shot(board, coord):
+        def fake_apply_shot(*args, **kwargs):
             called['val'] = True
             return router.battle.MISS
 

--- a/tests/test_board15_telegram_updates.py
+++ b/tests/test_board15_telegram_updates.py
@@ -52,15 +52,15 @@ def test_board_updates_accumulate(tmp_path, monkeypatch):
     context = SimpleNamespace(bot=bot, bot_data={})
 
     coord1 = (0, 0)
-    res1 = battle.apply_shot(match.boards['B'], coord1)
-    battle.update_history(match.history, match.boards, coord1, {'B': res1})
+    res1 = battle.apply_shot(match.board, coord1)
+    battle.update_history(match.history, match.board, match.cell_owner, coord1, {'B': res1})
     match.shots['A']['last_coord'] = coord1
     asyncio.run(router._send_state(context, match, 'A', 'msg'))
     assert boards[0][0][0] == 2
 
     coord2 = (1, 1)
-    res2 = battle.apply_shot(match.boards['A'], coord2)
-    battle.update_history(match.history, match.boards, coord2, {'A': res2})
+    res2 = battle.apply_shot(match.board, coord2)
+    battle.update_history(match.history, match.board, match.cell_owner, coord2, {'A': res2})
     match.shots['B']['last_coord'] = coord2
     asyncio.run(router._send_state(context, match, 'B', 'msg'))
     assert boards[1][0][0] == 2

--- a/tests/test_board15_test_autoplay.py
+++ b/tests/test_board15_test_autoplay.py
@@ -83,11 +83,13 @@ def test_auto_play_bots_skips_own_ship(monkeypatch):
         match.players['B'] = Player(user_id=0, chat_id=0, name='B')
         match.status = 'playing'
         match.turn = 'B'
-        match.boards['B'].grid[0][0] = 1
+        match.board.grid[0][0] = 1
+        match.cell_owner[0][0] = 'B'
 
         recorded = {}
 
-        def fake_apply_shot(board, coord):
+        def fake_apply_shot(*args, **kwargs):
+            coord = args[1] if len(args) > 1 else kwargs.get('coord')
             recorded['coord'] = coord
             raise RuntimeError('stop')
 


### PR DESCRIPTION
## Summary
- update board15 tests to use shared board and cell ownership mapping
- adjust history tracking tests for unified board
- rewrite overlap helper to check shared grid owners

## Testing
- `pytest tests/test_board15_bot_elimination.py tests/test_board15_history.py tests/test_board15_telegram_updates.py tests/test_board15_own_ship.py tests/test_board15_no_overlap.py tests/test_board15_test_autoplay.py tests/test_board15_invite.py tests/test_board15_keyboard.py tests/test_board15_router.py -q` *(fails: AttributeError: 'Match15' object has no attribute 'board', etc.)*


------
https://chatgpt.com/codex/tasks/task_e_68af4d587e988326a196d1b4e85e815f