### PR TITLE
Clear highlights before bot shots

### DIFF
--- a/game_board15/handlers.py
+++ b/game_board15/handlers.py
@@ -192,6 +192,8 @@ async def _auto_play_bots(
             break
         coord = random.choice(candidates)
         enemies = [k for k in alive if k != current]
+        for b in match.boards.values():
+            b.highlight = []
         results = {}
         hit_any = False
         for enemy in enemies:
@@ -205,6 +207,16 @@ async def _auto_play_bots(
             shot_hist.append({"coord": coord, "enemy": enemy, "result": res})
         battle.update_history(match.history, match.boards, coord, results)
         match.shots[current]["last_coord"] = coord
+        if any(res == battle.KILL for res in results.values()):
+            cells: list[tuple[int, int]] = []
+            for enemy, res in results.items():
+                if res == battle.KILL:
+                    cells.extend(match.boards[enemy].highlight)
+            match.last_highlight = cells.copy()
+        elif any(res == battle.HIT for res in results.values()):
+            match.last_highlight = [coord]
+        else:
+            match.last_highlight = [coord]
         for k in match.shots:
             shots = match.shots[k]
             shots.setdefault('move_count', 0)

--- a/handlers/board_test.py
+++ b/handlers/board_test.py
@@ -94,6 +94,8 @@ async def _auto_play_bots(
             break
 
         enemies = [k for k in alive if k != current]
+        for b in match.boards.values():
+            b.highlight = []
         enemy_boards = {k: match.boards[k] for k in enemies}
         results = battle.apply_shot_multi(coord, enemy_boards, match.history)
         match.shots[current]["last_coord"] = coord


### PR DESCRIPTION
## Summary
- reset board highlights before bot shots in board_test autoplay
- clear highlights and track last shot in board15 autoplay

## Testing
- `pytest` *(partial: process killed)*

------
https://chatgpt.com/codex/tasks/task_e_68b3122d7adc832688d1f079ada2a34a