### PR TITLE
Simplify move summary in board test router

### DIFF
--- a/handlers/router.py
+++ b/handlers/router.py
@@ -458,10 +458,10 @@ async def router_text_board_test(update: Update, context: ContextTypes.DEFAULT_T
     next_phrase_self = (
         'Ваш ход.' if next_player == player_key else f"Ход {next_label}."
     )
-    self_lines = [
-        f"Ваш ход: {coord_str} — {body}" for body in self_msgs.values()
-    ]
-    if not self_lines:
+    summary = random.choice(list(self_msgs.values())) if self_msgs else ''
+    if summary:
+        self_lines = [f"Ваш ход: {coord_str} — {summary}"]
+    else:
         self_lines = [f"Ваш ход: {coord_str}"]
     self_lines.append(next_phrase_self)
     await _send_state_board_test(


### PR DESCRIPTION
## Summary
- Collapse multiple move messages into a single summary line for the current player

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b176677f588326b631af5f77cfdf49