### PR TITLE
Use orange color for orange player's hits

### DIFF
--- a/game_board15/renderer.py
+++ b/game_board15/renderer.py
@@ -137,7 +137,10 @@ def render_board(state: Board15State, player_key: str | None = None) -> BytesIO:
                 if val == 1 and owner:
                     color = PLAYER_SHIP_COLORS.get(THEME, {}).get(owner, COLORS[THEME]["ship"])
                 elif val == 3:
-                    color = COLORS[THEME]["hit"]
+                    if owner == "C":
+                        color = PLAYER_SHIP_COLORS_DARK.get(THEME, {}).get("C", COLORS[THEME]["hit"])
+                    else:
+                        color = COLORS[THEME]["hit"]
                 elif val == 4:
                     shape = "square"
                     if owner:
@@ -254,7 +257,10 @@ def render_player_board(board: Board15, player_key: str | None = None) -> BytesI
                 if val == 1 and player_key:
                     color = PLAYER_SHIP_COLORS.get(THEME, {}).get(player_key, COLORS[THEME]["ship"])
                 elif val == 3:
-                    color = COLORS[THEME]["hit"]
+                    if player_key == "C":
+                        color = PLAYER_SHIP_COLORS_DARK.get(THEME, {}).get("C", COLORS[THEME]["hit"])
+                    else:
+                        color = COLORS[THEME]["hit"]
                 elif val == 4:
                     shape = "square"
                     if player_key:

--- a/logic/render.py
+++ b/logic/render.py
@@ -77,12 +77,14 @@ def render_board_own(board: Board) -> str:
                 else:
                     sym = '<span style="color:black">x</span>'
             elif cell_state == 3:
-                sym = '<span style="color:#8b0000">■</span>'
+                hit_color = "#ff8c00" if owner == "C" else "#8b0000"
+                sym = f'<span style="color:{hit_color}">■</span>'
             elif cell_state == 4:
                 if coord in highlight:
                     sym = '💣'
                 else:
-                    sym = '<span style="color:#8b0000">■</span>'
+                    hit_color = "#ff8c00" if owner == "C" else "#8b0000"
+                    sym = f'<span style="color:{hit_color}">■</span>'
             else:
                 sym = '·'
             if coord in highlight:
@@ -111,12 +113,14 @@ def render_board_enemy(board: Board) -> str:
                 else:
                     sym = '<span style="color:black">x</span>'
             elif cell_state == 3:
-                sym = '<span style="color:#8b0000">■</span>'
+                hit_color = "#ff8c00" if owner == "C" else "#8b0000"
+                sym = f'<span style="color:{hit_color}">■</span>'
             elif cell_state == 4:
                 if coord in highlight:
                     sym = '💣'
                 else:
-                    sym = '<span style="color:#8b0000">■</span>'
+                    hit_color = "#ff8c00" if owner == "C" else "#8b0000"
+                    sym = f'<span style="color:{hit_color}">■</span>'
             else:
                 sym = '·'
             if coord in highlight:

--- a/tests/test_board15_renderer.py
+++ b/tests/test_board15_renderer.py
@@ -70,3 +70,24 @@ def test_miss_renders_cross_without_fill():
     sample = (cx + 6, cy)
     assert img.getpixel(sample) == renderer.COLORS[renderer.THEME]["bg"]
 
+
+def test_hit_orange_player_renders_dark_orange():
+    sys.modules.pop("PIL", None)
+    sys.modules.pop("game_board15.renderer", None)
+    from PIL import Image
+    renderer = importlib.import_module("game_board15.renderer")
+    from game_board15.state import Board15State
+
+    board = [[0] * 15 for _ in range(15)]
+    owners = [[None] * 15 for _ in range(15)]
+    board[0][0] = 3
+    owners[0][0] = "C"
+    state = Board15State(board=board, owners=owners)
+    buf = renderer.render_board(state)
+
+    img = Image.open(buf)
+    x = renderer.TILE_PX + 5
+    y = renderer.TILE_PX + 5
+    expected = renderer.PLAYER_SHIP_COLORS_DARK.get(renderer.THEME, {}).get("C")
+    assert img.getpixel((x, y)) == expected
+

--- a/tests/test_render.py
+++ b/tests/test_render.py
@@ -18,6 +18,13 @@ def test_render_board_enemy_marks_hit_dark_red():
     assert "#8b0000" in enemy
 
 
+def test_render_board_enemy_marks_hit_orange_player():
+    b = Board(owner='C')
+    b.grid[0][0] = 3
+    enemy = render_board_enemy(b)
+    assert "#ff8c00" in enemy
+
+
 def test_render_last_move_symbols():
     b = Board()
     b.grid = _new_grid()


### PR DESCRIPTION
## Summary
- Show orange player's hit cells in saturated orange instead of maroon in text renderer
- Paint image renderer hit cells for orange player in dark orange
- Add tests for new color in both renderers

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b32d26231483269789c3393fb7dbe4