### PR TITLE
Add third player support and shot history tracking

### DIFF
--- a/models.py
+++ b/models.py
@@ -39,28 +39,32 @@ class Match:
     players: Dict[str, Player] = field(default_factory=dict)
     turn: str = "A"
     boards: Dict[str, Board] = field(default_factory=dict)
-    shots: Dict[str, Dict[str, object]] = field(default_factory=lambda: {
-        "A": {
-            "history": [],
-            "last_result": None,
-            "move_count": 0,
-            "joke_start": random.randint(1, 10),
-        },
-        "B": {
-            "history": [],
-            "last_result": None,
-            "move_count": 0,
-            "joke_start": random.randint(1, 10),
-        },
-    })
+    # global shot history for rendering target board
+    history: List[List[int]] = field(
+        default_factory=lambda: [[0] * 10 for _ in range(10)]
+    )
+    shots: Dict[str, Dict[str, object]] = field(
+        default_factory=lambda: {
+            k: {
+                "history": [],
+                "last_result": None,
+                "move_count": 0,
+                "joke_start": random.randint(1, 10),
+            }
+            for k in ("A", "B", "C")
+        }
+    )
     # stores ids of service messages per player: e.g. last board or keyboard
-    messages: Dict[str, Dict[str, int]] = field(default_factory=lambda: {"A": {}, "B": {}})
+    messages: Dict[str, Dict[str, int]] = field(
+        default_factory=lambda: {"A": {}, "B": {}, "C": {}}
+    )
 
     @staticmethod
     def new(a_user_id: int, a_chat_id: int) -> 'Match':
         match_id = uuid.uuid4().hex
         match = Match(match_id=match_id)
         match.players["A"] = Player(user_id=a_user_id, chat_id=a_chat_id)
-        match.boards["A"] = Board()
-        match.boards["B"] = Board()
+        for k in ("A", "B", "C"):
+            match.boards[k] = Board()
+        match.history = [[0] * 10 for _ in range(10)]
         return match

--- a/storage.py
+++ b/storage.py
@@ -69,6 +69,7 @@ def get_match(match_id: str) -> Match | None:
             alive_cells=b.get('alive_cells', 20),
         )
     match.turn = m.get('turn', 'A')
+    match.history = m.get('history', [[0] * 10 for _ in range(10)])
     match.shots = m.get('shots', match.shots)
     match.messages = m.get('messages', {})
     return match
@@ -126,6 +127,7 @@ def save_board(match: Match, player_key: str, board: Board) -> None:
             current.turn = m_dict.get('turn', 'A')
             current.shots = m_dict.get('shots', current.shots)
             current.messages = m_dict.get('messages', {})
+            current.history = m_dict.get('history', [[0] * 10 for _ in range(10)])
         else:
             current = match
 
@@ -149,6 +151,7 @@ def save_board(match: Match, player_key: str, board: Board) -> None:
                        for k, b in current.boards.items()},
             'shots': current.shots,
             'messages': current.messages,
+            'history': current.history,
         }
         _save_all(data)
 
@@ -158,6 +161,7 @@ def save_board(match: Match, player_key: str, board: Board) -> None:
     match.players = current.players
     match.boards = current.boards
     match.shots = current.shots
+    match.history = current.history
     match.messages = current.messages
 
 
@@ -192,6 +196,7 @@ def save_match(match: Match) -> str | None:
             },
             "shots": match.shots,
             "messages": match.messages,
+            "history": match.history,
         }
         return _save_all(data)
 


### PR DESCRIPTION
## Summary
- Expand `Match` model to handle three players and maintain a global shot history grid
- Initialize boards for players A, B and C and ensure history starts empty
- Persist and restore the new history field in storage operations

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68af5d261ec8832695c0e9257d4c3c6f