### PR TITLE
Remove per-player board image from Board15 updates

### DIFF
--- a/tests/test_board15_history.py
+++ b/tests/test_board15_history.py
@@ -40,7 +40,6 @@ def test_send_state_uses_history(monkeypatch):
             return BytesIO(b'img')
 
         monkeypatch.setattr(router, 'render_board', fake_render_board)
-        monkeypatch.setattr(router, 'render_player_board', lambda board, player_key=None: BytesIO(b'own'))
         monkeypatch.setattr(router.storage, 'save_match', lambda m: None)
 
         context = SimpleNamespace(
@@ -90,9 +89,6 @@ def test_kill_contour_visible_to_all_players(monkeypatch):
             return BytesIO(b'img')
 
         monkeypatch.setattr(router, 'render_board', fake_render_board)
-        monkeypatch.setattr(
-            router, 'render_player_board', lambda board, player_key=None: BytesIO(b'own')
-        )
         monkeypatch.setattr(router.storage, 'save_match', lambda m: None)
 
         context = SimpleNamespace(
@@ -135,9 +131,6 @@ def test_render_board_shows_cumulative_history(monkeypatch):
             return BytesIO(b'img')
 
         monkeypatch.setattr(router, 'render_board', fake_render_board)
-        monkeypatch.setattr(
-            router, 'render_player_board', lambda board, player_key=None: BytesIO(b'own')
-        )
         monkeypatch.setattr(router.storage, 'save_match', lambda m: None)
 
         context = SimpleNamespace(

--- a/tests/test_board15_keyboard.py
+++ b/tests/test_board15_keyboard.py
@@ -17,18 +17,14 @@ def test_send_state_records_history(monkeypatch):
             messages={"A": {"history_active": True, "board_history": [], "text_history": []}},
         )
         monkeypatch.setattr(router, "render_board", lambda state, player_key=None: BytesIO(b"img"))
-        monkeypatch.setattr(router, "render_player_board", lambda board, player_key=None: BytesIO(b"own"))
         monkeypatch.setattr(router.storage, "save_match", lambda m: None)
         bot = SimpleNamespace(
-            send_photo=AsyncMock(side_effect=[
-                SimpleNamespace(message_id=50),
-                SimpleNamespace(message_id=51),
-            ]),
+            send_photo=AsyncMock(side_effect=[SimpleNamespace(message_id=51)]),
             send_message=AsyncMock(return_value=SimpleNamespace(message_id=60)),
         )
         context = SimpleNamespace(bot=bot, bot_data={}, chat_data={})
         await router._send_state(context, match, "A", "msg")
-        assert bot.send_photo.await_count == 2
+        assert bot.send_photo.await_count == 1
         assert bot.send_message.await_count == 1
         assert match.messages["A"]["board"] == 51
         assert match.messages["A"]["text"] == 60
@@ -46,13 +42,10 @@ def test_send_state_appends_history(monkeypatch):
             messages={"A": {"history_active": True, "board_history": [], "text_history": []}},
         )
         monkeypatch.setattr(router, "render_board", lambda state, player_key=None: BytesIO(b"img"))
-        monkeypatch.setattr(router, "render_player_board", lambda board, player_key=None: BytesIO(b"own"))
         monkeypatch.setattr(router.storage, "save_match", lambda m: None)
         bot = SimpleNamespace(
             send_photo=AsyncMock(side_effect=[
-                SimpleNamespace(message_id=10),
                 SimpleNamespace(message_id=11),
-                SimpleNamespace(message_id=12),
                 SimpleNamespace(message_id=13),
             ]),
             send_message=AsyncMock(side_effect=[
@@ -63,7 +56,7 @@ def test_send_state_appends_history(monkeypatch):
         context = SimpleNamespace(bot=bot, bot_data={}, chat_data={})
         await router._send_state(context, match, "A", "first")
         await router._send_state(context, match, "A", "second")
-        assert bot.send_photo.await_count == 4
+        assert bot.send_photo.await_count == 2
         assert bot.send_message.await_count == 2
         assert match.messages["A"]["board"] == 13
         assert match.messages["A"]["text"] == 21
@@ -81,13 +74,9 @@ def test_history_not_recorded_when_inactive(monkeypatch):
             messages={"A": {"history_active": False, "board_history": [], "text_history": []}},
         )
         monkeypatch.setattr(router, "render_board", lambda state, player_key=None: BytesIO(b"img"))
-        monkeypatch.setattr(router, "render_player_board", lambda board, player_key=None: BytesIO(b"own"))
         monkeypatch.setattr(router.storage, "save_match", lambda m: None)
         bot = SimpleNamespace(
-            send_photo=AsyncMock(side_effect=[
-                SimpleNamespace(message_id=1),
-                SimpleNamespace(message_id=2),
-            ]),
+            send_photo=AsyncMock(side_effect=[SimpleNamespace(message_id=1)]),
             send_message=AsyncMock(return_value=SimpleNamespace(message_id=3)),
         )
         context = SimpleNamespace(bot=bot, bot_data={}, chat_data={})

--- a/tests/test_board15_message_order.py
+++ b/tests/test_board15_message_order.py
@@ -72,7 +72,6 @@ def test_board15_message_order(tmp_path, monkeypatch):
     coord2 = parser.format_coord((r2, c2))
 
     monkeypatch.setattr(router, 'render_board', lambda state, player_key=None: BytesIO(b'board'))
-    monkeypatch.setattr(router, 'render_player_board', lambda board, player_key=None: BytesIO(b'own'))
 
     bot = DummyBot()
     context = SimpleNamespace(bot=bot, bot_data={})
@@ -94,8 +93,8 @@ def test_board15_message_order(tmp_path, monkeypatch):
 
     asyncio.run(play_moves())
 
-    expected = ['photo', 'photo', 'text_send', 'photo', 'photo', 'text_send', 'photo', 'photo', 'text_send']
-    extra = ['photo', 'photo', 'text_send', 'photo', 'photo', 'text_send', 'photo', 'photo', 'text_send', 'photo', 'photo', 'text_send']
+    expected = ['photo', 'text_send', 'photo', 'text_send', 'photo', 'text_send']
+    extra = ['photo', 'text_send', 'photo', 'text_send', 'photo', 'text_send', 'photo', 'text_send']
     assert bot.logs[1] == expected
     assert bot.logs[2] == expected
     assert bot.logs[3] == extra

--- a/tests/test_board15_telegram_updates.py
+++ b/tests/test_board15_telegram_updates.py
@@ -32,7 +32,6 @@ def test_board_updates_accumulate(tmp_path, monkeypatch):
         return BytesIO(b"board")
 
     monkeypatch.setattr(router, "render_board", fake_render_board)
-    monkeypatch.setattr(router, "render_player_board", lambda board, player_key=None: BytesIO(b"own"))
 
     class DummyBot:
         def __init__(self):

--- a/tests/test_board15_test_manual.py
+++ b/tests/test_board15_test_manual.py
@@ -40,7 +40,6 @@ def test_board15_test_manual(monkeypatch):
         # renderers
         monkeypatch.setattr(handlers, "render_board", lambda *a, **k: BytesIO())
         monkeypatch.setattr(router, "render_board", lambda *a, **k: BytesIO())
-        monkeypatch.setattr(router, "render_player_board", lambda *a, **k: BytesIO())
 
         # capture background tasks
         tasks = []

--- a/tests/test_empty_buffer.py
+++ b/tests/test_empty_buffer.py
@@ -19,7 +19,6 @@ def test_empty_buffer_skips_send(monkeypatch, caplog):
         )
 
         monkeypatch.setattr(router, "render_board", lambda state, player_key=None: BytesIO())
-        monkeypatch.setattr(router, "render_player_board", lambda board, player_key=None: BytesIO(b"own"))
         monkeypatch.setattr(router.storage, "save_match", lambda m: None)
 
         bot = SimpleNamespace(

--- a/tests/test_render_failure.py
+++ b/tests/test_render_failure.py
@@ -52,7 +52,6 @@ def test_render_failure(monkeypatch):
 
         monkeypatch.setattr(handlers, "render_board", fail_render)
         monkeypatch.setattr(router, "render_board", fail_render)
-        monkeypatch.setattr(router, "render_player_board", lambda *a, **k: BytesIO())
 
         safe_send_state = _get_safe_send_state(context, match, "A")
         await safe_send_state("B", "msg")

--- a/tests/test_three_player_match.py
+++ b/tests/test_three_player_match.py
@@ -37,7 +37,6 @@ def test_three_player_match(monkeypatch):
         # non-empty renders
         monkeypatch.setattr(handlers, "render_board", lambda *a, **k: BytesIO(b"img"))
         monkeypatch.setattr(router, "render_board", lambda *a, **k: BytesIO(b"img"))
-        monkeypatch.setattr(router, "render_player_board", lambda *a, **k: BytesIO(b"img"))
 
         async def assert_reply_photo(photo, *args, **kwargs):
             assert photo.getbuffer().nbytes > 0


### PR DESCRIPTION
## Summary
- stop sending the individual player's board in `game_board15.router._send_state`
- only send the shared board image highlighting the last move
- update tests to expect one board image per message

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b1aab8f7708326b5a1dc50f5e2e1c8