### PR TITLE
Refine move result wording

### DIFF
--- a/game_board15/handlers.py
+++ b/game_board15/handlers.py
@@ -240,14 +240,12 @@ async def _auto_play_bots(
 
         for player_key, msg_body in enemy_msgs.items():
             if match.players[player_key].user_id != 0:
-                next_phrase = (
-                    ' Ваш ход.' if next_player == player_key else f" Ход {next_name}."
-                )
+                next_phrase = f" Следующим ходит {next_name}."
                 if player_key == current:
                     msg_text = f"Ваш ход: {coord_str} - {msg_body} {phrase_self}{next_phrase}"
                 else:
                     msg_text = (
-                        f"Ход игрока {player_label}: {coord_str} - {msg_body}{next_phrase}"
+                        f"Ход игрока {player_label}: {coord_str} - {msg_body} {phrase_self}{next_phrase}"
                     )
                 await _safe_send_state(player_key, msg_text)
 

--- a/game_board15/router.py
+++ b/game_board15/router.py
@@ -261,7 +261,7 @@ async def router_text(update: Update, context: ContextTypes.DEFAULT_TYPE) -> Non
     if enemy_msgs and not same_chat:
         for enemy, (res_enemy, msg_body_enemy) in enemy_msgs.items():
             if match.players[enemy].user_id != 0:
-                next_phrase = ' Ваш ход.' if match.turn == enemy else f" Ход {next_name}."
+                next_phrase = f" Следующим ходит {next_name}."
                 await _send_state(
                     context,
                     match,
@@ -271,24 +271,22 @@ async def router_text(update: Update, context: ContextTypes.DEFAULT_TYPE) -> Non
     if others and not same_chat:
         msg_body = ' '.join(parts_self) if parts_self else 'мимо'
         for other in others:
-            next_phrase = ' Ваш ход.' if match.turn == other else f" Ход {next_name}."
+            next_phrase = f" Следующим ходит {next_name}."
             if match.players[other].user_id != 0:
                 await _send_state(
                     context,
                     match,
                     other,
-                    f"Ход игрока {player_label}: {coord_str} - {msg_body}{next_phrase}",
+                    f"Ход игрока {player_label}: {coord_str} - {msg_body} {phrase_self}{next_phrase}",
                 )
     msg_body = ' '.join(parts_self) if parts_self else 'мимо'
     if same_chat:
         result_self = (
-            f"Ход игрока {player_label}: {coord_str} - {msg_body} {phrase_self} Ход {next_name}."
+            f"Ход игрока {player_label}: {coord_str} - {msg_body} {phrase_self} Следующим ходит {next_name}."
         )
         view_key = match.turn
     else:
-        result_self = f"Ваш ход: {coord_str} - {msg_body} {phrase_self}" + (
-            ' Ваш ход.' if match.turn == player_key else f" Ход {next_name}."
-        )
+        result_self = f"Ваш ход: {coord_str} - {msg_body} {phrase_self} Следующим ходит {next_name}."
         view_key = match.turn if single_user else player_key
     await _send_state(context, match, view_key, result_self)
 

--- a/handlers/board_test.py
+++ b/handlers/board_test.py
@@ -157,7 +157,7 @@ async def _auto_play_bots(
                 if enemy == human:
                     continue
                 if match.players[enemy].user_id != 0:
-                    next_phrase = " Ваш ход." if next_player == enemy else f" Ход {next_name}."
+                    next_phrase = f" Следующим ходит {next_name}."
                     await _safe_send_state(
                         enemy,
                         f"Ход игрока {current}: {coord_str} - {msg_body}{next_phrase}",
@@ -168,7 +168,7 @@ async def _auto_play_bots(
             and human in enemy_msgs
             and match.players[human].user_id != 0
         ):
-            next_phrase = " Ваш ход." if next_player == human else f" Ход {next_name}."
+            next_phrase = f" Следующим ходит {next_name}."
             await _safe_send_state(
                 human,
                 f"Ход игрока {current}: {coord_str} - {enemy_msgs[human]}{next_phrase}",
@@ -181,9 +181,7 @@ async def _auto_play_bots(
             if parts_text
             else f"Ваш ход: {coord_str} - {phrase_self}"
         ).rstrip()
-        result_self = base_self + (
-            " Ваш ход." if next_player == current else f" Ход {next_name}."
-        )
+        result_self = base_self + f" Следующим ходит {next_name}."
         if match.players[current].user_id != 0:
             await _safe_send_state(current, result_self)
 

--- a/handlers/router.py
+++ b/handlers/router.py
@@ -292,8 +292,8 @@ async def router_text(update: Update, context: ContextTypes.DEFAULT_TYPE) -> Non
         next_label = getattr(match.players[next_player], 'name', '') or next_player
         phrase_self = _phrase_or_joke(match, player_key, SELF_MISS)
         phrase_enemy = _phrase_or_joke(match, enemy_key, ENEMY_MISS)
-        next_phrase_self = f"Ход {next_label}."
-        next_phrase_enemy = 'Ваш ход.'
+        next_phrase_self = f" Следующим ходит {next_label}."
+        next_phrase_enemy = f" Следующим ходит {next_label}."
         result_self = f"Ваш ход: {coord_str} — Мимо. {phrase_self}{next_phrase_self}"
         result_enemy = (
             f"Ход игрока {player_label}: {coord_str} — Соперник промахнулся. {phrase_enemy}{next_phrase_enemy}"
@@ -304,8 +304,8 @@ async def router_text(update: Update, context: ContextTypes.DEFAULT_TYPE) -> Non
         next_label = getattr(match.players[next_player], 'name', '') or next_player
         phrase_self = _phrase_or_joke(match, player_key, SELF_HIT)
         phrase_enemy = _phrase_or_joke(match, enemy_key, ENEMY_HIT)
-        next_phrase_self = 'Ваш ход.'
-        next_phrase_enemy = f"Ход {next_label}."
+        next_phrase_self = f" Следующим ходит {next_label}."
+        next_phrase_enemy = f" Следующим ходит {next_label}."
         result_self = f"Ваш ход: {coord_str} — Ранил. {phrase_self}{next_phrase_self}"
         result_enemy = (
             f"Ход игрока {player_label}: {coord_str} — Соперник ранил ваш корабль. {phrase_enemy}{next_phrase_enemy}"
@@ -316,8 +316,8 @@ async def router_text(update: Update, context: ContextTypes.DEFAULT_TYPE) -> Non
         next_label = getattr(match.players[next_player], 'name', '') or next_player
         phrase_self = _phrase_or_joke(match, player_key, SELF_MISS)
         phrase_enemy = _phrase_or_joke(match, enemy_key, ENEMY_MISS)
-        next_phrase_self = 'Ваш ход.'
-        next_phrase_enemy = f"Ход {next_label}."
+        next_phrase_self = f" Следующим ходит {next_label}."
+        next_phrase_enemy = f" Следующим ходит {next_label}."
         result_self = (
             f"Ваш ход: {coord_str} — Клетка уже обстреляна. {phrase_self}{next_phrase_self}"
         )
@@ -339,8 +339,8 @@ async def router_text(update: Update, context: ContextTypes.DEFAULT_TYPE) -> Non
         else:
             next_player = player_key
             next_label = getattr(match.players[next_player], 'name', '') or next_player
-            next_phrase_self = 'Ваш ход.'
-            next_phrase_enemy = f"Ход {next_label}."
+            next_phrase_self = f" Следующим ходит {next_label}."
+            next_phrase_enemy = f" Следующим ходит {next_label}."
             result_self = (
                 f"Ваш ход: {coord_str} — Корабль соперника уничтожен! {phrase_self}{next_phrase_self}"
             )
@@ -351,10 +351,10 @@ async def router_text(update: Update, context: ContextTypes.DEFAULT_TYPE) -> Non
     else:
         next_player = enemy_key
         next_label = getattr(match.players[next_player], 'name', '') or next_player
-        next_phrase_self = f"Ход {next_label}."
-        next_phrase_enemy = 'Ваш ход.'
-        result_self = f"Ваш ход: {coord_str} — Ошибка. {next_phrase_self}"
-        result_enemy = f"Ход игрока {player_label}: {coord_str} — Техническая ошибка. {next_phrase_enemy}"
+        next_phrase_self = f" Следующим ходит {next_label}."
+        next_phrase_enemy = f" Следующим ходит {next_label}."
+        result_self = f"Ваш ход: {coord_str} — Ошибка.{next_phrase_self}"
+        result_enemy = f"Ход игрока {player_label}: {coord_str} — Техническая ошибка.{next_phrase_enemy}"
 
     if error:
         msg = 'Произошла техническая ошибка. Ход прерван.'
@@ -371,11 +371,7 @@ async def router_text(update: Update, context: ContextTypes.DEFAULT_TYPE) -> Non
                     await context.bot.delete_message(chat_id, msg_id)
                 except Exception:
                     pass
-        if next_player == player_key:
-            next_label = getattr(match.players[next_player], 'name', '') or next_player
-            result_self = result_self.replace('Ваш ход.', f'Ход {next_label}.')
         result_shared = result_self.replace('Ваш ход:', f'Ход игрока {player_label}:')
-        result_shared = result_shared.replace('Ваш ход.', f'Ход {player_label}.')
         result_shared = result_shared.replace('Вы победили.', f'Игрок {player_label} победил.')
         await _send_state(context, match, player_key, result_shared)
         match.messages[enemy_key] = match.messages[player_key].copy()
@@ -483,9 +479,7 @@ async def router_text_board_test(update: Update, context: ContextTypes.DEFAULT_T
     storage.save_match(match)
 
     next_label = getattr(match.players[next_player], 'name', '') or next_player
-    next_phrase_self = (
-        'Ваш ход.' if next_player == player_key else f"Ход {next_label}."
-    )
+    next_phrase_self = f"Следующим ходит {next_label}."
     summary = random.choice(list(self_msgs.values())) if self_msgs else ''
     if summary:
         self_lines = [f"Ваш ход: {coord_str} — {summary}"]
@@ -501,9 +495,7 @@ async def router_text_board_test(update: Update, context: ContextTypes.DEFAULT_T
 
     for enemy, body in enemy_msgs.items():
         if match.players[enemy].user_id != 0:
-            next_phrase = (
-                'Ваш ход.' if next_player == enemy else f"Ход {next_label}."
-            )
+            next_phrase = f"Следующим ходит {next_label}."
             await _send_state_board_test(
                 context,
                 match,

--- a/tests/test_board15_router.py
+++ b/tests/test_board15_router.py
@@ -126,7 +126,7 @@ def test_router_notifies_other_players_on_hit(monkeypatch):
         assert len(calls) >= 2
         msg = calls[-1].args[3]
         assert msg.startswith('Ход игрока A: a1 - B: ранил')
-        assert msg.strip().endswith('Ход A.')
+        assert msg.strip().endswith('Следующим ходит A.')
 
     asyncio.run(run_test())
 
@@ -234,7 +234,7 @@ def test_router_notifies_next_player_on_miss(monkeypatch):
         await router.router_text(update, context)
 
         b_msgs = [c for c in send_message.call_args_list if c.args[0] == 20]
-        assert b_msgs and b_msgs[0].args[1].endswith('Ваш ход.')
+        assert b_msgs and b_msgs[0].args[1].endswith('Следующим ходит B.')
         assert 'a1 - мимо' not in b_msgs[0].args[1]
 
     asyncio.run(run_test())
@@ -328,7 +328,7 @@ def test_router_uses_player_names(monkeypatch):
         msg = send_state.call_args[0][3]
         assert 'Bob' in msg and 'Carl' in msg
         assert 'B:' not in msg and 'C:' not in msg
-        assert msg.strip().endswith('Ход Bob.')
+        assert msg.strip().endswith('Следующим ходит Bob.')
 
     asyncio.run(run_test())
 

--- a/tests/test_board15_test_autoplay.py
+++ b/tests/test_board15_test_autoplay.py
@@ -141,7 +141,7 @@ def test_auto_play_bots_notifies_human(monkeypatch):
         with pytest.raises(asyncio.TimeoutError):
             await asyncio.wait_for(handlers._auto_play_bots(match, context, 1), timeout=0.01)
 
-        assert any(player == 'A' and msg.endswith('Ваш ход.') for player, msg in calls)
+        assert any(player == 'A' and msg.endswith('Следующим ходит A.') for player, msg in calls)
 
     asyncio.run(run())
 

--- a/tests/test_router_text.py
+++ b/tests/test_router_text.py
@@ -208,10 +208,10 @@ def test_router_kill_message(monkeypatch):
         msg_enemy = calls[3].args[1]
         assert 'Ваш ход: a1 — Корабль соперника уничтожен!' in msg_self
         assert any(p in msg_self for p in phrases.SELF_KILL)
-        assert msg_self.strip().endswith('Ваш ход.')
+        assert msg_self.strip().endswith('Следующим ходит A.')
         assert 'Ход игрока A: a1 — Соперник уничтожил ваш корабль.' in msg_enemy
         assert any(p in msg_enemy for p in phrases.ENEMY_KILL)
-        assert msg_enemy.strip().endswith('Ход A.')
+        assert msg_enemy.strip().endswith('Следующим ходит A.')
     asyncio.run(run_test())
 
 
@@ -274,7 +274,7 @@ def test_router_joke_format(monkeypatch):
         )
         await router.router_text(update, context)
         msg_self = send_message.call_args_list[1].args[1]
-        assert 'Слушай анекдот по этому поводу:\nJOKE\n\nХод B.' in msg_self
+        assert 'Слушай анекдот по этому поводу:\nJOKE\n\n Следующим ходит B.' in msg_self
 
     asyncio.run(run_test())
 


### PR DESCRIPTION
## Summary
- add "Следующим ходит ..." phrasing to move messages for all players
- adjust three-player and board test handlers to use the new wording
- update tests for new messages

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b21dc92028832692160b06d7b4b1b5