### PR TITLE
Use match-level last_highlight for shared board

### DIFF
--- a/handlers/board_test.py
+++ b/handlers/board_test.py
@@ -97,6 +97,19 @@ async def _auto_play_bots(
         enemy_boards = {k: match.boards[k] for k in enemies}
         results = battle.apply_shot_multi(coord, enemy_boards, match.history)
         match.shots[current]["last_coord"] = coord
+        if any(res == battle.KILL for res in results.values()):
+            cells: list[tuple[int, int]] = []
+            for enemy, res in results.items():
+                if res == battle.KILL:
+                    cells.extend(match.boards[enemy].highlight)
+            match.last_highlight = cells.copy()
+            match.shots[current]["last_result"] = "kill"
+        elif any(res == battle.HIT for res in results.values()):
+            match.last_highlight = [coord]
+            match.shots[current]["last_result"] = "hit"
+        else:
+            match.last_highlight = [coord]
+            match.shots[current]["last_result"] = "miss"
         for k in match.shots:
             shots = match.shots[k]
             shots.setdefault("move_count", 0)

--- a/models.py
+++ b/models.py
@@ -45,6 +45,7 @@ class Match:
     history: List[List[int]] = field(
         default_factory=lambda: [[0] * 10 for _ in range(10)]
     )
+    last_highlight: List[Coord] = field(default_factory=list)
     shots: Dict[str, Dict[str, object]] = field(
         default_factory=lambda: {
             k: {

--- a/storage.py
+++ b/storage.py
@@ -71,6 +71,7 @@ def get_match(match_id: str) -> Match | None:
         )
     match.turn = m.get('turn', 'A')
     match.history = m.get('history', [[0] * 10 for _ in range(10)])
+    match.last_highlight = [tuple(cell) for cell in m.get('last_highlight', [])]
     match.shots = m.get('shots', match.shots)
     match.messages = m.get('messages', {})
     return match
@@ -130,6 +131,7 @@ def save_board(match: Match, player_key: str, board: Board) -> None:
             current.shots = m_dict.get('shots', current.shots)
             current.messages = m_dict.get('messages', {})
             current.history = m_dict.get('history', [[0] * 10 for _ in range(10)])
+            current.last_highlight = [tuple(cell) for cell in m_dict.get('last_highlight', [])]
         else:
             current = match
 
@@ -156,6 +158,7 @@ def save_board(match: Match, player_key: str, board: Board) -> None:
             'shots': current.shots,
             'messages': current.messages,
             'history': current.history,
+            'last_highlight': current.last_highlight,
         }
         _save_all(data)
 
@@ -167,6 +170,7 @@ def save_board(match: Match, player_key: str, board: Board) -> None:
     match.shots = current.shots
     match.history = current.history
     match.messages = current.messages
+    match.last_highlight = current.last_highlight
 
 
 def finish(match: Match, winner: str) -> str | None:
@@ -202,6 +206,7 @@ def save_match(match: Match) -> str | None:
             "shots": match.shots,
             "messages": match.messages,
             "history": match.history,
+            "last_highlight": match.last_highlight,
         }
         return _save_all(data)
 

--- a/tests/test_board_test_last_highlight.py
+++ b/tests/test_board_test_last_highlight.py
@@ -1,0 +1,94 @@
+from types import SimpleNamespace
+
+import asyncio
+from types import SimpleNamespace
+
+from models import Board, Ship
+from handlers import router
+import storage
+from unittest.mock import AsyncMock
+
+
+def _new_grid():
+    return [[0] * 10 for _ in range(10)]
+
+
+def test_send_state_board_test_uses_match_highlight(monkeypatch):
+    async def run_test():
+        board = Board()
+        match = SimpleNamespace(
+            players={"A": SimpleNamespace(chat_id=1)},
+            messages={"A": {}},
+            history=_new_grid(),
+            boards={"A": board},
+            last_highlight=[(1, 1)],
+            shots={"A": {"last_coord": (2, 2)}},
+        )
+
+        captured = {}
+
+        def fake_render_board_own(b):
+            captured["highlight"] = b.highlight.copy()
+            return "board"
+
+        monkeypatch.setattr(router, "render_board_own", fake_render_board_own)
+        monkeypatch.setattr(router, "move_keyboard", lambda: None)
+        send_message = AsyncMock(return_value=SimpleNamespace(message_id=1))
+        bot = SimpleNamespace(send_message=send_message)
+        context = SimpleNamespace(bot=bot)
+        async def fast_sleep(t):
+            pass
+        monkeypatch.setattr(asyncio, "sleep", fast_sleep)
+        monkeypatch.setattr(storage, "save_match", lambda m: None)
+
+        await router._send_state_board_test(context, match, "A", "msg")
+
+        assert captured["highlight"] == [(1, 1)]
+
+    asyncio.run(run_test())
+
+
+def test_last_highlight_persists_after_kill(monkeypatch):
+    async def run_test():
+        board_self = Board()
+        board_enemy = Board()
+        ship = Ship(cells=[(0, 0)])
+        board_enemy.ships = [ship]
+        board_enemy.grid[0][0] = 1
+        board_enemy.alive_cells = 1
+        match = SimpleNamespace(
+            status="playing",
+            players={
+                "A": SimpleNamespace(user_id=1, chat_id=10, name="A"),
+                "B": SimpleNamespace(user_id=2, chat_id=20, name="B"),
+            },
+            boards={"A": board_self, "B": board_enemy},
+            turn="A",
+            shots={"A": {"history": [], "move_count": 0, "joke_start": 10}, "B": {}},
+            messages={"A": {}, "B": {}},
+            history=_new_grid(),
+            last_highlight=[],
+        )
+
+        monkeypatch.setattr(storage, "find_match_by_user", lambda uid, chat_id=None: match)
+        monkeypatch.setattr(storage, "save_match", lambda m: None)
+        monkeypatch.setattr(router, "parse_coord", lambda text: (0, 0))
+        monkeypatch.setattr(router, "format_coord", lambda coord: "a1")
+        monkeypatch.setattr(router, "_phrase_or_joke", lambda m, pk, ph: "")
+        monkeypatch.setattr(router, "_send_state_board_test", AsyncMock())
+
+        update = SimpleNamespace(
+            message=SimpleNamespace(text="a1", reply_text=AsyncMock()),
+            effective_user=SimpleNamespace(id=1),
+            effective_chat=SimpleNamespace(id=10),
+        )
+        context = SimpleNamespace(bot=SimpleNamespace(send_message=AsyncMock()), bot_data={})
+
+        await router.router_text_board_test(update, context)
+
+        assert match.last_highlight == [(0, 0)]
+        board_enemy.highlight.clear()
+        assert match.last_highlight == [(0, 0)]
+
+    asyncio.run(run_test())
+


### PR DESCRIPTION
## Summary
- unify shared board highlighting by tracking a match-level `last_highlight`
- update tests and storage to persist `last_highlight`
- add regression tests for the shared board highlight handling

## Testing
- `pytest tests/test_board_test_last_highlight.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b301acfaf883268a4305346e9c6aee