### PR TITLE
Replace crosses with dots and reduce bot delay

### DIFF
--- a/game_board15/handlers.py
+++ b/game_board15/handlers.py
@@ -382,7 +382,7 @@ async def board15_test(update: Update, context: ContextTypes.DEFAULT_TYPE) -> No
     storage.save_match(match)
     asyncio.create_task(
         _auto_play_bots(
-            match, context, update.effective_chat.id, human='A', delay=6
+            match, context, update.effective_chat.id, human='A', delay=4
         )
     )
 

--- a/game_board15/renderer.py
+++ b/game_board15/renderer.py
@@ -82,12 +82,12 @@ PLAYER_SHIP_COLORS_LIGHT = {
 
 CELL_STYLE = {
     1: ("square", "ship"),
-    2: ("cross", "miss"),
+    2: ("dot", "miss"),
     3: ("square", "hit"),
     4: ("square", "destroyed"),
-    # Cells adjacent to a destroyed ship are marked as a cross so they look
+    # Cells adjacent to a destroyed ship are marked as a dot so they look
     # the same as already shot cells on the board.
-    5: ("cross", "miss"),
+    5: ("dot", "miss"),
 }
 
 

--- a/handlers/board_test.py
+++ b/handlers/board_test.py
@@ -254,6 +254,6 @@ async def board_test(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None
     )
     asyncio.create_task(
         _auto_play_bots(
-            match, context, update.effective_chat.id, human="A", delay=6
+            match, context, update.effective_chat.id, human="A", delay=4
         )
     )

--- a/tests/test_board15_renderer.py
+++ b/tests/test_board15_renderer.py
@@ -51,7 +51,7 @@ def test_killed_ship_past_move_renders_dark_square():
     assert img.getpixel((cx, cy)) == expected
 
 
-def test_miss_renders_cross_without_fill():
+def test_miss_renders_dot():
     sys.modules.pop("PIL", None)
     sys.modules.pop("game_board15.renderer", None)
     from PIL import Image
@@ -68,6 +68,7 @@ def test_miss_renders_cross_without_fill():
     y0 = renderer.TILE_PX
     cx = x0 + renderer.TILE_PX // 2
     cy = y0 + renderer.TILE_PX // 2
+    assert img.getpixel((cx, cy)) == renderer.COLORS[renderer.THEME]["miss"]
     sample = (cx + 6, cy)
     assert img.getpixel(sample) == renderer.COLORS[renderer.THEME]["bg"]
 


### PR DESCRIPTION
## Summary
- Use dots instead of crosses when rendering misses on the 15x15 board
- Lower autoplay bot move delay to 4 seconds in test modes

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68b34efc07e08326b61595e275ed3b5d