### PR TITLE
Add quit commands to end current game session

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -19,6 +19,7 @@ from handlers.commands import (
     start,
     newgame,
     board,
+    quit_game,
     send_invite_link,
     choose_mode,
     confirm_newgame,
@@ -69,6 +70,7 @@ bot_app = ApplicationBuilder().token(token).updater(None).build()
 bot_app.add_handler(CommandHandler("start", start))
 bot_app.add_handler(CommandHandler("newgame", newgame))
 bot_app.add_handler(CommandHandler("board", board))
+bot_app.add_handler(CommandHandler(["quit", "exit"], quit_game))
 bot_app.add_handler(CallbackQueryHandler(send_invite_link, pattern="^get_link$"))
 bot_app.add_handler(CallbackQueryHandler(choose_mode, pattern="^mode_"))
 bot_app.add_handler(CallbackQueryHandler(confirm_newgame, pattern="^ng_"))


### PR DESCRIPTION
## Summary
- support /quit and /exit commands to close the active match
- notify all players when a match is terminated

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b0583b6e1c8326a6ecdcc5807f0520