### PR TITLE
feat: add detailed cell visuals

### DIFF
--- a/game_board15/battle.py
+++ b/game_board15/battle.py
@@ -51,7 +51,7 @@ def apply_shot(board: Board15, coord: Tuple[int, int]) -> str:
 
 
 def update_history(
-    history: List[List[int]],
+    history: List[List[List[object]]],
     boards: Dict[str, Board15],
     coord: Tuple[int, int],
     results: Dict[str, str],
@@ -60,23 +60,27 @@ def update_history(
 
     r, c = coord
     if any(res == KILL for res in results.values()):
+        kill_key = None
         for key, res in results.items():
             if res != KILL:
                 continue
+            kill_key = key if kill_key is None else kill_key
             board = boards[key]
             for rr in range(15):
                 for cc in range(15):
                     val = board.grid[rr][cc]
                     if val == 4:
-                        _set_cell_state(history, rr, cc, 4)
+                        _set_cell_state(history, rr, cc, 4, key)
                     elif val == 5:
                         # Mark contour cells as shot-through for everyone without
                         # overwriting prior shot information.
                         if _get_cell_state(history[rr][cc]) == 0:
                             _set_cell_state(history, rr, cc, 5)
-        _set_cell_state(history, r, c, 4)
+        if kill_key is not None:
+            _set_cell_state(history, r, c, 4, kill_key)
     elif any(res == HIT for res in results.values()):
-        _set_cell_state(history, r, c, 3)
+        hit_key = next((k for k, res in results.items() if res == HIT), None)
+        _set_cell_state(history, r, c, 3, hit_key)
     elif all(res == MISS for res in results.values()):
         if _get_cell_state(history[r][c]) == 0:
             _set_cell_state(history, r, c, 2)

--- a/game_board15/models.py
+++ b/game_board15/models.py
@@ -40,7 +40,10 @@ class Match15:
     turn: str = "A"
     boards: Dict[str, Board15] = field(default_factory=dict)
     # global shot history for rendering target board
-    history: List[List[int]] = field(default_factory=lambda: [[0] * 15 for _ in range(15)])
+    history: List[List[List[object]]] = field(
+        default_factory=lambda: [[[0, None] for _ in range(15)] for _ in range(15)]
+    )
+    last_highlight: List[Coord] = field(default_factory=list)
     shots: Dict[str, Dict[str, object]] = field(
         default_factory=lambda: {
             k: {

--- a/game_board15/renderer.py
+++ b/game_board15/renderer.py
@@ -50,6 +50,19 @@ PLAYER_SHIP_COLORS = {
     },
 }
 
+PLAYER_SHIP_COLORS_DARK = {
+    "light": {
+        "A": (0, 0, 139, 255),  # dark blue
+        "B": (34, 139, 34, 255),  # dark green
+        "C": (255, 140, 0, 255),  # dark orange
+    },
+    "dark": {
+        "A": (0, 0, 139, 255),
+        "B": (34, 139, 34, 255),
+        "C": (255, 140, 0, 255),
+    },
+}
+
 
 CELL_STYLE = {
     1: ("square", "ship"),
@@ -89,13 +102,23 @@ def render_board(state: Board15State, player_key: str | None = None) -> BytesIO:
             x0 = margin + c * TILE_PX
             y0 = margin + r * TILE_PX
             coord = (r, c)
+            owner = state.owners[r][c] if state.owners else None
             shape, color_key = CELL_STYLE.get(val, ("square", "ship"))
             if coord in highlight:
-                color = COLORS[THEME]["mark"]
-                shape = "cross" if val in (2, 5) else "square"
+                if val in (2, 5):
+                    color = COLORS[THEME]["mark"]
+                    shape = "cross"
+                elif val == 4:
+                    color = PLAYER_SHIP_COLORS.get(THEME, {}).get(owner, COLORS[THEME]["ship"])
+                    shape = "bomb"
+                else:
+                    color = COLORS[THEME]["mark"]
+                    shape = "square"
             else:
-                if val == 1 and player_key:
-                    color = PLAYER_SHIP_COLORS.get(THEME, {}).get(player_key, COLORS[THEME]["ship"])
+                if val == 1 and owner:
+                    color = PLAYER_SHIP_COLORS.get(THEME, {}).get(owner, COLORS[THEME]["ship"])
+                elif val in (3, 4) and owner:
+                    color = PLAYER_SHIP_COLORS_DARK.get(THEME, {}).get(owner, COLORS[THEME][color_key])
                 else:
                     color = COLORS[THEME][color_key]
             if shape == "square":
@@ -114,6 +137,15 @@ def render_board(state: Board15State, player_key: str | None = None) -> BytesIO:
                     fill=color,
                     width=3,
                 )
+            elif shape == "bomb":
+                draw.rectangle(
+                    (x0 + 4, y0 + 4, x0 + TILE_PX - 4, y0 + TILE_PX - 4),
+                    fill=color,
+                )
+                cx = x0 + TILE_PX // 2
+                cy = y0 + TILE_PX // 2
+                r = max(2, TILE_PX // 6)
+                draw.ellipse((cx - r, cy - r, cx + r, cy + r), fill=(0, 0, 0, 255))
             elif shape == "dot":
                 cx = x0 + TILE_PX // 2
                 cy = y0 + TILE_PX // 2
@@ -173,11 +205,20 @@ def render_player_board(board: Board15, player_key: str | None = None) -> BytesI
             coord = (r, c)
             shape, color_key = CELL_STYLE.get(val, ("square", "ship"))
             if coord in highlight:
-                color = COLORS[THEME]["mark"]
-                shape = "cross" if val in (2, 5) else "square"
+                if val in (2, 5):
+                    color = COLORS[THEME]["mark"]
+                    shape = "cross"
+                elif val == 4 and player_key:
+                    color = PLAYER_SHIP_COLORS.get(THEME, {}).get(player_key, COLORS[THEME]["ship"])
+                    shape = "bomb"
+                else:
+                    color = COLORS[THEME]["mark"]
+                    shape = "square"
             else:
                 if val == 1 and player_key:
                     color = PLAYER_SHIP_COLORS.get(THEME, {}).get(player_key, COLORS[THEME]["ship"])
+                elif val in (3, 4) and player_key:
+                    color = PLAYER_SHIP_COLORS_DARK.get(THEME, {}).get(player_key, COLORS[THEME][color_key])
                 else:
                     color = COLORS[THEME][color_key]
             if shape == "square":
@@ -196,6 +237,15 @@ def render_player_board(board: Board15, player_key: str | None = None) -> BytesI
                     fill=color,
                     width=3,
                 )
+            elif shape == "bomb":
+                draw.rectangle(
+                    (x0 + 4, y0 + 4, x0 + TILE_PX - 4, y0 + TILE_PX - 4),
+                    fill=color,
+                )
+                cx = x0 + TILE_PX // 2
+                cy = y0 + TILE_PX // 2
+                r = max(2, TILE_PX // 6)
+                draw.ellipse((cx - r, cy - r, cx + r, cy + r), fill=(0, 0, 0, 255))
             elif shape == "dot":
                 cx = x0 + TILE_PX // 2
                 cy = y0 + TILE_PX // 2

--- a/game_board15/state.py
+++ b/game_board15/state.py
@@ -19,6 +19,9 @@ class Board15State:
     board: List[List[int]] = field(
         default_factory=lambda: [[0] * 15 for _ in range(15)]
     )
+    owners: List[List[Optional[str]]] = field(
+        default_factory=lambda: [[None] * 15 for _ in range(15)]
+    )
     chat_id: Optional[int] = None
     message_id: Optional[int] = None
     player_key: Optional[str] = None

--- a/game_board15/utils.py
+++ b/game_board15/utils.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import random
-from typing import List, Union, Tuple
+from typing import List, Union, Tuple, Optional
 
 from logic.phrases import random_phrase, random_joke
 
@@ -22,13 +22,37 @@ def _get_cell_state(cell: Union[int, List[int], Tuple[int, str]]) -> int:
     return cell[0] if isinstance(cell, (list, tuple)) else cell
 
 
-def _set_cell_state(grid: List[List[Union[int, List[int]]]], r: int, c: int, value: int) -> None:
-    """Set numeric state on history cell preserving list structure."""
+def _get_cell_owner(cell: Union[int, List[int], Tuple[int, str]]) -> Optional[str]:
+    """Return owner from history cell if present."""
+    return cell[1] if isinstance(cell, (list, tuple)) and len(cell) > 1 else None
+
+
+def _set_cell_state(
+    grid: List[List[Union[int, List[Union[int, Optional[str]]]]]],
+    r: int,
+    c: int,
+    value: int,
+    owner: Optional[str] = None,
+) -> None:
+    """Set state and optionally owner on history cell preserving list structure."""
     cell = grid[r][c]
     if isinstance(cell, list):
-        cell[0] = value
+        if not cell:
+            cell.extend([value, owner])
+        else:
+            cell[0] = value
+            if owner is not None:
+                if len(cell) > 1:
+                    cell[1] = owner
+                else:
+                    cell.append(owner)
     else:
-        grid[r][c] = value
+        grid[r][c] = [value, owner] if owner is not None else value
 
 
-__all__ = ["_phrase_or_joke", "_get_cell_state", "_set_cell_state"]
+__all__ = [
+    "_phrase_or_joke",
+    "_get_cell_state",
+    "_get_cell_owner",
+    "_set_cell_state",
+]


### PR DESCRIPTION
## Summary
- track cell owners and last move highlighting
- render ships with player colors and bomb icons for kills

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b1cb629aec8326831ea4658838e571