### PR TITLE
Fix board15 human turn and single-user messaging

### DIFF
--- a/game_board15/handlers.py
+++ b/game_board15/handlers.py
@@ -180,10 +180,8 @@ async def _auto_play_bots(
             await asyncio.sleep(delay)
 
         current = match.turn
-        if (
-            match.players[current].user_id != 0
-            or current == human
-        ):
+        player = match.players.get(current)
+        if player is None or player.user_id != 0:
             await asyncio.sleep(delay)
             continue
         board = match.boards[current]

--- a/game_board15/router.py
+++ b/game_board15/router.py
@@ -140,10 +140,6 @@ async def router_text(update: Update, context: ContextTypes.DEFAULT_TYPE) -> Non
         if k != player_key and match.boards[k].alive_cells > 0
     ]
 
-    if not single_user and match.turn != player_key:
-        await update.message.reply_text('Сейчас ход другого игрока.')
-        return
-
     coord = parser.parse_coord(text)
     if coord is None:
         await update.message.reply_text('Не понял клетку. Пример: e5.')
@@ -159,6 +155,10 @@ async def router_text(update: Update, context: ContextTypes.DEFAULT_TYPE) -> Non
     state = _get_cell_state(match.history[r][c])
     if state in {2, 3, 4, 5}:
         await update.message.reply_text('Эта клетка уже обстреляна')
+        return
+
+    if not single_user and match.turn != player_key:
+        await update.message.reply_text('Сейчас ход другого игрока.')
         return
 
     results = {}
@@ -298,14 +298,14 @@ async def router_text(update: Update, context: ContextTypes.DEFAULT_TYPE) -> Non
     body_self = msg_body.rstrip()
     if not body_self.endswith(('.', '!', '?')):
         body_self += '.'
-    if same_chat:
+    if same_chat or single_user:
         result_self = (
             f"Ход игрока {player_label}: {coord_str} - {body_self} {phrase_self} Следующим ходит {next_name}."
         )
         view_key = player_key
     else:
         result_self = f"Ваш ход: {coord_str} - {body_self} {phrase_self} Следующим ходит {next_name}."
-        view_key = match.turn if single_user else player_key
+        view_key = player_key
     await _send_state(context, match, view_key, result_self)
 
     storage.save_match(match)

--- a/tests/test_board15_human_autoplay_message.py
+++ b/tests/test_board15_human_autoplay_message.py
@@ -1,0 +1,75 @@
+import asyncio
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+from game_board15 import handlers, router, storage
+from game_board15.models import Match15, Player
+from tests.utils import _new_grid
+
+
+def test_human_shot_no_autoplay_and_message(monkeypatch):
+    async def run():
+        match = Match15.new(1, 10, 'A')
+        match.players['B'] = Player(user_id=1, chat_id=20, name='B')
+        match.status = 'playing'
+        match.turn = 'A'
+        match.history = _new_grid(15)
+
+        monkeypatch.setattr(storage, 'find_match_by_user', lambda uid, chat_id=None: match)
+        monkeypatch.setattr(storage, 'save_match', lambda m: None)
+        monkeypatch.setattr(storage, 'get_match', lambda mid: match)
+        monkeypatch.setattr(storage, 'finish', lambda m, w: None)
+
+        shot_calls = {'n': 0}
+
+        def fake_apply_shot(board, coord):
+            shot_calls['n'] += 1
+            return handlers.battle.MISS
+
+        monkeypatch.setattr(router.battle, 'apply_shot', fake_apply_shot)
+        monkeypatch.setattr(handlers.battle, 'apply_shot', fake_apply_shot)
+        monkeypatch.setattr(router, '_phrase_or_joke', lambda m, pk, ph: '')
+        monkeypatch.setattr(router.parser, 'parse_coord', lambda text: (0, 0))
+        monkeypatch.setattr(router.parser, 'format_coord', lambda coord: 'a1')
+
+        send_calls = []
+
+        async def fake_send_state(context, match_, player_key, message):
+            send_calls.append((player_key, message))
+
+        monkeypatch.setattr(router, '_send_state', fake_send_state)
+
+        orig_sleep = asyncio.sleep
+
+        async def fast_sleep(t):
+            await orig_sleep(0)
+
+        monkeypatch.setattr(asyncio, 'sleep', fast_sleep)
+
+        context = SimpleNamespace(
+            bot=SimpleNamespace(send_message=AsyncMock(), send_photo=AsyncMock()),
+            bot_data={},
+            chat_data={},
+        )
+
+        task = asyncio.create_task(handlers._auto_play_bots(match, context, 10, human='A', delay=0.01))
+        await asyncio.sleep(0)
+
+        update = SimpleNamespace(
+            message=SimpleNamespace(text='a1', reply_text=AsyncMock()),
+            effective_user=SimpleNamespace(id=1),
+            effective_chat=SimpleNamespace(id=10),
+        )
+
+        await router.router_text(update, context)
+        await asyncio.sleep(0)
+        task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+
+        assert shot_calls['n'] == 1
+        assert any(player == 'A' and msg.startswith('Ход игрока A:') for player, msg in send_calls)
+
+    asyncio.run(run())


### PR DESCRIPTION
## Summary
- Avoid auto-play when it's a real player's turn
- Tweak single-user messages to show "Ход игрока" and send to the shooter
- Cover human shot behaviour with a dedicated test

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b3e713a5e08326b43e71a804d32b55