### PR TITLE
Use player-specific hit colors

### DIFF
--- a/game_board15/renderer.py
+++ b/game_board15/renderer.py
@@ -137,8 +137,10 @@ def render_board(state: Board15State, player_key: str | None = None) -> BytesIO:
                 if val == 1 and owner:
                     color = PLAYER_SHIP_COLORS.get(THEME, {}).get(owner, COLORS[THEME]["ship"])
                 elif val == 3:
-                    if owner == "C":
-                        color = PLAYER_SHIP_COLORS_DARK.get(THEME, {}).get("C", COLORS[THEME]["hit"])
+                    if owner:
+                        color = PLAYER_SHIP_COLORS_DARK.get(THEME, {}).get(
+                            owner, COLORS[THEME]["hit"]
+                        )
                     else:
                         color = COLORS[THEME]["hit"]
                 elif val == 4:

--- a/logic/render.py
+++ b/logic/render.py
@@ -22,6 +22,13 @@ PLAYER_COLORS = {
     "C": "#ffc88c",  # light orange
 }
 
+# darker colours for hit cells per player
+PLAYER_COLORS_DARK = {
+    "A": "#00008b",  # dark blue
+    "B": "#228b22",  # dark green
+    "C": "#ff8c00",  # dark orange
+}
+
 
 def format_cell(symbol: str) -> str:
     """Pad cell contents so that the board remains aligned.
@@ -77,7 +84,12 @@ def render_board_own(board: Board) -> str:
                 else:
                     sym = '<span style="color:black">x</span>'
             elif cell_state == 3:
-                hit_color = "#ff8c00" if owner == "C" else "#8b0000"
+                if coord in highlight:
+                    hit_color = "#8b0000"
+                else:
+                    hit_color = PLAYER_COLORS_DARK.get(
+                        owner or getattr(board, "owner", None), "#8b0000"
+                    )
                 sym = f'<span style="color:{hit_color}">■</span>'
             elif cell_state == 4:
                 if coord in highlight:
@@ -113,7 +125,12 @@ def render_board_enemy(board: Board) -> str:
                 else:
                     sym = '<span style="color:black">x</span>'
             elif cell_state == 3:
-                hit_color = "#ff8c00" if owner == "C" else "#8b0000"
+                if coord in highlight:
+                    hit_color = "#8b0000"
+                else:
+                    hit_color = PLAYER_COLORS_DARK.get(
+                        owner or getattr(board, "owner", None), "#8b0000"
+                    )
                 sym = f'<span style="color:{hit_color}">■</span>'
             elif cell_state == 4:
                 if coord in highlight:

--- a/tests/test_board15_renderer.py
+++ b/tests/test_board15_renderer.py
@@ -1,5 +1,6 @@
 import sys
 import importlib
+import pytest
 
 
 def test_killed_ship_last_move_renders_bomb():
@@ -89,5 +90,27 @@ def test_hit_orange_player_renders_dark_orange():
     x = renderer.TILE_PX + 5
     y = renderer.TILE_PX + 5
     expected = renderer.PLAYER_SHIP_COLORS_DARK.get(renderer.THEME, {}).get("C")
+    assert img.getpixel((x, y)) == expected
+
+
+@pytest.mark.parametrize("owner", ["A", "B"])
+def test_hit_player_renders_dark_color(owner):
+    sys.modules.pop("PIL", None)
+    sys.modules.pop("game_board15.renderer", None)
+    from PIL import Image
+    renderer = importlib.import_module("game_board15.renderer")
+    from game_board15.state import Board15State
+
+    board = [[0] * 15 for _ in range(15)]
+    owners = [[None] * 15 for _ in range(15)]
+    board[0][0] = 3
+    owners[0][0] = owner
+    state = Board15State(board=board, owners=owners)
+    buf = renderer.render_board(state)
+
+    img = Image.open(buf)
+    x = renderer.TILE_PX + 5
+    y = renderer.TILE_PX + 5
+    expected = renderer.PLAYER_SHIP_COLORS_DARK.get(renderer.THEME, {}).get(owner)
     assert img.getpixel((x, y)) == expected
 

--- a/tests/test_render.py
+++ b/tests/test_render.py
@@ -1,4 +1,10 @@
-from logic.render import render_board_own, render_board_enemy, PLAYER_COLORS
+import pytest
+from logic.render import (
+    render_board_own,
+    render_board_enemy,
+    PLAYER_COLORS,
+    PLAYER_COLORS_DARK,
+)
 from logic.battle import apply_shot, KILL
 from models import Board, Ship
 from tests.utils import _new_grid, _state
@@ -9,20 +15,19 @@ def test_render_board_own_uses_board_owner_color():
     b.grid[0][0] = 1
     own = render_board_own(b)
     assert PLAYER_COLORS['A'] in own
-
-
-def test_render_board_enemy_marks_hit_dark_red():
-    b = Board(owner='B')
+@pytest.mark.parametrize(
+    "owner, expected",
+    [
+        ("A", PLAYER_COLORS_DARK["A"]),
+        ("B", PLAYER_COLORS_DARK["B"]),
+        ("C", PLAYER_COLORS_DARK["C"]),
+    ],
+)
+def test_render_board_enemy_marks_hit_player_color(owner, expected):
+    b = Board(owner=owner)
     b.grid[0][0] = 3
     enemy = render_board_enemy(b)
-    assert "#8b0000" in enemy
-
-
-def test_render_board_enemy_marks_hit_orange_player():
-    b = Board(owner='C')
-    b.grid[0][0] = 3
-    enemy = render_board_enemy(b)
-    assert "#ff8c00" in enemy
+    assert expected in enemy
 
 
 def test_render_last_move_symbols():
@@ -48,7 +53,7 @@ def test_render_last_move_symbols():
     assert "border:1px solid red" in enemy and "#8b0000" in enemy
     b.highlight = []
     enemy = render_board_enemy(b)
-    assert "border:1px solid red" not in enemy and "#8b0000" in enemy
+    assert "border:1px solid red" not in enemy and PLAYER_COLORS_DARK['B'] in enemy
 
     # kill highlight
     b.grid[2][2] = [4, 'B']


### PR DESCRIPTION
## Summary
- add player dark color palette and apply for hit cells
- draw 15x15 board hits using owner dark colors
- cover player-specific hit colors with tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b34205f6448326bbd4cb682f245898