### PR TITLE
Maintain turn after hit in board15 router

### DIFF
--- a/tests/test_board15_router.py
+++ b/tests/test_board15_router.py
@@ -299,7 +299,52 @@ def test_router_notifies_other_players_on_hit(monkeypatch):
         assert len(calls) >= 1
         msg = calls[-1].args[3]
         assert msg.startswith('Ход игрока A: a1 - игрок A поразил корабль игрока B')
-        assert msg.strip().endswith('Следующим ходит B.')
+        assert msg.strip().endswith('Следующим ходит A.')
+
+    asyncio.run(run_test())
+
+
+def test_hit_keeps_turn(monkeypatch):
+    async def run_test():
+        board_self = Board15()
+        board_enemy = Board15()
+        ship = Ship(cells=[(0, 0), (0, 1)])
+        board_enemy.ships = [ship]
+        board_enemy.grid[0][0] = 1
+        board_enemy.grid[0][1] = 1
+        board_enemy.alive_cells = 2
+        match = SimpleNamespace(
+            status="playing",
+            players={
+                "A": SimpleNamespace(user_id=1, chat_id=10, name="A"),
+                "B": SimpleNamespace(user_id=2, chat_id=20, name="B"),
+            },
+            boards={"A": board_self, "B": board_enemy},
+            turn="A",
+            shots={"A": {"move_count": 0, "joke_start": 10}, "B": {}},
+            messages={"A": {}, "B": {}},
+            history=_new_grid(15),
+        )
+
+        monkeypatch.setattr(storage, "find_match_by_user", lambda uid, chat_id=None: match)
+        monkeypatch.setattr(storage, "save_match", lambda m: None)
+        monkeypatch.setattr(router.parser, "parse_coord", lambda text: (0, 0))
+        monkeypatch.setattr(router.parser, "format_coord", lambda coord: "a1")
+        monkeypatch.setattr(router, "_phrase_or_joke", lambda m, pk, ph: "")
+
+        send_state = AsyncMock()
+        monkeypatch.setattr(router, "_send_state", send_state)
+
+        update = SimpleNamespace(
+            message=SimpleNamespace(text="a1", reply_text=AsyncMock()),
+            effective_user=SimpleNamespace(id=1),
+            effective_chat=SimpleNamespace(id=10),
+        )
+        context = SimpleNamespace(bot=SimpleNamespace(send_message=AsyncMock()), chat_data={}, bot_data={})
+
+        await router.router_text(update, context)
+
+        assert match.turn == "A"
 
     asyncio.run(run_test())
 


### PR DESCRIPTION
## Summary
- Keep current player's turn after hits or repeated shots by checking results for HIT, KILL or REPEAT
- Update message flow to use the resolved next player
- Add regression test ensuring a hit doesn't advance the turn

## Testing
- `pytest tests/test_board15_router.py::test_hit_keeps_turn -q`
- `pytest tests/test_board15_router.py -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68b4113a12948326822ec164a282f60f