### PR TITLE
Add default miss message for board15 watchers

### DIFF
--- a/game_board15/handlers.py
+++ b/game_board15/handlers.py
@@ -268,7 +268,7 @@ async def _auto_play_bots(
                         f"⛔ Игрок {enemy_label} выбыл (флот уничтожен)",
                     )
         enemy_msgs[current] = ' '.join(parts_self) if parts_self else 'мимо'
-        watch_msg = ' '.join(watch_parts)
+        watch_msg = ' '.join(watch_parts).strip() or 'мимо'
         for pk in match.players:
             enemy_msgs.setdefault(pk, watch_msg)
 

--- a/game_board15/router.py
+++ b/game_board15/router.py
@@ -254,7 +254,7 @@ async def router_text(update: Update, context: ContextTypes.DEFAULT_TYPE) -> Non
     else:
         phrase_self = _phrase_or_joke(match, player_key, SELF_MISS)
 
-    msg_watch = ' '.join(watch_parts)
+    msg_watch = ' '.join(watch_parts).strip() or 'мимо'
     others = [
         k
         for k in match.players

--- a/tests/test_board15_router.py
+++ b/tests/test_board15_router.py
@@ -408,7 +408,7 @@ def test_router_notifies_next_player_on_miss(monkeypatch):
 
         b_msgs = [c for c in send_message.call_args_list if c.args[0] == 20]
         assert b_msgs and b_msgs[0].args[1].endswith('Следующим ходит B.')
-        assert 'a1 - мимо' not in b_msgs[0].args[1]
+        assert 'a1 - мимо' in b_msgs[0].args[1]
 
     asyncio.run(run_test())
 


### PR DESCRIPTION
## Summary
- ensure watchers see `мимо` when a shot has no notable events in router and handlers
- update tests for new watcher message

## Testing
- `pytest tests/test_router_text.py tests/test_board15_router.py`

------
https://chatgpt.com/codex/tasks/task_e_68b329e9de88832689bd928f5ef3fc77