### PR TITLE
Handle repeat shots in test mode

### DIFF
--- a/handlers/board_test.py
+++ b/handlers/board_test.py
@@ -99,7 +99,10 @@ async def _auto_play_bots(
             shots.setdefault("joke_start", random.randint(1, 10))
             shots["move_count"] += 1
         coord_str = parser.format_coord(coord)
-        hit_any = any(res in (battle.HIT, battle.KILL) for res in results.values())
+        hit_any = any(
+            res in (battle.HIT, battle.KILL, battle.REPEAT)
+            for res in results.values()
+        )
 
         if not hit_any:
             alive_order = [k for k in order if k in alive]
@@ -132,6 +135,13 @@ async def _auto_play_bots(
                         match.players[enemy].chat_id,
                         f"⛔ Игрок {enemy} выбыл (флот уничтожен)",
                     )
+            elif res == battle.REPEAT:
+                phrase_self = _phrase_or_joke(match, current, SELF_MISS)
+                phrase_enemy = _phrase_or_joke(match, enemy, ENEMY_MISS)
+                parts_self.append(f"{enemy}: клетка уже обстреляна. {phrase_self}")
+                enemy_msgs[enemy] = (
+                    f"соперник стрелял по уже обстрелянной клетке. {phrase_enemy}"
+                )
 
         next_name = next_player
         if enemy_msgs:

--- a/handlers/router.py
+++ b/handlers/router.py
@@ -420,7 +420,7 @@ async def router_text_board_test(update: Update, context: ContextTypes.DEFAULT_T
         shots['move_count'] += 1
 
     coord_str = format_coord(coord)
-    hit_any = any(res in (HIT, KILL) for res in results.values())
+    hit_any = any(res in (HIT, KILL, REPEAT) for res in results.values())
     alive = [k for k, b in match.boards.items() if b.alive_cells > 0 and k in match.players]
     if not hit_any:
         alive_order = [k for k in ('A', 'B', 'C') if k in alive]
@@ -458,6 +458,13 @@ async def router_text_board_test(update: Update, context: ContextTypes.DEFAULT_T
                     match.players[enemy].chat_id,
                     f"⛔ Игрок {enemy_label} выбыл (флот уничтожен)",
                 )
+        elif res == REPEAT:
+            phrase_self = _phrase_or_joke(match, player_key, SELF_MISS)
+            phrase_enemy = _phrase_or_joke(match, enemy, ENEMY_MISS)
+            self_msgs[enemy] = f"{enemy_label}: клетка уже обстреляна. {phrase_self}"
+            enemy_msgs[enemy] = (
+                f"соперник стрелял по уже обстрелянной клетке. {phrase_enemy}"
+            )
 
     storage.save_match(match)
 


### PR DESCRIPTION
## Summary
- Handle repeat-shot results in three-player router to notify shooter and defender
- Allow bot autoplay to report repeat shots and keep turn

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b1d2900dd083268149a651436a99b1