### PR TITLE
feat: announce eliminations and winners

### DIFF
--- a/tests/test_board15_bot_elimination.py
+++ b/tests/test_board15_bot_elimination.py
@@ -47,7 +47,8 @@ def test_router_notifies_on_bot_elimination(monkeypatch):
 
         await router.router_text(update, context)
 
-        assert context.bot.send_message.call_count == 0
+        assert context.bot.send_message.call_count == 1
+        assert 'B выбывает' in context.bot.send_message.call_args.args[1]
         calls = [(c.args[2], c.args[3]) for c in send_state.call_args_list]
         assert any(
             player == 'A' and 'уничтожен корабль игрока B!' in msg

--- a/tests/test_board15_router.py
+++ b/tests/test_board15_router.py
@@ -299,7 +299,7 @@ def test_router_notifies_other_players_on_hit(monkeypatch):
         assert len(calls) >= 1
         msg = calls[-1].args[3]
         assert msg.startswith('Ход игрока A: a1 - игрок A поразил корабль игрока B')
-        assert msg.strip().endswith('Следующим ходит A.')
+        assert msg.strip().endswith('Следующим ходит B.')
 
     asyncio.run(run_test())
 

--- a/tests/test_board15_test_autoplay.py
+++ b/tests/test_board15_test_autoplay.py
@@ -43,7 +43,7 @@ def test_board15_test_autoplay(monkeypatch):
         await handlers.board15_test(update, context)
         await asyncio.gather(*tasks)
         messages = [c.args[1] for c in context.bot.send_message.call_args_list]
-        assert any('Вы победили' in m for m in messages)
+        assert any('Вы победили!🏆' in m for m in messages)
     asyncio.run(run())
 
 

--- a/tests/test_board15_test_manual.py
+++ b/tests/test_board15_test_manual.py
@@ -115,7 +115,9 @@ def test_board15_test_manual(monkeypatch):
 
         assert finished.get("winner") == "A"
         messages = [c.args[1] for c in context.bot.send_message.call_args_list]
-        assert any("Вы победили" in m for m in messages)
+        assert any("B выбывает" in m for m in messages)
+        assert any("C занял 2 место" in m for m in messages)
+        assert any("Вы победили!🏆" in m for m in messages)
         assert set(sent_to) == {"A"}
 
     asyncio.run(run())

--- a/tests/test_router_text.py
+++ b/tests/test_router_text.py
@@ -316,10 +316,12 @@ def test_router_game_over_messages(monkeypatch):
         )
         await router.router_text(update, context)
         calls = send_message.call_args_list
-        assert 'Вы победили. 🏆🎉' in calls[1].args[1]
-        assert 'Все ваши корабли уничтожены' in calls[3].args[1]
-        assert calls[4].args[1] == 'Игра завершена!'
-        assert calls[5].args[1] == 'Игра завершена!'
-        assert calls[4].kwargs['reply_markup'].keyboard[0][0].text == 'Начать новую игру'
-        assert calls[5].kwargs['reply_markup'].keyboard[0][0].text == 'Начать новую игру'
+        texts = [c.args[1] for c in calls]
+        assert any('Флот игрока B потоплен! B занял 2 место. Вы победили!🏆' in t for t in texts)
+        assert any('Флот игрока B потоплен! B занял 2 место. Игрок A победил!' in t for t in texts)
+        assert any('Все ваши корабли уничтожены' in t for t in texts)
+        assert texts[-2] == 'Игра завершена!'
+        assert texts[-1] == 'Игра завершена!'
+        assert calls[-2].kwargs['reply_markup'].keyboard[0][0].text == 'Начать новую игру'
+        assert calls[-1].kwargs['reply_markup'].keyboard[0][0].text == 'Начать новую игру'
     asyncio.run(run_test())


### PR DESCRIPTION
## Summary
- broadcast fleet eliminations in both classic and 15x15 modes, announcing winner when only one player remains
- ensure spectators see "Игрок {name} победил!" and adjust turn handling for 15x15 matches
- expand tests to verify elimination messaging, victory announcements and trophy display

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b35d0fd6948326a330ca434e51f21f