### PR TITLE
Render miss cells with cross only

### DIFF
--- a/game_board15/renderer.py
+++ b/game_board15/renderer.py
@@ -24,7 +24,6 @@ COLORS = {
         "mark": (220, 0, 0, 255),
         "ship": (0, 0, 0, 255),
         "miss": (220, 0, 0, 255),
-        "miss_bg": (255, 165, 0, 255),
         "hit": (139, 0, 0, 255),
         "destroyed": (139, 0, 0, 255),
         "contour": (120, 120, 120, 255),
@@ -35,7 +34,6 @@ COLORS = {
         "mark": (255, 0, 0, 255),
         "ship": (220, 220, 220, 255),
         "miss": (255, 0, 0, 255),
-        "miss_bg": (255, 140, 0, 255),
         "hit": (139, 0, 0, 255),
         "destroyed": (255, 100, 100, 255),
         "contour": (160, 160, 160, 255),
@@ -146,10 +144,6 @@ def render_board(state: Board15State, player_key: str | None = None) -> BytesIO:
                     fill=color,
                 )
             elif shape == "cross":
-                draw.rectangle(
-                    (x0 + 4, y0 + 4, x0 + TILE_PX - 4, y0 + TILE_PX - 4),
-                    fill=COLORS[THEME]["miss_bg"],
-                )
                 draw.line(
                     (x0 + 4, y0 + 4, x0 + TILE_PX - 4, y0 + TILE_PX - 4),
                     fill=color,
@@ -255,10 +249,6 @@ def render_player_board(board: Board15, player_key: str | None = None) -> BytesI
                     fill=color,
                 )
             elif shape == "cross":
-                draw.rectangle(
-                    (x0 + 4, y0 + 4, x0 + TILE_PX - 4, y0 + TILE_PX - 4),
-                    fill=COLORS[THEME]["miss_bg"],
-                )
                 draw.line(
                     (x0 + 4, y0 + 4, x0 + TILE_PX - 4, y0 + TILE_PX - 4),
                     fill=color,

--- a/tests/test_board15_renderer.py
+++ b/tests/test_board15_renderer.py
@@ -24,3 +24,24 @@ def test_killed_ship_renders_bomb():
     cx = renderer.TILE_PX + renderer.TILE_PX // 2
     cy = renderer.TILE_PX + renderer.TILE_PX // 2
     assert img.getpixel((cx, cy))[:3] == (0, 0, 0)
+
+
+def test_miss_renders_cross_without_fill():
+    sys.modules.pop("PIL", None)
+    sys.modules.pop("game_board15.renderer", None)
+    from PIL import Image
+    renderer = importlib.import_module("game_board15.renderer")
+    from game_board15.state import Board15State
+
+    board = [[0] * 15 for _ in range(15)]
+    board[0][0] = 2
+    state = Board15State(board=board)
+    buf = renderer.render_board(state)
+
+    img = Image.open(buf)
+    x0 = renderer.TILE_PX
+    y0 = renderer.TILE_PX
+    cx = x0 + renderer.TILE_PX // 2
+    cy = y0 + renderer.TILE_PX // 2
+    sample = (cx + 6, cy)
+    assert img.getpixel(sample) == renderer.COLORS[renderer.THEME]["bg"]


### PR DESCRIPTION
## Summary
- remove background fill for miss markers
- add regression test to ensure miss cells remain unfilled

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b2df7efeb883269ed80c90af35be13