### PR TITLE
Fix hanging auto-play bots test by yielding event loop

### DIFF
--- a/tests/test_board15_test_autoplay.py
+++ b/tests/test_board15_test_autoplay.py
@@ -173,11 +173,16 @@ def test_auto_play_bots_reports_hits(monkeypatch):
 
         async def fake_send_state(context, match_, player_key, message):
             calls.append((player_key, message))
+            # Yield control to the event loop so wait_for's timeout can trigger
+            await asyncio.sleep(0)
 
         monkeypatch.setattr(router, '_send_state', fake_send_state)
 
+        orig_sleep = asyncio.sleep
+
         async def fast_sleep(t):
-            pass
+            # Allow the event loop to run other tasks without real delay
+            await orig_sleep(0)
 
         monkeypatch.setattr(asyncio, 'sleep', fast_sleep)
 


### PR DESCRIPTION
## Summary
- Ensure the fake `_send_state` coroutine yields control to the event loop
- Patch `asyncio.sleep` to avoid real delays while still yielding

## Testing
- `pytest tests/test_board15_test_autoplay.py::test_auto_play_bots_reports_hits -q`

------
https://chatgpt.com/codex/tasks/task_e_68b31b486640832695b0403b643f3b77