### PR TITLE
Clear stale board highlights before applying shots

### DIFF
--- a/game_board15/router.py
+++ b/game_board15/router.py
@@ -148,6 +148,9 @@ async def router_text(update: Update, context: ContextTypes.DEFAULT_TYPE) -> Non
         await update.message.reply_text('Здесь ваш корабль')
         return
 
+    for b in match.boards.values():
+        b.highlight = []
+
     results = {}
     hit_any = False
     repeat = False
@@ -193,6 +196,7 @@ async def router_text(update: Update, context: ContextTypes.DEFAULT_TYPE) -> Non
     else:
         match.last_highlight = [coord]
         match.shots[player_key]["last_result"] = "miss"
+    storage.save_match(match)
     for k in match.shots:
         shots = match.shots[k]
         shots.setdefault('move_count', 0)

--- a/handlers/router.py
+++ b/handlers/router.py
@@ -266,6 +266,9 @@ async def router_text(update: Update, context: ContextTypes.DEFAULT_TYPE) -> Non
         await _send_state(context, match, player_key, 'Не понял клетку. Пример: е5 или д10.')
         return
 
+    for b in match.boards.values():
+        b.highlight = []
+
     result = apply_shot(match.boards[enemy_key], coord)
     match.shots[player_key]['history'].append(text)
     match.shots[player_key]['last_result'] = result
@@ -414,6 +417,8 @@ async def router_text_board_test(update: Update, context: ContextTypes.DEFAULT_T
 
     enemies = [k for k in match.players.keys() if k != player_key and match.boards[k].alive_cells > 0]
     boards = {k: match.boards[k] for k in enemies}
+    for b in match.boards.values():
+        b.highlight = []
     results = apply_shot_multi(coord, boards, match.history)
     match.shots[player_key]['history'].append(text)
     match.shots[player_key]['last_coord'] = coord
@@ -430,6 +435,7 @@ async def router_text_board_test(update: Update, context: ContextTypes.DEFAULT_T
     else:
         match.last_highlight = [coord]
         match.shots[player_key]['last_result'] = 'miss'
+    storage.save_match(match)
     for k in match.shots:
         shots = match.shots.setdefault(k, {})
         shots.setdefault('move_count', 0)
@@ -482,8 +488,6 @@ async def router_text_board_test(update: Update, context: ContextTypes.DEFAULT_T
             enemy_msgs[enemy] = (
                 f"соперник стрелял по уже обстрелянной клетке. {phrase_enemy}"
             )
-
-    storage.save_match(match)
 
     next_label = getattr(match.players[next_player], 'name', '') or next_player
     next_phrase_self = f"Следующим ходит {next_label}."

--- a/tests/test_highlight_reset.py
+++ b/tests/test_highlight_reset.py
@@ -1,0 +1,96 @@
+import asyncio
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+from models import Board, Ship
+from handlers import router
+import storage
+
+from game_board15 import router as router15, storage as storage15
+from game_board15.models import Board15, Ship as Ship15
+from tests.utils import _new_grid
+
+
+def test_router_clears_player_highlight(monkeypatch):
+    async def run_test():
+        board_self = Board()
+        board_self.highlight = [(5, 5)]
+        board_enemy = Board()
+        ship = Ship(cells=[(0, 0)])
+        board_enemy.ships = [ship]
+        board_enemy.grid[0][0] = 1
+        board_enemy.alive_cells = 1
+        match = SimpleNamespace(
+            status="playing",
+            players={
+                "A": SimpleNamespace(user_id=1, chat_id=10, name="A"),
+                "B": SimpleNamespace(user_id=2, chat_id=20, name="B"),
+            },
+            boards={"A": board_self, "B": board_enemy},
+            turn="A",
+            shots={"A": {"history": [], "move_count": 0, "joke_start": 10}, "B": {}},
+            messages={"A": {}, "B": {}},
+        )
+
+        monkeypatch.setattr(storage, "find_match_by_user", lambda uid, chat_id=None: match)
+        monkeypatch.setattr(storage, "save_match", lambda m: None)
+        monkeypatch.setattr(router, "parse_coord", lambda text: (0, 0))
+        monkeypatch.setattr(router, "format_coord", lambda coord: "a1")
+        monkeypatch.setattr(router, "_phrase_or_joke", lambda m, pk, ph: "")
+        monkeypatch.setattr(router, "_send_state", AsyncMock())
+
+        update = SimpleNamespace(
+            message=SimpleNamespace(text="a1", reply_text=AsyncMock()),
+            effective_user=SimpleNamespace(id=1),
+            effective_chat=SimpleNamespace(id=10),
+        )
+        context = SimpleNamespace(bot=SimpleNamespace(send_message=AsyncMock()))
+
+        await router.router_text(update, context)
+
+        assert board_self.highlight == []
+
+    asyncio.run(run_test())
+
+
+def test_board15_router_clears_player_highlight(monkeypatch):
+    async def run_test():
+        board_self = Board15()
+        board_self.highlight = [(5, 5)]
+        board_enemy = Board15()
+        ship = Ship15(cells=[(0, 0)])
+        board_enemy.ships = [ship]
+        board_enemy.grid[0][0] = 1
+        board_enemy.alive_cells = 1
+        match = SimpleNamespace(
+            status="playing",
+            players={
+                "A": SimpleNamespace(user_id=1, chat_id=10, name="A"),
+                "B": SimpleNamespace(user_id=2, chat_id=20, name="B"),
+            },
+            boards={"A": board_self, "B": board_enemy},
+            turn="A",
+            shots={"A": {"history": [], "last_result": None, "move_count": 0, "joke_start": 10, "last_coord": None}, "B": {}},
+            messages={"A": {}, "B": {}},
+            history=_new_grid(15),
+        )
+
+        monkeypatch.setattr(storage15, "find_match_by_user", lambda uid, chat_id=None: match)
+        monkeypatch.setattr(storage15, "save_match", lambda m: None)
+        monkeypatch.setattr(router15.parser, "parse_coord", lambda text: (0, 0))
+        monkeypatch.setattr(router15.parser, "format_coord", lambda coord: "a1")
+        monkeypatch.setattr(router15, "_phrase_or_joke", lambda m, pk, ph: "")
+        monkeypatch.setattr(router15, "_send_state", AsyncMock())
+
+        update = SimpleNamespace(
+            message=SimpleNamespace(text="a1", reply_text=AsyncMock()),
+            effective_user=SimpleNamespace(id=1),
+            effective_chat=SimpleNamespace(id=10),
+        )
+        context = SimpleNamespace(bot=SimpleNamespace(send_message=AsyncMock()), bot_data={}, chat_data={})
+
+        await router15.router_text(update, context)
+
+        assert board_self.highlight == []
+
+    asyncio.run(run_test())


### PR DESCRIPTION
## Summary
- Reset all board highlights before processing shots in game and test routers
- Persist last highlighted cells after multi-board shots and ensure match state is saved
- Add tests validating highlight clearing for standard and 15x15 modes

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b306d1bf588326bd79429e9fbaedb1