### PR TITLE
Normalize 15x15 board coordinates and add alias tests

### DIFF
--- a/game_board15/parser.py
+++ b/game_board15/parser.py
@@ -1,16 +1,34 @@
 from __future__ import annotations
-import re
 from typing import Optional, Tuple
 
 """Parsing utilities for 15x15 board.
 
 Historically the project used Cyrillic letters to label columns.  The modern
 board displays latin letters instead, therefore outgoing coordinates and
-rendered boards must also use them.  ``ROWS`` keeps the Cyrillic sequence for
-backwards compatible parsing while ``LATIN`` is the user-facing counterpart."""
+rendered boards must also use them.  Older clients might still send Cyrillic
+letters; ``CYRILLIC_ALIASES`` maps them to their latin counterparts."""
 
-ROWS = 'абвгдежзиклмнопр'
-LATIN = 'abcdefghijklmnopr'
+LATIN = "abcdefghijklmno"
+CYRILLIC_ALIASES = {
+    "а": "a",
+    "б": "b",
+    "в": "b",
+    "г": "g",
+    "д": "d",
+    "е": "e",
+    "х": "h",
+    "и": "i",
+    "к": "k",
+    "л": "l",
+    "м": "m",
+    "н": "n",
+    "о": "o",
+    "ц": "c",
+    "с": "c",
+    "э": "e",
+    "ф": "f",
+    "й": "j",
+}
 
 
 def normalize(cell: str) -> str:
@@ -22,18 +40,17 @@ def parse_coord(cell: str) -> Optional[Tuple[int, int]]:
     if len(cell) < 2:
         return None
     letter = cell[0]
-    rest = cell[1:]
-    if letter in LATIN:
-        letter = ROWS[LATIN.index(letter)]
-    if letter not in ROWS:
+    letter = CYRILLIC_ALIASES.get(letter, letter)
+    if letter not in LATIN:
         return None
+    rest = cell[1:]
     try:
         row = int(rest)
     except ValueError:
         return None
     if not 1 <= row <= 15:
         return None
-    col = ROWS.index(letter)
+    col = LATIN.index(letter)
     return row - 1, col
 
 

--- a/tests/test_board15_parser.py
+++ b/tests/test_board15_parser.py
@@ -1,0 +1,23 @@
+import pytest
+
+from game_board15.parser import CYRILLIC_ALIASES, LATIN, parse_coord
+
+
+@pytest.mark.parametrize("cyr, latin", CYRILLIC_ALIASES.items())
+def test_cyrillic_aliases(cyr, latin):
+    col = LATIN.index(latin)
+    assert parse_coord(f"{cyr}1") == (0, col)
+    assert parse_coord(f"{cyr.upper()}1") == (0, col)
+
+
+@pytest.mark.parametrize("letter", list(LATIN))
+def test_latin_case_insensitive(letter):
+    col = LATIN.index(letter)
+    assert parse_coord(f"{letter}1") == (0, col)
+    assert parse_coord(f"{letter.upper()}1") == (0, col)
+
+
+@pytest.mark.parametrize("letter", ["p", "q", "ж", "щ", "ы"])
+def test_unsupported_letters(letter):
+    assert parse_coord(f"{letter}1") is None
+    assert parse_coord(f"{letter.upper()}1") is None


### PR DESCRIPTION
## Summary
- replace legacy column constants with latin sequence and cyrillic alias map
- validate coordinates through the new latin alphabet and expose formatting
- exercise parser across all cyrillic aliases and edge cases

## Testing
- `pytest tests/test_board15_parser.py -q`
- `pytest tests/test_parser.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b4248e2c3c83268d9d457fc7a67141