### PR TITLE
Prevent firing on already shot cells

### DIFF
--- a/game_board15/router.py
+++ b/game_board15/router.py
@@ -156,6 +156,11 @@ async def router_text(update: Update, context: ContextTypes.DEFAULT_TYPE) -> Non
     for b in match.boards.values():
         b.highlight = []
 
+    state = _get_cell_state(match.history[r][c])
+    if state in {2, 3, 4, 5}:
+        await update.message.reply_text('Эта клетка уже обстреляна')
+        return
+
     results = {}
     hit_any = False
     repeat = False
@@ -167,7 +172,7 @@ async def router_text(update: Update, context: ContextTypes.DEFAULT_TYPE) -> Non
         elif res in (battle.HIT, battle.KILL):
             hit_any = True
     if repeat:
-        await update.message.reply_text('Эта клетка уже открыта')
+        await update.message.reply_text('Эта клетка уже обстреляна')
         return
 
     if match.players[player_key].user_id != 0:

--- a/tests/test_board15_router.py
+++ b/tests/test_board15_router.py
@@ -588,7 +588,7 @@ def test_router_repeat_shot(monkeypatch):
 
         await router.router_text(update, context)
 
-        update.message.reply_text.assert_called_once_with('Эта клетка уже открыта')
+        update.message.reply_text.assert_called_once_with('Эта клетка уже обстреляна')
         assert not send_state.called
         assert match.turn == 'A'
         assert match.shots['A']['move_count'] == 0


### PR DESCRIPTION
## Summary
- Ensure router checks history grid before applying a shot
- Reword repeat-shot message to 'Эта клетка уже обстреляна'
- Update tests for revised message

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b353b043408326ab21592b6f097c50