### PR TITLE
Reduce bot delay in test mode to 3 seconds

### DIFF
--- a/game_board15/handlers.py
+++ b/game_board15/handlers.py
@@ -382,7 +382,7 @@ async def board15_test(update: Update, context: ContextTypes.DEFAULT_TYPE) -> No
     storage.save_match(match)
     asyncio.create_task(
         _auto_play_bots(
-            match, context, update.effective_chat.id, human='A', delay=4
+            match, context, update.effective_chat.id, human='A', delay=3
         )
     )
 

--- a/handlers/board_test.py
+++ b/handlers/board_test.py
@@ -254,6 +254,6 @@ async def board_test(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None
     )
     asyncio.create_task(
         _auto_play_bots(
-            match, context, update.effective_chat.id, human="A", delay=4
+            match, context, update.effective_chat.id, human="A", delay=3
         )
     )


### PR DESCRIPTION
## Summary
- shorten bot wait before each move in test battles to 3 seconds

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b35d4041d88326b16f2283411cd1a0