### PR TITLE
Refactor bomb emoji into shared constant

### DIFF
--- a/constants.py
+++ b/constants.py
@@ -1,0 +1,1 @@
+BOMB = '\N{BOMB}'

--- a/game_board15/renderer.py
+++ b/game_board15/renderer.py
@@ -5,6 +5,7 @@ from io import BytesIO
 
 from PIL import Image, ImageDraw, ImageFont
 
+from constants import BOMB
 from .state import Board15State
 from .models import Board15
 
@@ -182,7 +183,7 @@ def render_board(state: Board15State, player_key: str | None = None) -> BytesIO:
                     bomb_font = ImageFont.truetype(FONT_PATH, int(TILE_PX * 0.8))
                 except OSError:
                     bomb_font = ImageFont.load_default()
-                draw.text((cx, cy), "💣", fill=(0, 0, 0, 255), anchor="mm", font=bomb_font)
+                draw.text((cx, cy), BOMB, fill=(0, 0, 0, 255), anchor="mm", font=bomb_font)
                 draw.point((cx, cy), fill=(0, 0, 0, 255))
             elif shape == "dot":
                 cx = x0 + TILE_PX // 2
@@ -302,7 +303,7 @@ def render_player_board(board: Board15, player_key: str | None = None) -> BytesI
                     bomb_font = ImageFont.truetype(FONT_PATH, int(TILE_PX * 0.8))
                 except OSError:
                     bomb_font = ImageFont.load_default()
-                draw.text((cx, cy), "💣", fill=(0, 0, 0, 255), anchor="mm", font=bomb_font)
+                draw.text((cx, cy), BOMB, fill=(0, 0, 0, 255), anchor="mm", font=bomb_font)
                 draw.point((cx, cy), fill=(0, 0, 0, 255))
             elif shape == "dot":
                 cx = x0 + TILE_PX // 2

--- a/logic/render.py
+++ b/logic/render.py
@@ -5,6 +5,7 @@ import re
 from models import Board
 from logic.parser import LATIN
 from wcwidth import wcswidth
+from constants import BOMB
 
 
 # figure space keeps alignment even when clients collapse regular spaces
@@ -93,7 +94,7 @@ def render_board_own(board: Board) -> str:
                 sym = f'<span style="color:{hit_color}">■</span>'
             elif cell_state == 4:
                 if coord in highlight:
-                    sym = '💣'
+                    sym = BOMB
                 else:
                     hit_color = "#ff8c00" if owner == "C" else "#8b0000"
                     sym = f'<span style="color:{hit_color}">■</span>'
@@ -134,7 +135,7 @@ def render_board_enemy(board: Board) -> str:
                 sym = f'<span style="color:{hit_color}">■</span>'
             elif cell_state == 4:
                 if coord in highlight:
-                    sym = '💣'
+                    sym = BOMB
                 else:
                     hit_color = "#ff8c00" if owner == "C" else "#8b0000"
                     sym = f'<span style="color:{hit_color}">■</span>'

--- a/tests/test_render.py
+++ b/tests/test_render.py
@@ -8,6 +8,7 @@ from logic.render import (
 from logic.battle import apply_shot, KILL
 from models import Board, Ship
 from tests.utils import _new_grid, _state
+from constants import BOMB
 
 
 def test_render_board_own_uses_board_owner_color():
@@ -62,20 +63,20 @@ def test_render_last_move_symbols():
     # highlight the kill cell
     b.highlight = [(2, 2)]
     enemy = render_board_enemy(b)
-    assert enemy.count('💣') == 1
+    assert enemy.count(BOMB) == 1
     assert enemy.count("border:1px solid red") == 1
 
     # highlight the contour cell
     b.highlight = [(2, 3)]
     enemy = render_board_enemy(b)
-    assert '💣' not in enemy
+    assert BOMB not in enemy
     assert enemy.count('background-color:orange') >= 1
     assert enemy.count("border:1px solid red") == 1
 
     # no highlight
     b.highlight = []
     enemy = render_board_enemy(b)
-    assert '💣' not in enemy and "border:1px solid red" not in enemy
+    assert BOMB not in enemy and "border:1px solid red" not in enemy
     assert '<span style="color:#8b0000">■</span>' in enemy
     assert '<span style="color:black">x</span>' in enemy
 


### PR DESCRIPTION
## Summary
- Introduce `BOMB` constant for bomb emoji
- Use shared `BOMB` in renderers to avoid hardcoded emoji
- Update tests to reference `BOMB` constant

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b34d95a7148326a5a5189c8ffc85ab