### PR TITLE
Ensure auto bot moves persist highlight

### DIFF
--- a/game_board15/handlers.py
+++ b/game_board15/handlers.py
@@ -213,8 +213,6 @@ async def _auto_play_bots(
                 if res == battle.KILL:
                     cells.extend(match.boards[enemy].highlight)
             match.last_highlight = cells.copy()
-        elif any(res == battle.HIT for res in results.values()):
-            match.last_highlight = [coord]
         else:
             match.last_highlight = [coord]
         for k in match.shots:
@@ -231,6 +229,8 @@ async def _auto_play_bots(
         else:
             next_player = current
         match.turn = next_player
+
+        storage.save_match(match)
 
         parts_self: list[str] = []
         watch_parts: list[str] = []


### PR DESCRIPTION
## Summary
- Build `last_highlight` from killed ship cells or the shot coordinate in `_auto_play_bots`
- Save the match before sending state so highlights are visible

## Testing
- `pytest tests/test_board15_bot_elimination.py tests/test_board15_test_autoplay.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b31e42a5408326956cb9aadea12e6b