### PR TITLE
Use board highlight for kill handling

### DIFF
--- a/game_board15/router.py
+++ b/game_board15/router.py
@@ -181,11 +181,7 @@ async def router_text(update: Update, context: ContextTypes.DEFAULT_TYPE) -> Non
         cells: list[tuple[int, int]] = []
         for enemy, res in results.items():
             if res == battle.KILL:
-                board = match.boards[enemy]
-                for rr in range(15):
-                    for cc in range(15):
-                        if board.grid[rr][cc] == 4:
-                            cells.append((rr, cc))
+                cells.extend(match.boards[enemy].highlight)
         match.last_highlight = cells.copy()
         match.shots[player_key]["last_result"] = "kill"
     elif any(res == battle.HIT for res in results.values()):

--- a/tests/test_board15_router.py
+++ b/tests/test_board15_router.py
@@ -199,6 +199,55 @@ def test_kill_marks_all_cells_and_contour(monkeypatch):
     asyncio.run(run_test())
 
 
+def test_kill_highlight_only_last_ship(monkeypatch):
+    async def run_test():
+        board_self = Board15()
+        board_enemy = Board15()
+        # Previously destroyed ship cells remain on the grid
+        board_enemy.grid[5][5] = 4
+        board_enemy.grid[5][6] = 4
+        # Current ship about to be killed
+        ship = Ship(cells=[(0, 0), (0, 1)])
+        board_enemy.ships = [ship]
+        board_enemy.grid[0][0] = 3  # already hit part
+        board_enemy.grid[0][1] = 1  # intact part
+        board_enemy.alive_cells = 1
+        match = SimpleNamespace(
+            status="playing",
+            players={
+                "A": SimpleNamespace(user_id=1, chat_id=10, name="A"),
+                "B": SimpleNamespace(user_id=2, chat_id=20, name="B"),
+            },
+            boards={"A": board_self, "B": board_enemy},
+            turn="A",
+            shots={"A": {"move_count": 0, "joke_start": 10}, "B": {}},
+            messages={"A": {}, "B": {}},
+            history=_new_grid(15),
+        )
+
+        monkeypatch.setattr(storage, "find_match_by_user", lambda uid, chat_id=None: match)
+        monkeypatch.setattr(storage, "save_match", lambda m: None)
+        monkeypatch.setattr(router.parser, "parse_coord", lambda text: (0, 1))
+        monkeypatch.setattr(router.parser, "format_coord", lambda coord: "b1")
+        monkeypatch.setattr(router, "_phrase_or_joke", lambda m, pk, ph: "")
+
+        send_state = AsyncMock()
+        monkeypatch.setattr(router, "_send_state", send_state)
+
+        update = SimpleNamespace(
+            message=SimpleNamespace(text="b1", reply_text=AsyncMock()),
+            effective_user=SimpleNamespace(id=1),
+            effective_chat=SimpleNamespace(id=10),
+        )
+        context = SimpleNamespace(bot=SimpleNamespace(send_message=AsyncMock()), chat_data={}, bot_data={})
+
+        await router.router_text(update, context)
+
+        assert set(match.last_highlight) == {(0, 0), (0, 1)}
+
+    asyncio.run(run_test())
+
+
 def test_router_notifies_other_players_on_hit(monkeypatch):
     async def run_test():
         board_self = Board15()


### PR DESCRIPTION
## Summary
- use board.highlight to collect destroyed ship cells when handling KILL
- test that only the most recently sunk ship's cells are highlighted

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b2a53c5c54832687bf4637d791e1b8