### PR TITLE
Ensure history grids handle structured cells

### DIFF
--- a/game_board15/battle.py
+++ b/game_board15/battle.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 from typing import Tuple, Dict, List
 
 from .models import Board15, Ship
+from .utils import _get_cell_state, _set_cell_state
 
 MISS, HIT, KILL, REPEAT = 'miss', 'hit', 'kill', 'repeat'
 
@@ -67,15 +68,15 @@ def update_history(
                 for cc in range(15):
                     val = board.grid[rr][cc]
                     if val == 4:
-                        history[rr][cc] = 4
+                        _set_cell_state(history, rr, cc, 4)
                     elif val == 5:
                         # Mark contour cells as shot-through for everyone without
                         # overwriting prior shot information.
-                        if history[rr][cc] == 0:
-                            history[rr][cc] = 5
-        history[r][c] = 4
+                        if _get_cell_state(history[rr][cc]) == 0:
+                            _set_cell_state(history, rr, cc, 5)
+        _set_cell_state(history, r, c, 4)
     elif any(res == HIT for res in results.values()):
-        history[r][c] = 3
+        _set_cell_state(history, r, c, 3)
     elif all(res == MISS for res in results.values()):
-        if history[r][c] == 0:
-            history[r][c] = 2
+        if _get_cell_state(history[r][c]) == 0:
+            _set_cell_state(history, r, c, 2)

--- a/game_board15/handlers.py
+++ b/game_board15/handlers.py
@@ -20,7 +20,7 @@ from logic.phrases import (
     SELF_KILL,
     SELF_MISS,
 )
-from .utils import _phrase_or_joke
+from .utils import _phrase_or_joke, _get_cell_state
 import random
 import asyncio
 import logging
@@ -61,7 +61,7 @@ async def board15(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
         player.name = name
         storage.save_match(match)
     state = Board15State(chat_id=update.effective_chat.id)
-    merged = [row[:] for row in match.history]
+    merged = [[_get_cell_state(cell) for cell in row] for row in match.history]
     own_grid = match.boards[player_key].grid
     for r in range(15):
         for c in range(15):
@@ -165,7 +165,7 @@ async def _auto_play_bots(
         for pt in coords:
             r, c = pt
             if (
-                match.history[r][c] == 0
+                _get_cell_state(match.history[r][c]) == 0
                 and match.boards[current].grid[r][c] != 1
             ):
                 coord = pt
@@ -285,7 +285,7 @@ async def board15_test(update: Update, context: ContextTypes.DEFAULT_TYPE) -> No
         match.boards[key] = board
     storage.save_match(match)
     state = Board15State(chat_id=update.effective_chat.id)
-    merged = [row[:] for row in match.history]
+    merged = [[_get_cell_state(cell) for cell in row] for row in match.history]
     own_grid = match.boards['A'].grid
     for r in range(15):
         for c in range(15):

--- a/game_board15/utils.py
+++ b/game_board15/utils.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
 import random
+from typing import List, Union, Tuple
+
 from logic.phrases import random_phrase, random_joke
 
 
@@ -15,4 +17,18 @@ def _phrase_or_joke(match, player_key: str, phrases: list[str]) -> str:
     return f"{random_phrase(phrases)} "
 
 
-__all__ = ["_phrase_or_joke"]
+def _get_cell_state(cell: Union[int, List[int], Tuple[int, str]]) -> int:
+    """Return numeric state from history cell which may be a list or int."""
+    return cell[0] if isinstance(cell, (list, tuple)) else cell
+
+
+def _set_cell_state(grid: List[List[Union[int, List[int]]]], r: int, c: int, value: int) -> None:
+    """Set numeric state on history cell preserving list structure."""
+    cell = grid[r][c]
+    if isinstance(cell, list):
+        cell[0] = value
+    else:
+        grid[r][c] = value
+
+
+__all__ = ["_phrase_or_joke", "_get_cell_state", "_set_cell_state"]

--- a/tests/test_board15_history.py
+++ b/tests/test_board15_history.py
@@ -6,10 +6,11 @@ from unittest.mock import AsyncMock
 from game_board15 import router
 from game_board15.battle import apply_shot, update_history, KILL
 from game_board15.models import Board15, Ship
+from tests.utils import _new_grid, _state
 
 
 def test_update_history_records_kill_and_contour():
-    history = [[0] * 15 for _ in range(15)]
+    history = _new_grid(15)
     boards = {'B': Board15()}
     ship = Ship(cells=[(1, 1)])
     boards['B'].ships = [ship]
@@ -17,8 +18,8 @@ def test_update_history_records_kill_and_contour():
     res = apply_shot(boards['B'], (1, 1))
     assert res == KILL
     update_history(history, boards, (1, 1), {'B': res})
-    assert history[1][1] == 4
-    assert history[0][0] == 5
+    assert _state(history[1][1]) == 4
+    assert _state(history[0][0]) == 5
 
 
 def test_send_state_uses_history(monkeypatch):
@@ -26,11 +27,11 @@ def test_send_state_uses_history(monkeypatch):
         match = SimpleNamespace(
             players={'A': SimpleNamespace(chat_id=1)},
             boards={'A': Board15()},
-            history=[[0] * 15 for _ in range(15)],
+            history=_new_grid(15),
             messages={'A': {}},
         )
         match.boards['A'].grid[2][2] = 1
-        match.history[0][0] = 2
+        match.history[0][0][0] = 2
 
         captured = {}
 
@@ -70,7 +71,7 @@ def test_kill_contour_visible_to_all_players(monkeypatch):
                 'C': SimpleNamespace(chat_id=3),
             },
             boards={'A': Board15(), 'B': Board15(), 'C': Board15()},
-            history=[[0] * 15 for _ in range(15)],
+            history=_new_grid(15),
             messages={'A': {}, 'B': {}, 'C': {}},
         )
         ship = Ship(cells=[(1, 1)])
@@ -120,7 +121,7 @@ def test_render_board_shows_cumulative_history(monkeypatch):
         match = SimpleNamespace(
             players={'A': SimpleNamespace(chat_id=1)},
             boards={'A': Board15()},
-            history=[[0] * 15 for _ in range(15)],
+            history=_new_grid(15),
             messages={'A': {}},
         )
         ship = Ship(cells=[(1, 1)])

--- a/tests/test_board15_invite.py
+++ b/tests/test_board15_invite.py
@@ -15,6 +15,7 @@ sys.modules.setdefault('PIL', pil)
 from handlers.commands import start
 from game_board15 import handlers as h
 from game_board15 import storage as storage15
+from tests.utils import _new_grid
 
 
 def test_board15_invite_flow(monkeypatch):
@@ -24,7 +25,7 @@ def test_board15_invite_flow(monkeypatch):
             players={'A': SimpleNamespace(user_id=1, chat_id=1, name='Alice')},
             boards={'A': SimpleNamespace(grid=[[0] * 15 for _ in range(15)], highlight=[])},
             messages={},
-            history=[[0] * 15 for _ in range(15)],
+            history=_new_grid(15),
         )
         monkeypatch.setattr(storage15, 'create_match', lambda uid, cid, name=None: match)
         monkeypatch.setattr(storage15, 'save_match', lambda m: None)

--- a/tests/test_board15_keyboard.py
+++ b/tests/test_board15_keyboard.py
@@ -2,6 +2,7 @@ import asyncio
 from io import BytesIO
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, call
+from tests.utils import _new_grid
 
 from game_board15 import router
 from game_board15.models import Board15
@@ -12,7 +13,7 @@ def test_send_state_sends_board_without_keyboard(monkeypatch):
         match = SimpleNamespace(
             players={'A': SimpleNamespace(chat_id=1)},
             boards={'A': Board15()},
-            history=[[0] * 15 for _ in range(15)],
+            history=_new_grid(15),
             messages={'A': {'player': 20}},
         )
 
@@ -52,7 +53,7 @@ def test_send_state_edits_existing_messages(monkeypatch):
         match = SimpleNamespace(
             players={'A': SimpleNamespace(chat_id=1)},
             boards={'A': Board15()},
-            history=[[0] * 15 for _ in range(15)],
+            history=_new_grid(15),
             messages={'A': {'board': 10, 'player': 20, 'text': 'old', 'text_id': 30, 'text_history': [30]}},
         )
 
@@ -89,7 +90,7 @@ def test_send_state_recreates_messages_on_edit_failure(monkeypatch):
         match = SimpleNamespace(
             players={'A': SimpleNamespace(chat_id=1)},
             boards={'A': Board15()},
-            history=[[0] * 15 for _ in range(15)],
+            history=_new_grid(15),
             messages={'A': {'board': 10, 'player': 20, 'text': 'old', 'text_id': 30, 'text_history': [30]}},
         )
 
@@ -138,7 +139,7 @@ def test_send_state_recreates_player_board_on_edit_failure(monkeypatch):
         match = SimpleNamespace(
             players={'A': SimpleNamespace(chat_id=1)},
             boards={'A': Board15()},
-            history=[[0] * 15 for _ in range(15)],
+            history=_new_grid(15),
             messages={'A': {'board': 10, 'player': 20, 'text': 'old', 'text_id': 30, 'text_history': [30]}},
         )
 
@@ -187,7 +188,7 @@ def test_send_state_avoids_duplicate_text(monkeypatch):
         match = SimpleNamespace(
             players={'A': SimpleNamespace(chat_id=1)},
             boards={'A': Board15()},
-            history=[[0] * 15 for _ in range(15)],
+            history=_new_grid(15),
             messages={'A': {}},
         )
 

--- a/tests/test_board15_router.py
+++ b/tests/test_board15_router.py
@@ -4,6 +4,7 @@ import types
 from io import BytesIO
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, Mock, call, ANY
+from tests.utils import _new_grid
 
 # Provide minimal Pillow stub to satisfy imports in game_board15.renderer
 pil = types.ModuleType('PIL')
@@ -30,7 +31,7 @@ def test_router_auto_sends_boards(monkeypatch):
             },
             turn='A',
             messages={},
-            history=[[0] * 15 for _ in range(15)],
+            history=_new_grid(15),
         )
 
         def fake_save_board(m, key, board=None):
@@ -96,7 +97,7 @@ def test_router_notifies_other_players_on_hit(monkeypatch):
             turn='A',
             shots={'A': {'move_count': 0, 'joke_start': 10}, 'B': {}, 'C': {}},
             messages={'A': {}, 'B': {}, 'C': {}},
-            history=[[0] * 15 for _ in range(15)],
+            history=_new_grid(15),
         )
 
         monkeypatch.setattr(storage, 'find_match_by_user', lambda uid, chat_id=None: match)
@@ -144,7 +145,7 @@ def test_router_notifies_next_player_on_miss(monkeypatch):
             turn='A',
             shots={'A': {'move_count': 0, 'joke_start': 10}, 'B': {}, 'C': {}},
             messages={'A': {}, 'B': {}, 'C': {}},
-            history=[[0] * 15 for _ in range(15)],
+            history=_new_grid(15),
         )
 
         monkeypatch.setattr(storage, 'find_match_by_user', lambda uid, chat_id=None: match)
@@ -190,7 +191,7 @@ def test_router_move_sends_player_board(monkeypatch):
             turn='A',
             shots={'A': {}, 'B': {}},
             messages={'A': {'board': 1}, 'B': {'board': 3}},
-            history=[[0] * 15 for _ in range(15)],
+            history=_new_grid(15),
         )
 
         monkeypatch.setattr(storage, 'find_match_by_user', lambda uid, chat_id=None: match)
@@ -250,7 +251,7 @@ def test_router_uses_player_names(monkeypatch):
             turn='A',
             shots={'A': {}, 'B': {}, 'C': {}},
             messages={'A': {}},
-            history=[[0] * 15 for _ in range(15)],
+            history=_new_grid(15),
         )
 
         monkeypatch.setattr(storage, 'find_match_by_user', lambda uid, chat_id=None: match)
@@ -292,7 +293,7 @@ def test_router_repeat_shot(monkeypatch):
             shots={'A': {'move_count': 0, 'joke_start': 10},
                    'B': {'move_count': 0, 'joke_start': 10}},
             messages={},
-            history=[[0] * 15 for _ in range(15)],
+            history=_new_grid(15),
         )
 
         monkeypatch.setattr(storage, 'find_match_by_user', lambda uid, chat_id=None: match)
@@ -334,7 +335,7 @@ def test_router_skips_eliminated_players(monkeypatch):
             turn='A',
             shots={'A': {}, 'B': {}, 'C': {}},
             messages={'A': {}},
-            history=[[0] * 15 for _ in range(15)],
+            history=_new_grid(15),
         )
         match.boards['B'].alive_cells = 0
 

--- a/tests/test_board15_telegram_updates.py
+++ b/tests/test_board15_telegram_updates.py
@@ -13,6 +13,7 @@ pil.ImageFont = types.SimpleNamespace()
 sys.modules.setdefault("PIL", pil)
 
 from game_board15 import router, storage, battle
+from tests.utils import _new_grid
 
 
 def test_board_updates_accumulate(tmp_path, monkeypatch):
@@ -21,6 +22,7 @@ def test_board_updates_accumulate(tmp_path, monkeypatch):
     match = storage.create_match(1, 1, "A")
     match = storage.join_match(match.match_id, 2, 2, "B")
     match.status = "playing"
+    match.history = _new_grid(15)
     storage.save_match(match)
 
     boards = []

--- a/tests/test_board15_test_autoplay.py
+++ b/tests/test_board15_test_autoplay.py
@@ -6,6 +6,7 @@ import pytest
 
 from game_board15 import handlers, storage, router
 from game_board15.models import Board15, Match15, Player
+from tests.utils import _new_grid
 
 
 def test_board15_test_autoplay(monkeypatch):
@@ -52,9 +53,12 @@ def test_auto_play_bots_skips_closed(monkeypatch):
         match.players['B'] = Player(user_id=0, chat_id=0, name='B')
         match.status = 'playing'
         match.turn = 'B'
-        match.history[0][0] = 2
-        match.history[0][1] = 3
-        match.history[0][2] = 5
+        match.history = _new_grid(15)
+        match.history = _new_grid(15)
+        match.history = _new_grid(15)
+        match.history[0][0][0] = 2
+        match.history[0][1][0] = 3
+        match.history[0][2][0] = 5
 
         recorded = {}
 
@@ -148,6 +152,7 @@ def test_auto_play_bots_refreshes_match(monkeypatch):
         match.players['B'] = Player(user_id=0, chat_id=0, name='B')
         match.status = 'playing'
         match.turn = 'B'
+        match.history = _new_grid(15)
 
         recorded: list[tuple[int, int]] = []
         import copy
@@ -158,7 +163,7 @@ def test_auto_play_bots_refreshes_match(monkeypatch):
             nonlocal current, calls
             calls += 1
             if calls == 2:
-                current.history[0][1] = 2
+                current.history[0][1][0] = 2
                 current.turn = 'B'
             return copy.deepcopy(current)
 

--- a/tests/test_empty_buffer.py
+++ b/tests/test_empty_buffer.py
@@ -6,6 +6,7 @@ from unittest.mock import AsyncMock
 
 from game_board15 import router
 from game_board15.models import Board15
+from tests.utils import _new_grid
 
 
 def test_empty_buffer_skips_send(monkeypatch, caplog):
@@ -13,7 +14,7 @@ def test_empty_buffer_skips_send(monkeypatch, caplog):
         match = SimpleNamespace(
             players={"A": SimpleNamespace(chat_id=1)},
             boards={"A": Board15()},
-            history=[[0] * 15 for _ in range(15)],
+            history=_new_grid(15),
             messages={"A": {}},
         )
 


### PR DESCRIPTION
## Summary
- allow history grids to store cell lists by adding helpers and updating battle logic
- normalize history usage in router and handlers
- update tests to construct history with `_new_grid`

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b074704f288326b752dff268813ee6