### PR TITLE
Avoid adjacent bot shots

### DIFF
--- a/tests/test_board15_test_autoplay.py
+++ b/tests/test_board15_test_autoplay.py
@@ -70,6 +70,7 @@ def test_auto_play_bots_skips_closed(monkeypatch):
         monkeypatch.setattr(storage, 'save_match', lambda m: None)
         monkeypatch.setattr(storage, 'get_match', lambda mid: match)
         monkeypatch.setattr(storage, 'finish', lambda m, w: None)
+        monkeypatch.setattr(handlers.random, 'choice', lambda seq: seq[0])
 
         context = SimpleNamespace(bot=SimpleNamespace(send_message=AsyncMock()), bot_data={})
 
@@ -99,13 +100,14 @@ def test_auto_play_bots_skips_own_ship(monkeypatch):
         monkeypatch.setattr(storage, 'save_match', lambda m: None)
         monkeypatch.setattr(storage, 'get_match', lambda mid: match)
         monkeypatch.setattr(storage, 'finish', lambda m, w: None)
+        monkeypatch.setattr(handlers.random, 'choice', lambda seq: seq[0])
 
         context = SimpleNamespace(bot=SimpleNamespace(send_message=AsyncMock()), bot_data={})
 
         with pytest.raises(RuntimeError):
             await handlers._auto_play_bots(match, context, 0)
 
-        assert recorded['coord'] == (0, 1)
+        assert recorded['coord'] == (0, 2)
 
     asyncio.run(run())
 
@@ -189,6 +191,7 @@ def test_auto_play_bots_refreshes_match(monkeypatch):
             return handlers.battle.MISS
 
         monkeypatch.setattr(handlers.battle, 'apply_shot', fake_apply_shot)
+        monkeypatch.setattr(handlers.random, 'choice', lambda seq: seq[0])
 
         with pytest.raises(RuntimeError):
             await handlers._auto_play_bots(match, context, 0)

--- a/tests/test_three_player_single_board.py
+++ b/tests/test_three_player_single_board.py
@@ -131,6 +131,7 @@ def test_auto_play_bots_sequence_and_history(monkeypatch):
         async def fast_sleep(t):
             pass
         monkeypatch.setattr(asyncio, "sleep", fast_sleep)
+        monkeypatch.setattr(handlers.random, 'choice', lambda seq: seq[0])
         await handlers._auto_play_bots(match, context, 0, human="A")
         assert recorded == [(0, 0), (0, 2)]
         assert _state(match.history[0][0]) == 4


### PR DESCRIPTION
## Summary
- Skip bot shots on or near its own ships by computing adjacency mask
- Randomly select from remaining candidates instead of sequential scan
- Adjust autoplay tests to account for random targeting

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b2c699740483269ef1fe3e2ea1b854