### PR TITLE
Fix ship color rendering for multi-player boards

### DIFF
--- a/handlers/board_test.py
+++ b/handlers/board_test.py
@@ -192,6 +192,7 @@ async def board_test(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None
     mask = [[0] * 10 for _ in range(10)]
     for key in ("A", "B", "C"):
         board = placement.random_board_global(mask)
+        board.owner = key
         match.players[key].ready = True
         match.boards[key] = board
     storage.save_match(match)

--- a/handlers/router.py
+++ b/handlers/router.py
@@ -218,6 +218,7 @@ async def router_text(update: Update, context: ContextTypes.DEFAULT_TYPE) -> Non
     if match.status == 'placing':
         if text == 'авто':
             board = random_board()
+            board.owner = player_key
             storage.save_board(match, player_key, board)
             if match.status == 'playing':
                 await _send_state(

--- a/logic/render.py
+++ b/logic/render.py
@@ -68,7 +68,7 @@ def render_board_own(board: Board) -> str:
         for c_idx, v in enumerate(row):
             coord = (r_idx, c_idx)
             cell_state, owner = _resolve_cell(v)
-            color = PLAYER_COLORS.get(owner, "#000")
+            color = PLAYER_COLORS.get(owner or getattr(board, "owner", None), "#000")
             if cell_state == 1:
                 sym = f'<span style="color:{color}">□</span>'
             elif cell_state == 2:
@@ -98,7 +98,7 @@ def render_board_enemy(board: Board) -> str:
         for c_idx, v in enumerate(row):
             coord = (r_idx, c_idx)
             cell_state, owner = _resolve_cell(v)
-            color = PLAYER_COLORS.get(owner, "#000")
+            color = PLAYER_COLORS.get(owner or getattr(board, "owner", None), "#000")
             if cell_state == 1:
                 sym = '·'
             elif cell_state == 2:

--- a/models.py
+++ b/models.py
@@ -22,6 +22,8 @@ class Board:
     alive_cells: int = 20
     # cells to highlight (last shot or destroyed ship) for rendering
     highlight: List[Coord] = field(default_factory=list)
+    # owner key ("A", "B" or "C") used for colouring
+    owner: Optional[str] = None
 
 
 @dataclass
@@ -73,6 +75,6 @@ class Match:
         match = Match(match_id=match_id)
         match.players["A"] = Player(user_id=a_user_id, chat_id=a_chat_id)
         for k in ("A", "B", "C"):
-            match.boards[k] = Board()
+            match.boards[k] = Board(owner=k)
         match.history = [[0] * 10 for _ in range(10)]
         return match

--- a/storage.py
+++ b/storage.py
@@ -67,6 +67,7 @@ def get_match(match_id: str) -> Match | None:
             grid=b.get('grid', [[0] * 10 for _ in range(10)]),
             ships=ships,
             alive_cells=b.get('alive_cells', 20),
+            owner=b.get('owner', key),
         )
     match.turn = m.get('turn', 'A')
     match.history = m.get('history', [[0] * 10 for _ in range(10)])
@@ -123,6 +124,7 @@ def save_board(match: Match, player_key: str, board: Board) -> None:
                     grid=b.get('grid', [[0] * 10 for _ in range(10)]),
                     ships=ships,
                     alive_cells=b.get('alive_cells', 20),
+                    owner=b.get('owner', key),
                 )
             current.turn = m_dict.get('turn', 'A')
             current.shots = m_dict.get('shots', current.shots)
@@ -132,6 +134,7 @@ def save_board(match: Match, player_key: str, board: Board) -> None:
             current = match
 
         # apply board and readiness
+        board.owner = player_key
         current.boards[player_key] = board
         current.players[player_key].ready = True
         if all(p.ready for p in current.players.values()) and current.status != 'playing':
@@ -147,7 +150,8 @@ def save_board(match: Match, player_key: str, board: Board) -> None:
             'turn': current.turn,
             'boards': {k: {'grid': b.grid,
                            'ships': [{'cells': s.cells, 'alive': s.alive} for s in b.ships],
-                           'alive_cells': b.alive_cells}
+                           'alive_cells': b.alive_cells,
+                           'owner': b.owner}
                        for k, b in current.boards.items()},
             'shots': current.shots,
             'messages': current.messages,
@@ -191,6 +195,7 @@ def save_match(match: Match) -> str | None:
                     "grid": b.grid,
                     "ships": [{"cells": s.cells, "alive": s.alive} for s in b.ships],
                     "alive_cells": b.alive_cells,
+                    "owner": b.owner,
                 }
                 for k, b in match.boards.items()
             },

--- a/tests/test_render.py
+++ b/tests/test_render.py
@@ -4,6 +4,20 @@ from models import Board, Ship
 from tests.utils import _new_grid, _state
 
 
+def test_render_board_own_uses_board_owner_color():
+    b = Board(owner='A')
+    b.grid[0][0] = 1
+    own = render_board_own(b)
+    assert PLAYER_COLORS['A'] in own
+
+
+def test_render_board_enemy_uses_board_owner_color():
+    b = Board(owner='B')
+    b.grid[0][0] = 3
+    enemy = render_board_enemy(b)
+    assert PLAYER_COLORS['B'] in enemy
+
+
 def test_render_last_move_symbols():
     b = Board()
     b.grid = _new_grid()


### PR DESCRIPTION
## Summary
- track board owner in `Board` dataclass
- color ship cells by board owner when individual cell owner absent
- set owner when auto generating boards and in test matches
- persist owner data in storage layer and add tests

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b1d21d4cac83269075573e02e49319