### PR TITLE
Fade kill markers to dark ship cells after next move

### DIFF
--- a/game_board15/renderer.py
+++ b/game_board15/renderer.py
@@ -123,8 +123,11 @@ def render_board(state: Board15State, player_key: str | None = None) -> BytesIO:
             if coord in highlight:
                 if val in (2, 5):
                     color = COLORS[THEME]["mark"]
-                elif val == 4:
-                    color = PLAYER_SHIP_COLORS_LIGHT.get(THEME, {}).get(owner, COLORS[THEME]["destroyed"])
+                elif val == 4 and owner:
+                    shape = "bomb"
+                    color = PLAYER_SHIP_COLORS_LIGHT.get(
+                        THEME, {}
+                    ).get(owner, COLORS[THEME]["destroyed"])
                 else:
                     color = COLORS[THEME]["mark"]
             else:
@@ -133,7 +136,10 @@ def render_board(state: Board15State, player_key: str | None = None) -> BytesIO:
                 elif val == 3:
                     color = COLORS[THEME]["hit"]
                 elif val == 4 and owner:
-                    color = PLAYER_SHIP_COLORS_LIGHT.get(THEME, {}).get(owner, COLORS[THEME]["destroyed"])
+                    shape = "square"
+                    color = PLAYER_SHIP_COLORS_DARK.get(
+                        THEME, {}
+                    ).get(owner, COLORS[THEME]["destroyed"])
                 elif val in (2, 5):
                     color = COLORS[THEME]["miss"]
                 else:
@@ -229,7 +235,10 @@ def render_player_board(board: Board15, player_key: str | None = None) -> BytesI
                 if val in (2, 5):
                     color = COLORS[THEME]["mark"]
                 elif val == 4 and player_key:
-                    color = PLAYER_SHIP_COLORS_LIGHT.get(THEME, {}).get(player_key, COLORS[THEME]["destroyed"])
+                    shape = "bomb"
+                    color = PLAYER_SHIP_COLORS_LIGHT.get(
+                        THEME, {}
+                    ).get(player_key, COLORS[THEME]["destroyed"])
                 else:
                     color = COLORS[THEME]["mark"]
             else:
@@ -238,7 +247,10 @@ def render_player_board(board: Board15, player_key: str | None = None) -> BytesI
                 elif val == 3:
                     color = COLORS[THEME]["hit"]
                 elif val == 4 and player_key:
-                    color = PLAYER_SHIP_COLORS_LIGHT.get(THEME, {}).get(player_key, COLORS[THEME]["destroyed"])
+                    shape = "square"
+                    color = PLAYER_SHIP_COLORS_DARK.get(
+                        THEME, {}
+                    ).get(player_key, COLORS[THEME]["destroyed"])
                 elif val in (2, 5):
                     color = COLORS[THEME]["miss"]
                 else:

--- a/tests/test_board15_renderer.py
+++ b/tests/test_board15_renderer.py
@@ -2,7 +2,31 @@ import sys
 import importlib
 
 
-def test_killed_ship_renders_bomb():
+def test_killed_ship_last_move_renders_bomb():
+    sys.modules.pop("PIL", None)
+    sys.modules.pop("game_board15.renderer", None)
+    from PIL import Image
+    renderer = importlib.import_module("game_board15.renderer")
+    from game_board15.state import Board15State
+
+    board = [[0] * 15 for _ in range(15)]
+    owners = [[None] * 15 for _ in range(15)]
+    board[0][0] = 4
+    owners[0][0] = "A"
+    state = Board15State(board=board, owners=owners, highlight=[(0, 0)])
+    buf = renderer.render_board(state, player_key="B")
+
+    img = Image.open(buf)
+    x = renderer.TILE_PX + 5
+    y = renderer.TILE_PX + 5
+    expected = renderer.PLAYER_SHIP_COLORS_LIGHT.get(renderer.THEME, {}).get("A")
+    assert img.getpixel((x, y)) == expected
+    cx = renderer.TILE_PX + renderer.TILE_PX // 2
+    cy = renderer.TILE_PX + renderer.TILE_PX // 2
+    assert img.getpixel((cx, cy))[:3] == (0, 0, 0)
+
+
+def test_killed_ship_past_move_renders_dark_square():
     sys.modules.pop("PIL", None)
     sys.modules.pop("game_board15.renderer", None)
     from PIL import Image
@@ -19,11 +43,11 @@ def test_killed_ship_renders_bomb():
     img = Image.open(buf)
     x = renderer.TILE_PX + 5
     y = renderer.TILE_PX + 5
-    expected = renderer.PLAYER_SHIP_COLORS_LIGHT.get(renderer.THEME, {}).get("A")
+    expected = renderer.PLAYER_SHIP_COLORS_DARK.get(renderer.THEME, {}).get("A")
     assert img.getpixel((x, y)) == expected
     cx = renderer.TILE_PX + renderer.TILE_PX // 2
     cy = renderer.TILE_PX + renderer.TILE_PX // 2
-    assert img.getpixel((cx, cy))[:3] == (0, 0, 0)
+    assert img.getpixel((cx, cy)) == expected
 
 
 def test_miss_renders_cross_without_fill():
@@ -45,3 +69,4 @@ def test_miss_renders_cross_without_fill():
     cy = y0 + renderer.TILE_PX // 2
     sample = (cx + 6, cy)
     assert img.getpixel(sample) == renderer.COLORS[renderer.THEME]["bg"]
+


### PR DESCRIPTION
## Summary
- Render destroyed ships as bombs only for the most recent move
- Show dark ship-colored squares once play continues
- Add tests for last-move bomb rendering and dark-square fallback

## Testing
- `pytest >/tmp/pytest.log && tail -n 20 /tmp/pytest.log`


------
https://chatgpt.com/codex/tasks/task_e_68b2f90128408326acc1cc04f0696d50