### PR TITLE
Add global mask placement helper for 15x15 test matches

### DIFF
--- a/game_board15/handlers.py
+++ b/game_board15/handlers.py
@@ -280,16 +280,9 @@ async def board15_test(update: Update, context: ContextTypes.DEFAULT_TYPE) -> No
     # adjacent) and update it after each fleet is generated.
     mask = [[0] * 15 for _ in range(15)]
     for key in ('A', 'B', 'C'):
-        board = placement.random_board(mask)
+        board = placement.random_board_global(mask)
         match.players[key].ready = True
         match.boards[key] = board
-        for ship in board.ships:
-            for r, c in ship.cells:
-                for dr in (-1, 0, 1):
-                    for dc in (-1, 0, 1):
-                        nr, nc = r + dr, c + dc
-                        if 0 <= nr < 15 and 0 <= nc < 15:
-                            mask[nr][nc] = 1
     storage.save_match(match)
     state = Board15State(chat_id=update.effective_chat.id)
     merged = [row[:] for row in match.history]

--- a/game_board15/placement.py
+++ b/game_board15/placement.py
@@ -135,3 +135,24 @@ def random_board(global_mask: List[List[int]] | None = None) -> Board15:
                     return board
         # if placement failed for the player, try again from scratch
     raise RuntimeError("Failed to place fleet after several attempts")
+
+def random_board_global(global_mask: List[List[int]]) -> Board15:
+    """Place a fleet avoiding and updating a shared ``global_mask``.
+
+    ``global_mask`` uses ``1`` to mark cells that are occupied or adjacent to
+    existing ships.  The mask is updated in-place with the new fleet's cells
+    and contour so that subsequent calls will avoid those areas.
+    """
+    base_mask = [row[:] for row in global_mask]
+    for _ in range(GLOBAL_RESTART_LIMIT):
+        for _ in range(PLAYER_RETRY_LIMIT):
+            board = Board15()
+            mask = [row[:] for row in base_mask]
+            if _place_fleet(board, mask, base_mask):
+                if board.grid[0][0] == 0:
+                    for r in range(BOARD_SIZE):
+                        for c in range(BOARD_SIZE):
+                            global_mask[r][c] = mask[r][c]
+                    return board
+        # if placement failed for the player, try again from scratch
+    raise RuntimeError("Failed to place fleet after several attempts")

--- a/tests/test_board15_test_autoplay.py
+++ b/tests/test_board15_test_autoplay.py
@@ -11,9 +11,9 @@ from game_board15.models import Board15, Match15, Player
 def test_board15_test_autoplay(monkeypatch):
     async def run():
         boards = [Board15(), Board15(alive_cells=0), Board15(alive_cells=0)]
-        def fake_random_board(*args, **kwargs):
+        def fake_random_board(mask):
             return boards.pop(0)
-        monkeypatch.setattr(handlers.placement, 'random_board', fake_random_board)
+        monkeypatch.setattr(handlers.placement, 'random_board_global', fake_random_board)
         holder = {}
 
         def fake_save_match(m: Match15):

--- a/tests/test_board15_test_manual.py
+++ b/tests/test_board15_test_manual.py
@@ -25,7 +25,7 @@ def test_board15_test_manual(monkeypatch):
             make_board((0, 0)),    # B
             make_board((0, 1)),    # C
         ])
-        monkeypatch.setattr(handlers.placement, "random_board", lambda *a, **k: next(boards))
+        monkeypatch.setattr(handlers.placement, "random_board_global", lambda mask: next(boards))
 
         # in-memory match handling
         match = Match15.new(1, 100, "Tester")

--- a/tests/test_three_player_match.py
+++ b/tests/test_three_player_match.py
@@ -25,7 +25,7 @@ def test_three_player_match(monkeypatch):
             make_board((13, 13)),  # B
             make_board((12, 12)),  # C
         ])
-        monkeypatch.setattr(handlers.placement, "random_board", lambda mask=None: next(boards))
+        monkeypatch.setattr(handlers.placement, "random_board_global", lambda mask: next(boards))
 
         match = Match15.new(1, 100, "Tester")
         monkeypatch.setattr(storage, "create_match", lambda uid, cid, name: match)


### PR DESCRIPTION
## Summary
- add `random_board_global` to generate 15x15 fleets while updating a shared mask
- use the new helper when starting three-player test matches
- update tests to hook into `random_board_global`

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68af5f4e4ea88326a7c1842ddb14b56a