### PR TITLE
Render state 5 with distinct symbol

### DIFF
--- a/logic/render.py
+++ b/logic/render.py
@@ -79,11 +79,16 @@ def render_board_own(board: Board) -> str:
             color = PLAYER_COLORS.get(owner or getattr(board, "owner", None), "#000")
             if cell_state == 1:
                 sym = f'<span style="color:{color}">□</span>'
-            elif cell_state in (2, 5):
+            elif cell_state == 2:
                 if coord in highlight:
                     sym = '<span style="color:red;background-color:orange">x</span>'
                 else:
                     sym = '<span style="color:black">x</span>'
+            elif cell_state == 5:
+                if coord in highlight:
+                    sym = '<span style="color:red;background-color:orange">x</span>'
+                else:
+                    sym = '<span style="color:#808080">x</span>'
             elif cell_state == 3:
                 if coord in highlight:
                     hit_color = "#8b0000"
@@ -120,11 +125,16 @@ def render_board_enemy(board: Board) -> str:
             color = PLAYER_COLORS.get(owner or getattr(board, "owner", None), "#000")
             if cell_state == 1:
                 sym = '·'
-            elif cell_state in (2, 5):
+            elif cell_state == 2:
                 if coord in highlight:
                     sym = '<span style="color:red;background-color:orange">x</span>'
                 else:
                     sym = '<span style="color:black">x</span>'
+            elif cell_state == 5:
+                if coord in highlight:
+                    sym = '<span style="color:red;background-color:orange">x</span>'
+                else:
+                    sym = '<span style="color:#808080">x</span>'
             elif cell_state == 3:
                 if coord in highlight:
                     hit_color = "#8b0000"

--- a/tests/test_render.py
+++ b/tests/test_render.py
@@ -99,3 +99,15 @@ def test_apply_shot_marks_contour():
                 continue
             if 0 <= nr < 10 and 0 <= nc < 10:
                 assert _state(b.grid[nr][nc]) == 5
+
+
+def test_render_state5_symbol():
+    b = Board()
+    b.grid = _new_grid()
+    b.grid[0][0] = [5, 'A']
+
+    own = render_board_own(b)
+    enemy = render_board_enemy(b)
+
+    assert '<span style="color:#808080">x</span>' in own
+    assert '<span style="color:#808080">x</span>' in enemy


### PR DESCRIPTION
## Summary
- Distinguish rendering of miss (2) and contour (5) states on boards
- Display state 5 as a gray "x" and update own/enemy board renderers
- Test rendering of state 5

## Testing
- `pytest tests/test_render.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b4390754b08326893da8d1dc215062