### PR TITLE
Improve bot shot selection logic

### DIFF
--- a/tests/test_board15_test_autoplay.py
+++ b/tests/test_board15_test_autoplay.py
@@ -73,6 +73,8 @@ def test_auto_play_bots_skips_closed(monkeypatch):
 
         context = SimpleNamespace(bot=SimpleNamespace(send_message=AsyncMock()), bot_data={})
 
+        monkeypatch.setattr(handlers.random, 'choice', lambda seq: seq[0])
+
         with pytest.raises(RuntimeError):
             await handlers._auto_play_bots(match, context, 0)
 
@@ -102,10 +104,12 @@ def test_auto_play_bots_skips_own_ship(monkeypatch):
 
         context = SimpleNamespace(bot=SimpleNamespace(send_message=AsyncMock()), bot_data={})
 
+        monkeypatch.setattr(handlers.random, 'choice', lambda seq: seq[0])
+
         with pytest.raises(RuntimeError):
             await handlers._auto_play_bots(match, context, 0)
 
-        assert recorded['coord'] == (0, 1)
+        assert recorded['coord'] == (0, 2)
 
     asyncio.run(run())
 
@@ -189,6 +193,7 @@ def test_auto_play_bots_refreshes_match(monkeypatch):
             return handlers.battle.MISS
 
         monkeypatch.setattr(handlers.battle, 'apply_shot', fake_apply_shot)
+        monkeypatch.setattr(handlers.random, 'choice', lambda seq: seq[0])
 
         with pytest.raises(RuntimeError):
             await handlers._auto_play_bots(match, context, 0)

--- a/tests/test_board15_test_manual.py
+++ b/tests/test_board15_test_manual.py
@@ -77,6 +77,8 @@ def test_board15_test_manual(monkeypatch):
             bot_data={},
         )
 
+        monkeypatch.setattr(handlers.random, 'choice', lambda seq: seq[0])
+
         await handlers.board15_test(update, context)
 
         # ensure start text sent before board image


### PR DESCRIPTION
## Summary
- teach bot to avoid firing near its own ships by computing adjacent cells and randomly choosing from safe candidates
- update autoplay tests to patch randomness and expect new behaviour
- ensure manual autoplay test uses deterministic shots

## Testing
- `pytest tests/test_board15_test_autoplay.py`
- `pytest` *(failed: KeyboardInterrupt after 41 passed, 14 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68b2a7aa94b0832694a74984f9b545fd