### PR TITLE
Add configurable delay before result messages

### DIFF
--- a/handlers/router.py
+++ b/handlers/router.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 import random
 import os
+import asyncio
 from telegram import Update, ReplyKeyboardMarkup
 from telegram.ext import ContextTypes
 
@@ -24,6 +25,11 @@ from logic.phrases import (
     random_phrase,
     random_joke,
 )
+
+
+# Delay after sending the board and before sending/editing the result text.
+# Can be tuned with the ``STATE_DELAY`` environment variable.
+STATE_DELAY = float(os.getenv("STATE_DELAY", "0.2"))
 
 
 async def _send_state(
@@ -58,6 +64,8 @@ async def _send_state(
         reply_markup=kb,
     )
     msgs["board"] = board_msg.message_id
+
+    await asyncio.sleep(STATE_DELAY)
 
     # update text message with result
     if text_id:
@@ -133,6 +141,8 @@ async def _send_state_board_test(
         reply_markup=kb,
     )
     msgs["board"] = board_msg.message_id
+
+    await asyncio.sleep(STATE_DELAY)
 
     if text_id:
         try:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,3 +1,8 @@
+import os
 import sys
 from pathlib import Path
+
+# Disable artificial delays during tests for faster execution
+os.environ.setdefault("STATE_DELAY", "0")
+
 sys.path.append(str(Path(__file__).resolve().parents[1]))


### PR DESCRIPTION
## Summary
- introduce configurable delay between board updates and result texts
- disable delay during tests for faster execution

## Testing
- `pytest tests/test_router_message_order.py -q`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b09b999b448326bec4a078b7e65d34