### PR TITLE
feat: simplify multi-target shot messages

### DIFF
--- a/game_board15/handlers.py
+++ b/game_board15/handlers.py
@@ -208,15 +208,14 @@ async def _auto_play_bots(
             enemy_label = getattr(enemy_name, 'name', '') or enemy
             if res == battle.MISS:
                 phrase_enemy = _phrase_or_joke(match, enemy, ENEMY_MISS)
-                parts_self.append(f"{enemy_label}: мимо.")
                 enemy_msgs[enemy] = f"соперник промахнулся. {phrase_enemy}"
             elif res == battle.HIT:
                 phrase_enemy = _phrase_or_joke(match, enemy, ENEMY_HIT)
-                parts_self.append(f"{enemy_label}: ранил.")
+                parts_self.append(f"ранен корабль игрока {enemy_label}.")
                 enemy_msgs[enemy] = f"ваш корабль ранен. {phrase_enemy}"
             elif res == battle.KILL:
                 phrase_enemy = _phrase_or_joke(match, enemy, ENEMY_KILL)
-                parts_self.append(f"{enemy_label}: уничтожен!")
+                parts_self.append(f"уничтожен корабль игрока {enemy_label}!")
                 enemy_msgs[enemy] = f"ваш корабль уничтожен. {phrase_enemy}"
                 if match.boards[enemy].alive_cells == 0 and match.players[enemy].user_id != 0:
                     enemy_label = getattr(match.players.get(enemy), 'name', '') or enemy
@@ -224,7 +223,7 @@ async def _auto_play_bots(
                         match.players[enemy].chat_id,
                         f"⛔ Игрок {enemy_label} выбыл (флот уничтожен)",
                     )
-        enemy_msgs[current] = ' '.join(parts_self)
+        enemy_msgs[current] = ' '.join(parts_self) if parts_self else 'мимо'
 
         if any(res == battle.KILL for res in results.values()):
             phrase_self = _phrase_or_joke(match, current, SELF_KILL)

--- a/game_board15/router.py
+++ b/game_board15/router.py
@@ -209,16 +209,15 @@ async def router_text(update: Update, context: ContextTypes.DEFAULT_TYPE) -> Non
         enemy_label = getattr(enemy_obj, "name", "") or enemy
         if res == battle.MISS:
             phrase_enemy = _phrase_or_joke(match, enemy, ENEMY_MISS)
-            parts_self.append(f"{enemy_label}: мимо.")
             enemy_msgs[enemy] = (res, f"соперник промахнулся. {phrase_enemy}")
         elif res == battle.HIT:
             phrase_enemy = _phrase_or_joke(match, enemy, ENEMY_HIT)
-            parts_self.append(f"{enemy_label}: ранил.")
+            parts_self.append(f"ранен корабль игрока {enemy_label}.")
             enemy_msgs[enemy] = (res, f"ваш корабль ранен. {phrase_enemy}")
             targets.append(enemy)
         elif res == battle.KILL:
             phrase_enemy = _phrase_or_joke(match, enemy, ENEMY_KILL)
-            parts_self.append(f"{enemy_label}: уничтожен!")
+            parts_self.append(f"уничтожен корабль игрока {enemy_label}!")
             enemy_msgs[enemy] = (res, f"ваш корабль уничтожен. {phrase_enemy}")
             targets.append(enemy)
             if (

--- a/tests/test_board15_bot_elimination.py
+++ b/tests/test_board15_bot_elimination.py
@@ -49,6 +49,9 @@ def test_router_notifies_on_bot_elimination(monkeypatch):
 
         assert context.bot.send_message.call_count == 0
         calls = [(c.args[2], c.args[3]) for c in send_state.call_args_list]
-        assert any(player == 'A' and 'B: уничтожен!' in msg for player, msg in calls)
+        assert any(
+            player == 'A' and 'уничтожен корабль игрока B!' in msg
+            for player, msg in calls
+        )
 
     asyncio.run(run())

--- a/tests/test_board15_router.py
+++ b/tests/test_board15_router.py
@@ -171,7 +171,7 @@ def test_router_notifies_other_players_on_hit(monkeypatch):
         calls = [c for c in send_state.call_args_list if c.args[2] == 'C']
         assert len(calls) >= 2
         msg = calls[-1].args[3]
-        assert msg.startswith('Ход игрока A: a1 - B: ранил')
+        assert msg.startswith('Ход игрока A: a1 - ранен корабль игрока B')
         assert msg.strip().endswith('Следующим ходит A.')
 
     asyncio.run(run_test())
@@ -371,8 +371,9 @@ def test_router_uses_player_names(monkeypatch):
 
         await router.router_text(update, context)
 
-        msg = send_state.call_args[0][3]
-        assert 'Bob' in msg and 'Carl' in msg
+        calls = [c for c in send_state.call_args_list if 'мимо' in c.args[3]]
+        msg = calls[0].args[3]
+        assert msg.startswith('Ход игрока Alice: a1 - мимо')
         assert 'B:' not in msg and 'C:' not in msg
         assert msg.strip().endswith('Следующим ходит Bob.')
 
@@ -424,7 +425,7 @@ def test_router_miss_single_phrase(monkeypatch):
         msg = send_state.call_args[0][3]
         assert msg.count('SELF_JOKE') == 1
         assert 'B_JOKE' not in msg and 'C_JOKE' not in msg
-        assert 'C:' not in msg
+        assert 'B:' not in msg and 'C:' not in msg
 
     asyncio.run(run_test())
 


### PR DESCRIPTION
## Summary
- simplify shooter messages when firing at multiple opponents
- adjust three-player handler to use aggregated phrasing
- update tests for new wording

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68b2239b9e688326ab924a3776ab4317