### PR TITLE
Align tests with list-based board cells

### DIFF
--- a/logic/battle_test.py
+++ b/logic/battle_test.py
@@ -1,14 +1,26 @@
 from __future__ import annotations
-from typing import Dict, Tuple, List
+from typing import Dict, Tuple, List, Union
 
 from models import Board
 from .battle import apply_shot, mark_contour, MISS, HIT, KILL, REPEAT
 
 
+def _get_cell_state(cell: Union[int, List[int], Tuple[int, str]]) -> int:
+    return cell[0] if isinstance(cell, (list, tuple)) else cell
+
+
+def _set_cell_state(grid: List[List[Union[int, List[int]]]], r: int, c: int, value: int) -> None:
+    cell = grid[r][c]
+    if isinstance(cell, list):
+        cell[0] = value
+    else:
+        grid[r][c] = value
+
+
 def apply_shot_multi(
     coord: Tuple[int, int],
     boards: Dict[str, Board],
-    history: List[List[int]],
+    history: List[List[Union[int, List[int]]]],
 ) -> Dict[str, str]:
     """Apply a shot to multiple opponent boards and update global history.
 
@@ -46,19 +58,19 @@ def apply_shot_multi(
             for b in boards.values():
                 mark_contour(b, cells)
             for rr, cc in cells:
-                history[rr][cc] = 4
+                _set_cell_state(history, rr, cc, 4)
             for rr, cc in cells:
                 for dr in (-1, 0, 1):
                     for dc in (-1, 0, 1):
                         nr, nc = rr + dr, cc + dc
                         if 0 <= nr < 10 and 0 <= nc < 10:
-                            if history[nr][nc] == 0:
-                                history[nr][nc] = 5
-        history[r][c] = 4
+                            if _get_cell_state(history[nr][nc]) == 0:
+                                _set_cell_state(history, nr, nc, 5)
+        _set_cell_state(history, r, c, 4)
     elif any(res == HIT for res in results.values()):
-        history[r][c] = 3
+        _set_cell_state(history, r, c, 3)
     elif all(res == MISS for res in results.values()):
-        if history[r][c] == 0:
-            history[r][c] = 2
+        if _get_cell_state(history[r][c]) == 0:
+            _set_cell_state(history, r, c, 2)
 
     return results

--- a/tests/test_battle.py
+++ b/tests/test_battle.py
@@ -1,35 +1,39 @@
 from models import Board, Ship
 from logic.battle import apply_shot, MISS, HIT, KILL, REPEAT
+from tests.utils import _new_grid, _state
 
 
 def test_apply_shot_miss_and_repeat():
     board = Board()
+    board.grid = _new_grid()
     assert apply_shot(board, (0, 0)) == MISS
-    assert board.grid[0][0] == 2
+    assert _state(board.grid[0][0]) == 2
     assert apply_shot(board, (0, 0)) == REPEAT
 
 
 def test_apply_shot_kill_and_repeat():
     board = Board()
+    board.grid = _new_grid()
     ship = Ship(cells=[(0, 0)])
     board.ships.append(ship)
-    board.grid[0][0] = 1
+    board.grid[0][0] = [1, 'A']
     board.alive_cells = 1
     assert apply_shot(board, (0, 0)) == KILL
-    assert board.grid[0][0] == 4
+    assert _state(board.grid[0][0]) == 4
     assert board.alive_cells == 0
     assert apply_shot(board, (0, 0)) == REPEAT
 
 
 def test_apply_shot_highlight():
     board = Board()
+    board.grid = _new_grid()
     # miss highlight
     assert apply_shot(board, (0, 0)) == MISS
     assert board.highlight == [(0, 0)]
     # hit/kill highlight
     ship = Ship(cells=[(1, 1)])
     board.ships.append(ship)
-    board.grid[1][1] = 1
+    board.grid[1][1] = [1, 'A']
     board.alive_cells = 1
     assert apply_shot(board, (1, 1)) == KILL
     assert board.highlight == [(1, 1)]
@@ -37,12 +41,13 @@ def test_apply_shot_highlight():
 
 def test_apply_shot_kill_marks_contour():
     board = Board()
+    board.grid = _new_grid()
     ship = Ship(cells=[(1, 1), (1, 2)])
     board.ships.append(ship)
-    board.grid[1][1] = 1
-    board.grid[1][2] = 1
+    board.grid[1][1] = [1, 'A']
+    board.grid[1][2] = [1, 'A']
     board.alive_cells = 2
     assert apply_shot(board, (1, 1)) == HIT
     assert apply_shot(board, (1, 2)) == KILL
-    assert board.grid[0][0] == 5
-    assert board.grid[2][3] == 5
+    assert _state(board.grid[0][0]) == 5
+    assert _state(board.grid[2][3]) == 5

--- a/tests/test_placement.py
+++ b/tests/test_placement.py
@@ -1,6 +1,7 @@
 import random
 from models import Board
 from logic.placement import place_ship, random_board
+from tests.utils import _state
 
 
 def test_vertical_start_row_respects_ship_size(monkeypatch):
@@ -21,5 +22,5 @@ def test_vertical_start_row_respects_ship_size(monkeypatch):
 
 def test_random_board_ship_count():
     board = random_board()
-    total = sum(cell == 1 for row in board.grid for cell in row)
+    total = sum(_state(cell) == 1 for row in board.grid for cell in row)
     assert total == 20

--- a/tests/test_render.py
+++ b/tests/test_render.py
@@ -1,13 +1,15 @@
 from logic.render import render_board_own, render_board_enemy, PLAYER_COLORS
 from logic.battle import apply_shot, KILL
 from models import Board, Ship
+from tests.utils import _new_grid, _state
 
 
 def test_render_last_move_symbols():
     b = Board()
+    b.grid = _new_grid()
 
     # miss highlight
-    b.grid[0][0] = (2, 'A')
+    b.grid[0][0] = [2, 'A']
     b.highlight = [(0, 0)]
     own = render_board_own(b)
     assert "border:1px solid red" in own
@@ -16,7 +18,7 @@ def test_render_last_move_symbols():
     assert "border:1px solid red" not in own and 'x' in own
 
     # hit highlight
-    b.grid[1][1] = (3, 'B')
+    b.grid[1][1] = [3, 'B']
     b.highlight = [(1, 1)]
     enemy = render_board_enemy(b)
     assert "border:1px solid red" in enemy and PLAYER_COLORS['B'] in enemy
@@ -25,8 +27,8 @@ def test_render_last_move_symbols():
     assert "border:1px solid red" not in enemy and PLAYER_COLORS['B'] in enemy
 
     # kill highlight
-    b.grid[2][2] = (4, 'B')
-    b.grid[2][3] = (5, 'B')
+    b.grid[2][2] = [4, 'B']
+    b.grid[2][3] = [5, 'B']
     b.highlight = [(2, 3)]
     enemy = render_board_enemy(b)
     assert enemy.count(PLAYER_COLORS['B']) >= 2
@@ -38,9 +40,10 @@ def test_render_last_move_symbols():
 
 def test_apply_shot_marks_contour():
     b = Board()
+    b.grid = _new_grid()
     ship = Ship(cells=[(5, 5)])
     b.ships = [ship]
-    b.grid[5][5] = 1
+    b.grid[5][5] = [1, 'A']
     b.alive_cells = 1
 
     res = apply_shot(b, (5, 5))
@@ -52,4 +55,4 @@ def test_apply_shot_marks_contour():
             if dr == 0 and dc == 0:
                 continue
             if 0 <= nr < 10 and 0 <= nc < 10:
-                assert b.grid[nr][nc] == 5
+                assert _state(b.grid[nr][nc]) == 5

--- a/tests/test_router_message_order.py
+++ b/tests/test_router_message_order.py
@@ -6,6 +6,7 @@ from unittest.mock import AsyncMock
 from handlers import router
 from logic import placement, parser
 import storage
+from tests.utils import _state
 
 
 class DummyBot:
@@ -31,7 +32,7 @@ def _find_empty_cells(board1, board2):
     cells = []
     for r in range(10):
         for c in range(10):
-            if board1.grid[r][c] == 0 and board2.grid[r][c] == 0:
+            if _state(board1.grid[r][c]) == 0 and _state(board2.grid[r][c]) == 0:
                 cells.append((r, c))
                 if len(cells) == 2:
                     return cells

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,0 +1,6 @@
+def _new_grid(size=10):
+    return [[[0, None] for _ in range(size)] for _ in range(size)]
+
+
+def _state(cell):
+    return cell[0] if isinstance(cell, (list, tuple)) else cell


### PR DESCRIPTION
## Summary
- add helpers for creating grids and reading cell state in tests
- update tests to use list-based board cells and histories
- allow apply_shot_multi to work with list-based history grids

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b06f2761588326a098a7a5e2a4cc67