### PR TITLE
Highlight bomb only when selected

### DIFF
--- a/game_board15/renderer.py
+++ b/game_board15/renderer.py
@@ -84,7 +84,7 @@ CELL_STYLE = {
     1: ("square", "ship"),
     2: ("cross", "miss"),
     3: ("square", "hit"),
-    4: ("bomb", "destroyed"),
+    4: ("square", "destroyed"),
     # Cells adjacent to a destroyed ship are marked as a cross so they look
     # the same as already shot cells on the board.
     5: ("cross", "miss"),
@@ -123,11 +123,14 @@ def render_board(state: Board15State, player_key: str | None = None) -> BytesIO:
             if coord in highlight:
                 if val in (2, 5):
                     color = COLORS[THEME]["mark"]
-                elif val == 4 and owner:
+                elif val == 4:
                     shape = "bomb"
-                    color = PLAYER_SHIP_COLORS_LIGHT.get(
-                        THEME, {}
-                    ).get(owner, COLORS[THEME]["destroyed"])
+                    if owner:
+                        color = PLAYER_SHIP_COLORS_LIGHT.get(
+                            THEME, {}
+                        ).get(owner, COLORS[THEME]["destroyed"])
+                    else:
+                        color = COLORS[THEME]["destroyed"]
                 else:
                     color = COLORS[THEME]["mark"]
             else:
@@ -135,11 +138,14 @@ def render_board(state: Board15State, player_key: str | None = None) -> BytesIO:
                     color = PLAYER_SHIP_COLORS.get(THEME, {}).get(owner, COLORS[THEME]["ship"])
                 elif val == 3:
                     color = COLORS[THEME]["hit"]
-                elif val == 4 and owner:
+                elif val == 4:
                     shape = "square"
-                    color = PLAYER_SHIP_COLORS_DARK.get(
-                        THEME, {}
-                    ).get(owner, COLORS[THEME]["destroyed"])
+                    if owner:
+                        color = PLAYER_SHIP_COLORS_DARK.get(
+                            THEME, {}
+                        ).get(owner, COLORS[THEME]["destroyed"])
+                    else:
+                        color = COLORS[THEME]["destroyed"]
                 elif val in (2, 5):
                     color = COLORS[THEME]["miss"]
                 else:
@@ -234,11 +240,14 @@ def render_player_board(board: Board15, player_key: str | None = None) -> BytesI
             if coord in highlight:
                 if val in (2, 5):
                     color = COLORS[THEME]["mark"]
-                elif val == 4 and player_key:
+                elif val == 4:
                     shape = "bomb"
-                    color = PLAYER_SHIP_COLORS_LIGHT.get(
-                        THEME, {}
-                    ).get(player_key, COLORS[THEME]["destroyed"])
+                    if player_key:
+                        color = PLAYER_SHIP_COLORS_LIGHT.get(
+                            THEME, {}
+                        ).get(player_key, COLORS[THEME]["destroyed"])
+                    else:
+                        color = COLORS[THEME]["destroyed"]
                 else:
                     color = COLORS[THEME]["mark"]
             else:
@@ -246,11 +255,14 @@ def render_player_board(board: Board15, player_key: str | None = None) -> BytesI
                     color = PLAYER_SHIP_COLORS.get(THEME, {}).get(player_key, COLORS[THEME]["ship"])
                 elif val == 3:
                     color = COLORS[THEME]["hit"]
-                elif val == 4 and player_key:
+                elif val == 4:
                     shape = "square"
-                    color = PLAYER_SHIP_COLORS_DARK.get(
-                        THEME, {}
-                    ).get(player_key, COLORS[THEME]["destroyed"])
+                    if player_key:
+                        color = PLAYER_SHIP_COLORS_DARK.get(
+                            THEME, {}
+                        ).get(player_key, COLORS[THEME]["destroyed"])
+                    else:
+                        color = COLORS[THEME]["destroyed"]
                 elif val in (2, 5):
                     color = COLORS[THEME]["miss"]
                 else:

--- a/logic/render.py
+++ b/logic/render.py
@@ -79,7 +79,10 @@ def render_board_own(board: Board) -> str:
             elif cell_state == 3:
                 sym = '<span style="color:#8b0000">■</span>'
             elif cell_state == 4:
-                sym = '💣'
+                if coord in highlight:
+                    sym = '💣'
+                else:
+                    sym = '<span style="color:#8b0000">■</span>'
             else:
                 sym = '·'
             if coord in highlight:
@@ -110,7 +113,10 @@ def render_board_enemy(board: Board) -> str:
             elif cell_state == 3:
                 sym = '<span style="color:#8b0000">■</span>'
             elif cell_state == 4:
-                sym = '💣'
+                if coord in highlight:
+                    sym = '💣'
+                else:
+                    sym = '<span style="color:#8b0000">■</span>'
             else:
                 sym = '·'
             if coord in highlight:

--- a/tests/test_render.py
+++ b/tests/test_render.py
@@ -46,14 +46,25 @@ def test_render_last_move_symbols():
     # kill highlight
     b.grid[2][2] = [4, 'B']
     b.grid[2][3] = [5, 'B']
+
+    # highlight the kill cell
+    b.highlight = [(2, 2)]
+    enemy = render_board_enemy(b)
+    assert enemy.count('💣') == 1
+    assert enemy.count("border:1px solid red") == 1
+
+    # highlight the contour cell
     b.highlight = [(2, 3)]
     enemy = render_board_enemy(b)
-    assert enemy.count('💣') >= 1
+    assert '💣' not in enemy
     assert enemy.count('background-color:orange') >= 1
     assert enemy.count("border:1px solid red") == 1
+
+    # no highlight
     b.highlight = []
     enemy = render_board_enemy(b)
-    assert enemy.count('💣') >= 1 and "border:1px solid red" not in enemy
+    assert '💣' not in enemy and "border:1px solid red" not in enemy
+    assert '<span style="color:#8b0000">■</span>' in enemy
     assert '<span style="color:black">x</span>' in enemy
 
 


### PR DESCRIPTION
## Summary
- Show bomb emoji for destroyed cells only when the cell is highlighted
- Default destroyed cells to a red square marker
- Update image renderer and tests for new highlight behavior

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b3223f8ca083268df903c58c852c22