### PR TITLE
Handle kill history for all ship cells

### DIFF
--- a/game_board15/battle.py
+++ b/game_board15/battle.py
@@ -60,24 +60,22 @@ def update_history(
 
     r, c = coord
     if any(res == KILL for res in results.values()):
-        kill_key = None
         for key, res in results.items():
             if res != KILL:
                 continue
-            kill_key = key if kill_key is None else kill_key
             board = boards[key]
-            for rr in range(15):
-                for cc in range(15):
-                    val = board.grid[rr][cc]
-                    if val == 4:
-                        _set_cell_state(history, rr, cc, 4, key)
-                    elif val == 5:
-                        # Mark contour cells as shot-through for everyone without
-                        # overwriting prior shot information.
-                        if _get_cell_state(history[rr][cc]) == 0:
-                            _set_cell_state(history, rr, cc, 5, key)
-        if kill_key is not None:
-            _set_cell_state(history, r, c, 4, kill_key)
+            ship = next((s for s in board.ships if coord in s.cells), None)
+            if not ship:
+                continue
+            for rr, cc in ship.cells:
+                _set_cell_state(history, rr, cc, 4, key)
+            for rr, cc in ship.cells:
+                for dr in (-1, 0, 1):
+                    for dc in (-1, 0, 1):
+                        nr, nc = rr + dr, cc + dc
+                        if 0 <= nr < 15 and 0 <= nc < 15:
+                            if _get_cell_state(history[nr][nc]) == 0:
+                                _set_cell_state(history, nr, nc, 5)
     elif any(res == HIT for res in results.values()):
         hit_key = next((k for k, res in results.items() if res == HIT), None)
         _set_cell_state(history, r, c, 3, hit_key)

--- a/tests/test_board15_history.py
+++ b/tests/test_board15_history.py
@@ -4,7 +4,7 @@ from types import SimpleNamespace
 from unittest.mock import AsyncMock
 
 from game_board15 import router
-from game_board15.battle import apply_shot, update_history, KILL
+from game_board15.battle import apply_shot, update_history, KILL, HIT
 from game_board15.models import Board15, Ship
 from tests.utils import _new_grid, _state
 
@@ -20,6 +20,27 @@ def test_update_history_records_kill_and_contour():
     update_history(history, boards, (1, 1), {'B': res})
     assert _state(history[1][1]) == 4
     assert _state(history[0][0]) == 5
+
+
+def test_hit_then_kill_updates_all_cells():
+    history = _new_grid(15)
+    boards = {'A': Board15()}
+    ship = Ship(cells=[(0, 2), (0, 3)])
+    boards['A'].ships = [ship]
+    boards['A'].grid[0][2] = 1
+    boards['A'].grid[0][3] = 1
+
+    res_hit = apply_shot(boards['A'], (0, 2))
+    assert res_hit == HIT
+    update_history(history, boards, (0, 2), {'A': res_hit})
+    assert _state(history[0][2]) == 3
+
+    res_kill = apply_shot(boards['A'], (0, 3))
+    assert res_kill == KILL
+    update_history(history, boards, (0, 3), {'A': res_kill})
+
+    assert _state(history[0][2]) == 4
+    assert _state(history[0][3]) == 4
 
 
 def test_send_state_uses_history(monkeypatch):


### PR DESCRIPTION
## Summary
- Update history updates to mark every cell of a destroyed ship and add contour only once
- Preserve cell owner info when recording kills
- Add regression test for sequential hit then kill shots

## Testing
- `python -m pytest tests/test_board15_history.py::test_hit_then_kill_updates_all_cells -q`
- `python -m pytest tests/test_board15_history.py::test_kill_contour_visible_to_all_players -q`


------
https://chatgpt.com/codex/tasks/task_e_68b44c5c67ec832695acb88c9fde1f8b