### PR TITLE
Show only player's board during three-player tests

### DIFF
--- a/game_board15/router.py
+++ b/game_board15/router.py
@@ -283,7 +283,7 @@ async def router_text(update: Update, context: ContextTypes.DEFAULT_TYPE) -> Non
         result_self = (
             f"Ход игрока {player_label}: {coord_str} - {msg_body} {phrase_self} Следующим ходит {next_name}."
         )
-        view_key = match.turn
+        view_key = player_key
     else:
         result_self = f"Ваш ход: {coord_str} - {msg_body} {phrase_self} Следующим ходит {next_name}."
         view_key = match.turn if single_user else player_key

--- a/tests/test_board15_test_manual.py
+++ b/tests/test_board15_test_manual.py
@@ -77,6 +77,13 @@ def test_board15_test_manual(monkeypatch):
             bot_data={},
         )
 
+        sent_to: list[str] = []
+
+        async def fake_send_state(context, match_obj, player_key, message):
+            sent_to.append(player_key)
+
+        monkeypatch.setattr(router, "_send_state", fake_send_state)
+
         await handlers.board15_test(update, context)
 
         # ensure start text sent before board image
@@ -109,5 +116,6 @@ def test_board15_test_manual(monkeypatch):
         assert finished.get("winner") == "A"
         messages = [c.args[1] for c in context.bot.send_message.call_args_list]
         assert any("Вы победили" in m for m in messages)
+        assert set(sent_to) == {"A"}
 
     asyncio.run(run())


### PR DESCRIPTION
## Summary
- prevent opponent boards from being shown when all players share one chat
- add regression test ensuring only the human player's board is rendered

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b2a8483a0c83269fb8694f90b5cb6d