### PR TITLE
Add bot move delay in test games

### DIFF
--- a/game_board15/handlers.py
+++ b/game_board15/handlers.py
@@ -89,6 +89,7 @@ async def _auto_play_bots(
     context: ContextTypes.DEFAULT_TYPE,
     chat_id: int,
     human: str = 'A',
+    delay: float = 0.0,
 ) -> None:
     """Automatically let bot players make moves until the game ends."""
     logger = logging.getLogger(__name__)
@@ -173,7 +174,8 @@ async def _auto_play_bots(
             await asyncio.sleep(0.5)
             continue
 
-        await asyncio.sleep(6)
+        if delay:
+            await asyncio.sleep(delay)
 
         current = match.turn
         board = match.boards[current]
@@ -356,7 +358,9 @@ async def board15_test(update: Update, context: ContextTypes.DEFAULT_TYPE) -> No
     }
     storage.save_match(match)
     asyncio.create_task(
-        _auto_play_bots(match, context, update.effective_chat.id, human='A')
+        _auto_play_bots(
+            match, context, update.effective_chat.id, human='A', delay=6
+        )
     )
 
 

--- a/handlers/board_test.py
+++ b/handlers/board_test.py
@@ -38,6 +38,7 @@ async def _auto_play_bots(
     context: ContextTypes.DEFAULT_TYPE,
     chat_id: int,
     human: str = "A",
+    delay: float = 0.0,
 ) -> None:
     """Automatically let bot players make moves until the game ends."""
 
@@ -79,7 +80,8 @@ async def _auto_play_bots(
             await asyncio.sleep(0.5)
             continue
 
-        await asyncio.sleep(6)
+        if delay:
+            await asyncio.sleep(delay)
 
         current = match.turn
         coord = None
@@ -232,5 +234,7 @@ async def board_test(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None
         "Выберите клетку или введите ход текстом.",
     )
     asyncio.create_task(
-        _auto_play_bots(match, context, update.effective_chat.id, human="A")
+        _auto_play_bots(
+            match, context, update.effective_chat.id, human="A", delay=6
+        )
     )


### PR DESCRIPTION
## Summary
- Pause for 6 seconds before each bot move in three-player test matches

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68b2e0a00f70832691a4d902408e9117