### PR TITLE
Send new board messages instead of editing

### DIFF
--- a/handlers/router.py
+++ b/handlers/router.py
@@ -44,38 +44,20 @@ async def _send_state(
     enemy = render_board_enemy(match.boards[enemy_key])
     kb = move_keyboard()
 
-    # update board message with keyboard
+    # send a fresh board message with keyboard and remove the old one
     board_text = f"Ваше поле:\n{own}\nПоле соперника:\n{enemy}"
     if board_id:
         try:
-            await context.bot.edit_message_text(
-                chat_id=chat_id,
-                message_id=board_id,
-                text=board_text,
-                parse_mode="HTML",
-                reply_markup=kb,
-            )
+            await context.bot.delete_message(chat_id, board_id)
         except Exception:
-            try:
-                await context.bot.delete_message(chat_id, board_id)
-            except Exception:
-                pass
-            board_msg = await context.bot.send_message(
-                chat_id,
-                board_text,
-                parse_mode="HTML",
-                reply_markup=kb,
-            )
-            board_id = board_msg.message_id
-    else:
-        board_msg = await context.bot.send_message(
-            chat_id,
-            board_text,
-            parse_mode="HTML",
-            reply_markup=kb,
-        )
-        board_id = board_msg.message_id
-    msgs["board"] = board_id
+            pass
+    board_msg = await context.bot.send_message(
+        chat_id,
+        board_text,
+        parse_mode="HTML",
+        reply_markup=kb,
+    )
+    msgs["board"] = board_msg.message_id
 
     # update text message with result
     if text_id:
@@ -141,34 +123,16 @@ async def _send_state_board_test(
 
     if board_id:
         try:
-            await context.bot.edit_message_text(
-                chat_id=chat_id,
-                message_id=board_id,
-                text=board_text,
-                parse_mode="HTML",
-                reply_markup=kb,
-            )
+            await context.bot.delete_message(chat_id, board_id)
         except Exception:
-            try:
-                await context.bot.delete_message(chat_id, board_id)
-            except Exception:
-                pass
-            board_msg = await context.bot.send_message(
-                chat_id,
-                board_text,
-                parse_mode="HTML",
-                reply_markup=kb,
-            )
-            board_id = board_msg.message_id
-    else:
-        board_msg = await context.bot.send_message(
-            chat_id,
-            board_text,
-            parse_mode="HTML",
-            reply_markup=kb,
-        )
-        board_id = board_msg.message_id
-    msgs["board"] = board_id
+            pass
+    board_msg = await context.bot.send_message(
+        chat_id,
+        board_text,
+        parse_mode="HTML",
+        reply_markup=kb,
+    )
+    msgs["board"] = board_msg.message_id
 
     if text_id:
         try:

--- a/tests/test_router_keyboard.py
+++ b/tests/test_router_keyboard.py
@@ -55,17 +55,17 @@ def test_send_state_edits_existing_messages(monkeypatch):
         monkeypatch.setattr(router.storage, 'save_match', lambda m: None)
         bot = SimpleNamespace(
             edit_message_text=AsyncMock(),
-            send_message=AsyncMock(),
+            send_message=AsyncMock(return_value=SimpleNamespace(message_id=20)),
             delete_message=AsyncMock(),
         )
         context = SimpleNamespace(bot=bot)
 
         await router._send_state(context, match, 'A', 'msg')
 
-        assert bot.edit_message_text.await_count == 2
-        bot.send_message.assert_not_called()
-        bot.delete_message.assert_not_called()
-        assert match.messages['A']['board'] == 10
+        bot.edit_message_text.assert_awaited_once()
+        bot.send_message.assert_awaited_once()
+        assert bot.delete_message.await_args_list == [call(1, 10)]
+        assert match.messages['A']['board'] == 20
         assert match.messages['A']['text'] == 11
 
     asyncio.run(run_test())

--- a/tests/test_router_message_order.py
+++ b/tests/test_router_message_order.py
@@ -74,6 +74,6 @@ def test_router_message_order(tmp_path, monkeypatch):
 
     asyncio.run(play_moves())
 
-    expected = ['board_send', 'text_send', 'board_edit', 'text_edit']
+    expected = ['board_send', 'text_send', 'board_send', 'text_edit']
     assert bot.logs[1] == expected
     assert bot.logs[2] == expected


### PR DESCRIPTION
## Summary
- Always delete old board message and send a fresh one
- Preserve result text in a separate message following the board
- Update tests for new board message workflow

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b04376cea08326bdf16d0a9d28995a