### PR TITLE
Fix battle cell state comparisons

### DIFF
--- a/logic/battle.py
+++ b/logic/battle.py
@@ -7,29 +7,44 @@ from models import Board, Ship
 MISS, HIT, KILL, REPEAT = 'miss', 'hit', 'kill', 'repeat'
 
 
+def _get_cell_state(board: Board, r: int, c: int) -> int:
+    """Return the state value for a cell, accounting for tuple/list storage."""
+    cell = board.grid[r][c]
+    return cell[0] if isinstance(cell, (list, tuple)) else cell
+
+
+def _set_cell_state(board: Board, r: int, c: int, value: int) -> None:
+    """Set the state value for a cell, supporting tuple/list storage."""
+    cell = board.grid[r][c]
+    if isinstance(cell, list):
+        cell[0] = value
+    else:
+        board.grid[r][c] = value
+
+
 def mark_contour(board: Board, cells: list[Tuple[int,int]]) -> None:
     for r, c in cells:
         for dr in (-1,0,1):
             for dc in (-1,0,1):
                 nr, nc = r+dr, c+dc
                 if 0 <= nr < 10 and 0 <= nc < 10:
-                    if board.grid[nr][nc] == 0:
-                        board.grid[nr][nc] = 5
+                    if _get_cell_state(board, nr, nc) == 0:
+                        _set_cell_state(board, nr, nc, 5)
 
 
 def apply_shot(board: Board, coord: Tuple[int,int]) -> str:
     board.highlight = []
     r, c = coord
-    cell = board.grid[r][c]
-    if cell in (2,3,4,5):
+    cell_state = _get_cell_state(board, r, c)
+    if cell_state in (2,3,4,5):
         board.highlight = [coord]
         return REPEAT  # already shot here or around
-    if cell == 0:
-        board.grid[r][c] = 2
+    if cell_state == 0:
+        _set_cell_state(board, r, c, 2)
         board.highlight = [coord]
         return MISS
-    if cell == 1:
-        board.grid[r][c] = 3
+    if cell_state == 1:
+        _set_cell_state(board, r, c, 3)
         board.alive_cells -= 1
         # find ship
         ship = None
@@ -40,13 +55,13 @@ def apply_shot(board: Board, coord: Tuple[int,int]) -> str:
         if ship:
             all_hit = True
             for rr, cc in ship.cells:
-                if board.grid[rr][cc] != 3:  # some not hit yet
+                if _get_cell_state(board, rr, cc) != 3:  # some not hit yet
                     all_hit = False
                     break
             if all_hit:
                 ship.alive = False
                 for rr, cc in ship.cells:
-                    board.grid[rr][cc] = 4
+                    _set_cell_state(board, rr, cc, 4)
                 mark_contour(board, ship.cells)
                 board.highlight = ship.cells.copy()
                 return KILL


### PR DESCRIPTION
## Summary
- Normalize battle logic to read and write board cell state through helper functions
- Use cell state index when marking ship contour and evaluating hits/kills

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b05b289e848326a4595833c89a8ec6