### PR TITLE
Ensure killed ships highlight all cells on 15x15 board

### DIFF
--- a/game_board15/router.py
+++ b/game_board15/router.py
@@ -181,7 +181,11 @@ async def router_text(update: Update, context: ContextTypes.DEFAULT_TYPE) -> Non
         cells: list[tuple[int, int]] = []
         for enemy, res in results.items():
             if res == battle.KILL:
-                cells.extend(match.boards[enemy].highlight)
+                board = match.boards[enemy]
+                for rr in range(15):
+                    for cc in range(15):
+                        if board.grid[rr][cc] == 4:
+                            cells.append((rr, cc))
         match.last_highlight = cells.copy()
         match.shots[player_key]["last_result"] = "kill"
     elif any(res == battle.HIT for res in results.values()):

--- a/tests/test_board15_router.py
+++ b/tests/test_board15_router.py
@@ -17,6 +17,7 @@ sys.modules.setdefault('PIL', pil)
 
 from game_board15 import router, storage
 from game_board15.models import Board15, Ship
+from game_board15.utils import _get_cell_state
 
 
 def test_router_auto_sends_boards(monkeypatch):
@@ -117,6 +118,52 @@ def test_last_highlight_persists_after_kill(monkeypatch):
         assert match.last_highlight == [(0, 0)]
         board_enemy.highlight.clear()
         assert match.last_highlight == [(0, 0)]
+
+    asyncio.run(run_test())
+
+
+def test_kill_marks_all_cells_and_contour(monkeypatch):
+    async def run_test():
+        board_self = Board15()
+        board_enemy = Board15()
+        ship = Ship(cells=[(0, 0), (0, 1)])
+        board_enemy.ships = [ship]
+        board_enemy.grid[0][0] = 3
+        board_enemy.grid[0][1] = 1
+        board_enemy.alive_cells = 1
+        match = SimpleNamespace(
+            status="playing",
+            players={
+                "A": SimpleNamespace(user_id=1, chat_id=10, name="A"),
+                "B": SimpleNamespace(user_id=2, chat_id=20, name="B"),
+            },
+            boards={"A": board_self, "B": board_enemy},
+            turn="A",
+            shots={"A": {"move_count": 0, "joke_start": 10}, "B": {}},
+            messages={"A": {}, "B": {}},
+            history=_new_grid(15),
+        )
+
+        monkeypatch.setattr(storage, "find_match_by_user", lambda uid, chat_id=None: match)
+        monkeypatch.setattr(storage, "save_match", lambda m: None)
+        monkeypatch.setattr(router.parser, "parse_coord", lambda text: (0, 1))
+        monkeypatch.setattr(router.parser, "format_coord", lambda coord: "b1")
+        monkeypatch.setattr(router, "_phrase_or_joke", lambda m, pk, ph: "")
+
+        send_state = AsyncMock()
+        monkeypatch.setattr(router, "_send_state", send_state)
+
+        update = SimpleNamespace(
+            message=SimpleNamespace(text="b1", reply_text=AsyncMock()),
+            effective_user=SimpleNamespace(id=1),
+            effective_chat=SimpleNamespace(id=10),
+        )
+        context = SimpleNamespace(bot=SimpleNamespace(send_message=AsyncMock()), chat_data={}, bot_data={})
+
+        await router.router_text(update, context)
+
+        assert set(match.last_highlight) == {(0, 0), (0, 1)}
+        assert _get_cell_state(match.history[0][2]) == 5
 
     asyncio.run(run_test())
 


### PR DESCRIPTION
## Summary
- ensure kill highlight covers every destroyed cell by reading from board grid
- add regression test for highlighting entire sunk ship and marking its contour

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b22678d3708326a381df0d9b7723fe