### PR TITLE
Fix Cyrillic alias mapping and expand board15 parser tests

### DIFF
--- a/game_board15/parser.py
+++ b/game_board15/parser.py
@@ -12,7 +12,7 @@ LATIN = "abcdefghijklmno"
 CYRILLIC_ALIASES = {
     "а": "a",
     "б": "b",
-    "в": "b",
+    "в": "v",
     "г": "g",
     "д": "d",
     "е": "e",

--- a/tests/test_board15_parser.py
+++ b/tests/test_board15_parser.py
@@ -5,9 +5,13 @@ from game_board15.parser import CYRILLIC_ALIASES, LATIN, parse_coord
 
 @pytest.mark.parametrize("cyr, latin", CYRILLIC_ALIASES.items())
 def test_cyrillic_aliases(cyr, latin):
-    col = LATIN.index(latin)
-    assert parse_coord(f"{cyr}1") == (0, col)
-    assert parse_coord(f"{cyr.upper()}1") == (0, col)
+    if latin in LATIN:
+        col = LATIN.index(latin)
+        expected = (0, col)
+    else:
+        expected = None
+    assert parse_coord(f"{cyr}1") == expected
+    assert parse_coord(f"{cyr.upper()}1") == expected
 
 
 @pytest.mark.parametrize("letter", list(LATIN))
@@ -17,7 +21,7 @@ def test_latin_case_insensitive(letter):
     assert parse_coord(f"{letter.upper()}1") == (0, col)
 
 
-@pytest.mark.parametrize("letter", ["p", "q", "ж", "щ", "ы"])
+@pytest.mark.parametrize("letter", ["p", "q", "v", "ж", "щ", "ы", "в"])
 def test_unsupported_letters(letter):
     assert parse_coord(f"{letter}1") is None
     assert parse_coord(f"{letter.upper()}1") is None


### PR DESCRIPTION
## Summary
- map Cyrillic "в" to latin "v" in the 15x15 board parser
- broaden parser tests to handle aliases and reject unsupported letters

## Testing
- `pytest tests/test_board15_parser.py`


------
https://chatgpt.com/codex/tasks/task_e_68b43b9f8da8832681b7b6047615b1ff