### PR TITLE
Track board and text message history

### DIFF
--- a/game_board15/handlers.py
+++ b/game_board15/handlers.py
@@ -77,6 +77,9 @@ async def board15(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
     context.bot_data.setdefault(STATE_KEY, {})[update.effective_chat.id] = state
     match.messages[player_key] = {
         'board': msg.message_id,
+        'board_history': [],
+        'text_history': [],
+        'history_active': False,
     }
     storage.save_match(match)
 
@@ -310,6 +313,9 @@ async def board15_test(update: Update, context: ContextTypes.DEFAULT_TYPE) -> No
     context.bot_data.setdefault(STATE_KEY, {})[update.effective_chat.id] = state
     match.messages['A'] = {
         'board': board_msg_id,
+        'board_history': [],
+        'text_history': [],
+        'history_active': False,
     }
     storage.save_match(match)
     asyncio.create_task(_auto_play_bots(match, context, update.effective_chat.id, human='A'))

--- a/game_board15/models.py
+++ b/game_board15/models.py
@@ -53,7 +53,16 @@ class Match15:
             for k in ("A", "B", "C")
         }
     )
-    messages: Dict[str, Dict[str, int]] = field(default_factory=dict)
+    messages: Dict[str, Dict[str, object]] = field(
+        default_factory=lambda: {
+            k: {
+                "board_history": [],
+                "text_history": [],
+                "history_active": False,
+            }
+            for k in ("A", "B", "C")
+        }
+    )
 
     @staticmethod
     def new(a_user_id: int, a_chat_id: int, a_name: str) -> "Match15":

--- a/models.py
+++ b/models.py
@@ -55,8 +55,16 @@ class Match:
         }
     )
     # stores ids of service messages per player: e.g. last board or keyboard
-    messages: Dict[str, Dict[str, int]] = field(
-        default_factory=lambda: {"A": {}, "B": {}, "C": {}}
+    # also maintains chronological history of all board and text messages
+    messages: Dict[str, Dict[str, object]] = field(
+        default_factory=lambda: {
+            k: {
+                "board_history": [],
+                "text_history": [],
+                "history_active": False,
+            }
+            for k in ("A", "B", "C")
+        }
     )
 
     @staticmethod

--- a/tests/test_board15_keyboard.py
+++ b/tests/test_board15_keyboard.py
@@ -1,219 +1,97 @@
-import asyncio
 from io import BytesIO
+import asyncio
 from types import SimpleNamespace
-from unittest.mock import AsyncMock, call
-from tests.utils import _new_grid
+from unittest.mock import AsyncMock
 
+from tests.utils import _new_grid
 from game_board15 import router
 from game_board15.models import Board15
 
 
-def test_send_state_sends_board_without_keyboard(monkeypatch):
+def test_send_state_records_history(monkeypatch):
     async def run_test():
         match = SimpleNamespace(
-            players={'A': SimpleNamespace(chat_id=1)},
-            boards={'A': Board15()},
+            players={"A": SimpleNamespace(chat_id=1)},
+            boards={"A": Board15()},
             history=_new_grid(15),
-            messages={'A': {'player': 20}},
+            messages={"A": {"history_active": True, "board_history": [], "text_history": []}},
         )
-
-        monkeypatch.setattr(router, 'render_board', lambda state, player_key=None: BytesIO(b'img'))
-        monkeypatch.setattr(router, 'render_player_board', lambda board, player_key=None: BytesIO(b'own'))
-        monkeypatch.setattr(router.storage, 'save_match', lambda m: None)
-
+        monkeypatch.setattr(router, "render_board", lambda state, player_key=None: BytesIO(b"img"))
+        monkeypatch.setattr(router, "render_player_board", lambda board, player_key=None: BytesIO(b"own"))
+        monkeypatch.setattr(router.storage, "save_match", lambda m: None)
         bot = SimpleNamespace(
-            edit_message_media=AsyncMock(),
-            edit_message_text=AsyncMock(),
-            send_photo=AsyncMock(return_value=SimpleNamespace(message_id=50)),
+            send_photo=AsyncMock(side_effect=[
+                SimpleNamespace(message_id=50),
+                SimpleNamespace(message_id=51),
+            ]),
             send_message=AsyncMock(return_value=SimpleNamespace(message_id=60)),
-            delete_message=AsyncMock(),
         )
         context = SimpleNamespace(bot=bot, bot_data={}, chat_data={})
-
-        await router._send_state(context, match, 'A', 'msg')
-
-        bot.edit_message_media.assert_awaited_once()
-        bot.edit_message_text.assert_not_called()
-        bot.send_photo.assert_awaited_once()
-        bot.send_message.assert_awaited_once()
-        call_photo = bot.send_photo.await_args
-        assert call_photo.args[0] == 1
-        assert 'caption' not in call_photo.kwargs
-        assert 'reply_markup' not in call_photo.kwargs
-        assert bot.delete_message.await_count == 0
-        assert match.messages['A']['board'] == 50
-        assert match.messages['A']['text'] == 'msg'
-        assert match.messages['A']['text_id'] == 60
-        assert match.messages['A']['text_history'] == [60]
-
-    asyncio.run(run_test())
-
-def test_send_state_edits_existing_messages(monkeypatch):
-    async def run_test():
-        match = SimpleNamespace(
-            players={'A': SimpleNamespace(chat_id=1)},
-            boards={'A': Board15()},
-            history=_new_grid(15),
-            messages={'A': {'board': 10, 'player': 20, 'text': 'old', 'text_id': 30, 'text_history': [30]}},
-        )
-
-        monkeypatch.setattr(router, 'render_board', lambda state, player_key=None: BytesIO(b'img'))
-        monkeypatch.setattr(router, 'render_player_board', lambda board, player_key=None: BytesIO(b'own'))
-        monkeypatch.setattr(router.storage, 'save_match', lambda m: None)
-
-        bot = SimpleNamespace(
-            edit_message_media=AsyncMock(),
-            edit_message_text=AsyncMock(),
-            send_photo=AsyncMock(),
-            send_message=AsyncMock(),
-            delete_message=AsyncMock(),
-        )
-        context = SimpleNamespace(bot=bot, bot_data={}, chat_data={})
-
-        await router._send_state(context, match, 'A', 'msg')
-
-        assert bot.edit_message_media.await_count == 2
-        bot.edit_message_text.assert_awaited_once()
-        bot.send_photo.assert_not_called()
-        bot.send_message.assert_not_called()
-        bot.delete_message.assert_not_called()
-        assert match.messages['A']['board'] == 10
-        assert match.messages['A']['text'] == 'msg'
-        assert match.messages['A']['text_id'] == 30
-        assert match.messages['A']['text_history'] == [30]
-
-    asyncio.run(run_test())
-
-
-def test_send_state_recreates_messages_on_edit_failure(monkeypatch):
-    async def run_test():
-        match = SimpleNamespace(
-            players={'A': SimpleNamespace(chat_id=1)},
-            boards={'A': Board15()},
-            history=_new_grid(15),
-            messages={'A': {'board': 10, 'player': 20, 'text': 'old', 'text_id': 30, 'text_history': [30]}},
-        )
-
-        board_buf = BytesIO(b'img')
-        player_buf = BytesIO(b'own')
-        monkeypatch.setattr(router, 'render_board', lambda state, player_key=None: board_buf)
-        monkeypatch.setattr(router, 'render_player_board', lambda board, player_key=None: player_buf)
-        monkeypatch.setattr(router.storage, 'save_match', lambda m: None)
-
-        async def edit_media(chat_id, message_id, media):
-            if edit_media.calls == 0:
-                edit_media.calls += 1
-                return
-            edit_media.calls += 1
-            raise Exception()
-
-        edit_media.calls = 0
-
-        bot = SimpleNamespace(
-            edit_message_media=AsyncMock(side_effect=edit_media),
-            edit_message_text=AsyncMock(),
-            send_photo=AsyncMock(return_value=SimpleNamespace(message_id=40)),
-            send_message=AsyncMock(),
-            delete_message=AsyncMock(),
-        )
-        context = SimpleNamespace(bot=bot, bot_data={}, chat_data={})
-
-        await router._send_state(context, match, 'A', 'msg')
-
-        assert bot.edit_message_media.await_count == 2
-        bot.edit_message_text.assert_awaited_once()
-        assert bot.delete_message.await_args_list == [call(1, 10)]
-        bot.send_photo.assert_awaited_once()
-        bot.send_message.assert_not_called()
-        assert board_buf.tell() == 0
-        assert match.messages['A']['board'] == 40
-        assert match.messages['A']['text'] == 'msg'
-        assert match.messages['A']['text_id'] == 30
-        assert match.messages['A']['text_history'] == [30]
-
-    asyncio.run(run_test())
-
-
-def test_send_state_recreates_player_board_on_edit_failure(monkeypatch):
-    async def run_test():
-        match = SimpleNamespace(
-            players={'A': SimpleNamespace(chat_id=1)},
-            boards={'A': Board15()},
-            history=_new_grid(15),
-            messages={'A': {'board': 10, 'player': 20, 'text': 'old', 'text_id': 30, 'text_history': [30]}},
-        )
-
-        board_buf = BytesIO(b'img')
-        player_buf = BytesIO(b'own')
-        monkeypatch.setattr(router, 'render_board', lambda state, player_key=None: board_buf)
-        monkeypatch.setattr(router, 'render_player_board', lambda board, player_key=None: player_buf)
-        monkeypatch.setattr(router.storage, 'save_match', lambda m: None)
-
-        async def edit_media(chat_id, message_id, media):
-            if edit_media.calls == 0:
-                edit_media.calls += 1
-                raise Exception()
-            edit_media.calls += 1
-            return
-
-        edit_media.calls = 0
-
-        bot = SimpleNamespace(
-            edit_message_media=AsyncMock(side_effect=edit_media),
-            edit_message_text=AsyncMock(),
-            send_photo=AsyncMock(return_value=SimpleNamespace(message_id=40)),
-            send_message=AsyncMock(),
-            delete_message=AsyncMock(),
-        )
-        context = SimpleNamespace(bot=bot, bot_data={}, chat_data={})
-
-        await router._send_state(context, match, 'A', 'msg')
-
-        assert bot.edit_message_media.await_count == 2
-        bot.edit_message_text.assert_awaited_once()
-        assert bot.delete_message.await_args_list == [call(1, 20)]
-        bot.send_photo.assert_awaited_once()
-        assert bot.send_photo.await_args.args[1] is player_buf
-        assert player_buf.tell() == 0
-        bot.send_message.assert_not_called()
-        assert match.messages['A']['player'] == 40
-        assert match.messages['A']['board'] == 10
-        assert match.messages['A']['text'] == 'msg'
-        assert match.messages['A']['text_id'] == 30
-        assert match.messages['A']['text_history'] == [30]
-
-
-def test_send_state_avoids_duplicate_text(monkeypatch):
-    async def run_test():
-        match = SimpleNamespace(
-            players={'A': SimpleNamespace(chat_id=1)},
-            boards={'A': Board15()},
-            history=_new_grid(15),
-            messages={'A': {}},
-        )
-
-        board_buf = BytesIO(b'img')
-        player_buf = BytesIO(b'own')
-        monkeypatch.setattr(router, 'render_board', lambda state, player_key=None: board_buf)
-        monkeypatch.setattr(router, 'render_player_board', lambda board, player_key=None: player_buf)
-        monkeypatch.setattr(router.storage, 'save_match', lambda m: None)
-
-        bot = SimpleNamespace(
-            edit_message_media=AsyncMock(),
-            edit_message_text=AsyncMock(),
-            send_photo=AsyncMock(side_effect=[SimpleNamespace(message_id=40), SimpleNamespace(message_id=50)]),
-            send_message=AsyncMock(return_value=SimpleNamespace(message_id=60)),
-            delete_message=AsyncMock(),
-        )
-        context = SimpleNamespace(bot=bot, bot_data={}, chat_data={})
-
-        await router._send_state(context, match, 'A', 'msg')
-        await router._send_state(context, match, 'A', 'msg')
-
+        await router._send_state(context, match, "A", "msg")
+        assert bot.send_photo.await_count == 2
         assert bot.send_message.await_count == 1
-        bot.edit_message_text.assert_not_called()
-        assert match.messages['A']['text'] == 'msg'
-        assert match.messages['A']['text_id'] == 60
-        assert match.messages['A']['text_history'] == [60]
+        assert match.messages["A"]["board"] == 51
+        assert match.messages["A"]["text"] == 60
+        assert match.messages["A"]["board_history"] == [51]
+        assert match.messages["A"]["text_history"] == [60]
+    asyncio.run(run_test())
 
+
+def test_send_state_appends_history(monkeypatch):
+    async def run_test():
+        match = SimpleNamespace(
+            players={"A": SimpleNamespace(chat_id=1)},
+            boards={"A": Board15()},
+            history=_new_grid(15),
+            messages={"A": {"history_active": True, "board_history": [], "text_history": []}},
+        )
+        monkeypatch.setattr(router, "render_board", lambda state, player_key=None: BytesIO(b"img"))
+        monkeypatch.setattr(router, "render_player_board", lambda board, player_key=None: BytesIO(b"own"))
+        monkeypatch.setattr(router.storage, "save_match", lambda m: None)
+        bot = SimpleNamespace(
+            send_photo=AsyncMock(side_effect=[
+                SimpleNamespace(message_id=10),
+                SimpleNamespace(message_id=11),
+                SimpleNamespace(message_id=12),
+                SimpleNamespace(message_id=13),
+            ]),
+            send_message=AsyncMock(side_effect=[
+                SimpleNamespace(message_id=20),
+                SimpleNamespace(message_id=21),
+            ]),
+        )
+        context = SimpleNamespace(bot=bot, bot_data={}, chat_data={})
+        await router._send_state(context, match, "A", "first")
+        await router._send_state(context, match, "A", "second")
+        assert bot.send_photo.await_count == 4
+        assert bot.send_message.await_count == 2
+        assert match.messages["A"]["board"] == 13
+        assert match.messages["A"]["text"] == 21
+        assert match.messages["A"]["board_history"] == [11, 13]
+        assert match.messages["A"]["text_history"] == [20, 21]
+    asyncio.run(run_test())
+
+
+def test_history_not_recorded_when_inactive(monkeypatch):
+    async def run_test():
+        match = SimpleNamespace(
+            players={"A": SimpleNamespace(chat_id=1)},
+            boards={"A": Board15()},
+            history=_new_grid(15),
+            messages={"A": {"history_active": False, "board_history": [], "text_history": []}},
+        )
+        monkeypatch.setattr(router, "render_board", lambda state, player_key=None: BytesIO(b"img"))
+        monkeypatch.setattr(router, "render_player_board", lambda board, player_key=None: BytesIO(b"own"))
+        monkeypatch.setattr(router.storage, "save_match", lambda m: None)
+        bot = SimpleNamespace(
+            send_photo=AsyncMock(side_effect=[
+                SimpleNamespace(message_id=1),
+                SimpleNamespace(message_id=2),
+            ]),
+            send_message=AsyncMock(return_value=SimpleNamespace(message_id=3)),
+        )
+        context = SimpleNamespace(bot=bot, bot_data={}, chat_data={})
+        await router._send_state(context, match, "A", "msg")
+        assert match.messages["A"]["board_history"] == []
+        assert match.messages["A"]["text_history"] == []
     asyncio.run(run_test())

--- a/tests/test_board15_message_order.py
+++ b/tests/test_board15_message_order.py
@@ -94,8 +94,8 @@ def test_board15_message_order(tmp_path, monkeypatch):
 
     asyncio.run(play_moves())
 
-    expected = ['photo', 'photo', 'text_send', 'photo', 'photo', 'text_edit', 'photo', 'photo', 'text_edit']
-    extra = ['photo', 'photo', 'text_send', 'photo', 'photo', 'text_edit', 'photo', 'photo', 'text_edit', 'photo', 'photo', 'text_edit']
+    expected = ['photo', 'photo', 'text_send', 'photo', 'photo', 'text_send', 'photo', 'photo', 'text_send']
+    extra = ['photo', 'photo', 'text_send', 'photo', 'photo', 'text_send', 'photo', 'photo', 'text_send', 'photo', 'photo', 'text_send']
     assert bot.logs[1] == expected
     assert bot.logs[2] == expected
     assert bot.logs[3] == extra

--- a/tests/test_board15_telegram_updates.py
+++ b/tests/test_board15_telegram_updates.py
@@ -73,4 +73,4 @@ def test_board_updates_accumulate(tmp_path, monkeypatch):
     assert boards[2][1][1] == 2
 
     assert bot.send_photo.await_count > 0
-    assert bot.edit_message_media.await_count > 0
+    assert bot.edit_message_media.await_count == 0

--- a/tests/test_three_player_match.py
+++ b/tests/test_three_player_match.py
@@ -58,16 +58,10 @@ def test_three_player_match(monkeypatch):
             assert buf.getbuffer().nbytes > 0
             return SimpleNamespace(message_id=3)
 
-        async def assert_edit_media(*args, **kwargs):
-            media = kwargs.get("media") or (len(args) > 2 and args[2])
-            buf = media.media
-            assert buf.getbuffer().nbytes > 0
-            return SimpleNamespace()
-
         bot = SimpleNamespace(
             send_message=AsyncMock(return_value=SimpleNamespace(message_id=2)),
             send_photo=AsyncMock(side_effect=assert_send_photo),
-            edit_message_media=AsyncMock(side_effect=assert_edit_media),
+            edit_message_media=AsyncMock(),
             edit_message_text=AsyncMock(return_value=None),
             delete_message=AsyncMock(return_value=None),
         )
@@ -103,6 +97,6 @@ def test_three_player_match(monkeypatch):
 
         # ensure board images were produced for each turn
         assert update.message.reply_photo.call_count == 1
-        assert bot.edit_message_media.call_count >= 3
+        assert bot.send_photo.call_count >= 3
 
     asyncio.run(run())


### PR DESCRIPTION
## Summary
- Extend match message model with board and text histories
- Always send new board and result messages and record their IDs
- Start history tracking after first human move

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b13c01528c8326aabd7f43ace891db