### PR TITLE
Send board state with caption

### DIFF
--- a/game_board15/router.py
+++ b/game_board15/router.py
@@ -54,33 +54,23 @@ async def _send_state(context: ContextTypes.DEFAULT_TYPE, match, player_key: str
 
     msgs = match.messages.setdefault(player_key, {})
 
-    # always send main board image
+    # send main board image with caption text
     try:
         buf.seek(0)
-        msg_board = await context.bot.send_photo(chat_id, buf)
+        msg = await context.bot.send_photo(chat_id, buf, caption=message)
     except asyncio.CancelledError:
         raise
     except Exception:
         logger.exception("Failed to send board image for chat %s", chat_id)
         return
-    state.message_id = msg_board.message_id
-    msgs["board"] = msg_board.message_id
+    state.message_id = msg.message_id
+    msgs["board"] = msg.message_id
+    msgs["text"] = msg.message_id
     board_hist = msgs.setdefault("board_history", [])
-    if msgs.get("history_active"):
-        board_hist.append(msg_board.message_id)
-
-    # send result text message
-    try:
-        msg_text = await context.bot.send_message(chat_id, message)
-    except asyncio.CancelledError:
-        raise
-    except Exception:
-        logger.exception("Failed to send text message for chat %s", chat_id)
-        return
-    msgs["text"] = msg_text.message_id
     text_hist = msgs.setdefault("text_history", [])
     if msgs.get("history_active"):
-        text_hist.append(msg_text.message_id)
+        board_hist.append(msg.message_id)
+        text_hist.append(msg.message_id)
 
 
 async def router_text(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:

--- a/tests/test_board15_keyboard.py
+++ b/tests/test_board15_keyboard.py
@@ -20,16 +20,16 @@ def test_send_state_records_history(monkeypatch):
         monkeypatch.setattr(router.storage, "save_match", lambda m: None)
         bot = SimpleNamespace(
             send_photo=AsyncMock(side_effect=[SimpleNamespace(message_id=51)]),
-            send_message=AsyncMock(return_value=SimpleNamespace(message_id=60)),
+            send_message=AsyncMock(),
         )
         context = SimpleNamespace(bot=bot, bot_data={}, chat_data={})
         await router._send_state(context, match, "A", "msg")
         assert bot.send_photo.await_count == 1
-        assert bot.send_message.await_count == 1
+        assert bot.send_message.await_count == 0
         assert match.messages["A"]["board"] == 51
-        assert match.messages["A"]["text"] == 60
+        assert match.messages["A"]["text"] == 51
         assert match.messages["A"]["board_history"] == [51]
-        assert match.messages["A"]["text_history"] == [60]
+        assert match.messages["A"]["text_history"] == [51]
     asyncio.run(run_test())
 
 
@@ -48,20 +48,17 @@ def test_send_state_appends_history(monkeypatch):
                 SimpleNamespace(message_id=11),
                 SimpleNamespace(message_id=13),
             ]),
-            send_message=AsyncMock(side_effect=[
-                SimpleNamespace(message_id=20),
-                SimpleNamespace(message_id=21),
-            ]),
+            send_message=AsyncMock(),
         )
         context = SimpleNamespace(bot=bot, bot_data={}, chat_data={})
         await router._send_state(context, match, "A", "first")
         await router._send_state(context, match, "A", "second")
         assert bot.send_photo.await_count == 2
-        assert bot.send_message.await_count == 2
+        assert bot.send_message.await_count == 0
         assert match.messages["A"]["board"] == 13
-        assert match.messages["A"]["text"] == 21
+        assert match.messages["A"]["text"] == 13
         assert match.messages["A"]["board_history"] == [11, 13]
-        assert match.messages["A"]["text_history"] == [20, 21]
+        assert match.messages["A"]["text_history"] == [11, 13]
     asyncio.run(run_test())
 
 
@@ -77,7 +74,7 @@ def test_history_not_recorded_when_inactive(monkeypatch):
         monkeypatch.setattr(router.storage, "save_match", lambda m: None)
         bot = SimpleNamespace(
             send_photo=AsyncMock(side_effect=[SimpleNamespace(message_id=1)]),
-            send_message=AsyncMock(return_value=SimpleNamespace(message_id=3)),
+            send_message=AsyncMock(),
         )
         context = SimpleNamespace(bot=bot, bot_data={}, chat_data={})
         await router._send_state(context, match, "A", "msg")

--- a/tests/test_board15_message_order.py
+++ b/tests/test_board15_message_order.py
@@ -93,7 +93,7 @@ def test_board15_message_order(tmp_path, monkeypatch):
 
     asyncio.run(play_moves())
 
-    expected = ['photo', 'text_send', 'photo', 'text_send']
+    expected = ['photo', 'photo']
     assert bot.logs[1] == expected
     assert bot.logs[2] == expected
     assert bot.logs[3] == expected
@@ -140,5 +140,5 @@ def test_board15_message_order_single_chat(tmp_path, monkeypatch):
 
     asyncio.run(play_moves())
 
-    expected = ['photo', 'text_send', 'photo', 'text_send']
+    expected = ['photo', 'photo']
     assert bot.logs[1] == expected

--- a/tests/test_board15_router.py
+++ b/tests/test_board15_router.py
@@ -65,13 +65,10 @@ def test_router_auto_sends_boards(monkeypatch):
         await router.router_text(update, context)
 
         assert send_photo.call_args_list == [
-            call(10, ANY),
-            call(20, ANY),
+            call(10, ANY, caption='Соперник готов. Бой начинается! Ваш ход.'),
+            call(20, ANY, caption='Корабли расставлены. Бой начинается! Ход соперника.'),
         ]
-        assert send_message.call_args_list == [
-            call(10, 'Соперник готов. Бой начинается! Ваш ход.'),
-            call(20, 'Корабли расставлены. Бой начинается! Ход соперника.'),
-        ]
+        assert send_message.call_args_list == []
 
     asyncio.run(run_test())
 
@@ -451,9 +448,10 @@ def test_router_notifies_next_player_on_miss(monkeypatch):
 
         await router.router_text(update, context)
 
-        b_msgs = [c for c in send_message.call_args_list if c.args[0] == 20]
-        assert b_msgs and b_msgs[0].args[1].endswith('Следующим ходит B.')
-        assert 'a1 - мимо' in b_msgs[0].args[1]
+        b_msgs = [c for c in send_photo.call_args_list if c.args[0] == 20]
+        assert b_msgs and b_msgs[0].kwargs["caption"].endswith('Следующим ходит B.')
+        assert 'a1 - мимо' in b_msgs[0].kwargs["caption"]
+        assert send_message.call_args_list == []
 
     asyncio.run(run_test())
 


### PR DESCRIPTION
## Summary
- render 15x15 board state and send it as a single photo with caption
- record the same message ID for board and text history
- adjust board15 tests for captioned photos

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68b422bf2384832690106df992659286