### PR TITLE
Handle asyncio cancellation to avoid test hangs

### DIFF
--- a/game_board15/handlers.py
+++ b/game_board15/handlers.py
@@ -97,6 +97,8 @@ async def _auto_play_bots(
     async def _safe_send_state(player_key: str, message: str) -> None:
         try:
             await router_module._send_state(context, match, player_key, message)
+        except asyncio.CancelledError:
+            raise
         except Exception:
             logger.exception("Failed to send state to %s", player_key)
             human_player = match.players.get(human)
@@ -114,6 +116,8 @@ async def _auto_play_bots(
                     hist = msgs.setdefault("text_history", [])
                     hist.append(msg.message_id)
                     msgs["text"] = msg.message_id
+                except asyncio.CancelledError:
+                    raise
                 except Exception:
                     logger.exception(
                         "Failed to notify human about state send failure"
@@ -122,6 +126,8 @@ async def _auto_play_bots(
     async def _safe_send_message(chat_id: int, text: str) -> None:
         try:
             await context.bot.send_message(chat_id, text)
+        except asyncio.CancelledError:
+            raise
         except Exception:
             logger.exception("Failed to send message to chat %s", chat_id)
             human_player = match.players.get(human)
@@ -131,6 +137,8 @@ async def _auto_play_bots(
                         human_player.chat_id,
                         "Не удалось отправить сообщение участнику",
                     )
+                except asyncio.CancelledError:
+                    raise
                 except Exception:
                     logger.exception(
                         "Failed to notify human about message send failure"

--- a/game_board15/router.py
+++ b/game_board15/router.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 import logging
 import random
+import asyncio
 from telegram import Update
 from telegram.ext import ContextTypes
 
@@ -57,6 +58,8 @@ async def _send_state(context: ContextTypes.DEFAULT_TYPE, match, player_key: str
     try:
         buf.seek(0)
         msg_board = await context.bot.send_photo(chat_id, buf)
+    except asyncio.CancelledError:
+        raise
     except Exception:
         logger.exception("Failed to send board image for chat %s", chat_id)
         return
@@ -69,6 +72,8 @@ async def _send_state(context: ContextTypes.DEFAULT_TYPE, match, player_key: str
     # send result text message
     try:
         msg_text = await context.bot.send_message(chat_id, message)
+    except asyncio.CancelledError:
+        raise
     except Exception:
         logger.exception("Failed to send text message for chat %s", chat_id)
         return

--- a/handlers/board_test.py
+++ b/handlers/board_test.py
@@ -49,12 +49,16 @@ async def _auto_play_bots(
 
         try:
             await router_module._send_state_board_test(context, match, player_key, message)
+        except asyncio.CancelledError:
+            raise
         except Exception:
             logger.exception("Failed to send state to %s", player_key)
 
     async def _safe_send_message(chat_id_: int, text: str) -> None:
         try:
             await context.bot.send_message(chat_id_, text)
+        except asyncio.CancelledError:
+            raise
         except Exception:
             logger.exception("Failed to send message to chat %s", chat_id_)
 

--- a/handlers/router.py
+++ b/handlers/router.py
@@ -55,6 +55,8 @@ async def _send_state(
     if board_id:
         try:
             await context.bot.delete_message(chat_id, board_id)
+        except asyncio.CancelledError:
+            raise
         except Exception:
             pass
     board_msg = await context.bot.send_message(
@@ -76,9 +78,13 @@ async def _send_state(
                 text=message,
                 parse_mode="HTML",
             )
+        except asyncio.CancelledError:
+            raise
         except Exception:
             try:
                 await context.bot.delete_message(chat_id, text_id)
+            except asyncio.CancelledError:
+                raise
             except Exception:
                 pass
             text_msg = await context.bot.send_message(
@@ -126,6 +132,8 @@ async def _send_state_board_test(
     if board_id:
         try:
             await context.bot.delete_message(chat_id, board_id)
+        except asyncio.CancelledError:
+            raise
         except Exception:
             pass
     board_msg = await context.bot.send_message(
@@ -146,9 +154,13 @@ async def _send_state_board_test(
                 text=message,
                 parse_mode="HTML",
             )
+        except asyncio.CancelledError:
+            raise
         except Exception:
             try:
                 await context.bot.delete_message(chat_id, text_id)
+            except asyncio.CancelledError:
+                raise
             except Exception:
                 pass
             text_msg = await context.bot.send_message(
@@ -366,6 +378,8 @@ async def router_text(update: Update, context: ContextTypes.DEFAULT_TYPE) -> Non
             if msg_id:
                 try:
                     await context.bot.delete_message(chat_id, msg_id)
+                except asyncio.CancelledError:
+                    raise
                 except Exception:
                     pass
         result_shared = result_self.replace('Ваш ход:', f'Ход игрока {player_label}:')


### PR DESCRIPTION
## Summary
- Propagate `asyncio.CancelledError` in board15 helpers so background bot tasks can stop cleanly
- Ensure router helpers abort on cancellation when sending photos or messages
- Apply the same cancellation handling to classic board test utilities

## Testing
- `pytest -q` *(fails: KeyboardInterrupt)*

------
https://chatgpt.com/codex/tasks/task_e_68b325c8b7948326bb4202d27dec560b