### PR TITLE
Fix contour marking after ship destruction

### DIFF
--- a/game_board15/battle.py
+++ b/game_board15/battle.py
@@ -8,13 +8,19 @@ MISS, HIT, KILL, REPEAT = 'miss', 'hit', 'kill', 'repeat'
 
 
 def mark_contour(board: Board15, cells: list[Tuple[int, int]]) -> None:
+    """Mark the contour around ``cells`` on a 15×15 board."""
+
+    contour: set[Tuple[int, int]] = set()
     for r, c in cells:
         for dr in (-1, 0, 1):
             for dc in (-1, 0, 1):
                 nr, nc = r + dr, c + dc
                 if 0 <= nr < 15 and 0 <= nc < 15:
-                    if board.grid[nr][nc] == 0:
-                        board.grid[nr][nc] = 5
+                    contour.add((nr, nc))
+
+    for r, c in contour.difference(cells):
+        if board.grid[r][c] == 0:
+            board.grid[r][c] = 5
 
 
 def apply_shot(board: Board15, coord: Tuple[int, int]) -> str:

--- a/logic/battle.py
+++ b/logic/battle.py
@@ -22,14 +22,28 @@ def _set_cell_state(board: Board, r: int, c: int, value: int) -> None:
         board.grid[r][c] = value
 
 
-def mark_contour(board: Board, cells: list[Tuple[int,int]]) -> None:
+def mark_contour(board: Board, cells: list[Tuple[int, int]]) -> None:
+    """Mark all cells surrounding ``cells`` as shot.
+
+    The previous implementation updated the board in-place while iterating
+    through ``cells``.  When a ship spanned multiple cells this could skip
+    some neighbours because newly marked contour cells were visited again and
+    short‑circuited by the ``_get_cell_state`` check.  Collecting the contour
+    first and applying the update afterwards guarantees that every neighbour
+    around the destroyed ship becomes unavailable for subsequent shots.
+    """
+
+    contour: set[Tuple[int, int]] = set()
     for r, c in cells:
-        for dr in (-1,0,1):
-            for dc in (-1,0,1):
-                nr, nc = r+dr, c+dc
+        for dr in (-1, 0, 1):
+            for dc in (-1, 0, 1):
+                nr, nc = r + dr, c + dc
                 if 0 <= nr < 10 and 0 <= nc < 10:
-                    if _get_cell_state(board, nr, nc) == 0:
-                        _set_cell_state(board, nr, nc, 5)
+                    contour.add((nr, nc))
+
+    for r, c in contour.difference(cells):
+        if _get_cell_state(board, r, c) == 0:
+            _set_cell_state(board, r, c, 5)
 
 
 def apply_shot(board: Board, coord: Tuple[int,int]) -> str:

--- a/tests/test_three_player_single_board.py
+++ b/tests/test_three_player_single_board.py
@@ -93,7 +93,14 @@ def test_apply_shot_multi_updates_history():
     res1 = apply_shot_multi((1, 1), {"B": board_b, "C": board_c}, history)
     assert res1 == {"B": KILL, "C": MISS}
     assert _state(history[1][1]) == 4
-    assert _state(history[0][0]) == 5
+    # all surrounding cells should be marked as shot (5)
+    for dr in (-1, 0, 1):
+        for dc in (-1, 0, 1):
+            rr, cc = 1 + dr, 1 + dc
+            if (rr, cc) == (1, 1):
+                continue
+            if 0 <= rr < 10 and 0 <= cc < 10:
+                assert _state(history[rr][cc]) == 5
     res2 = apply_shot_multi((3, 3), {"B": board_b, "C": board_c}, history)
     assert res2 == {"B": MISS, "C": KILL}
     assert _state(history[3][3]) == 4


### PR DESCRIPTION
## Summary
- ensure contour cells around destroyed ships are all marked as fired
- apply same contour logic for 15×15 board variant
- test that every neighbour around a sunk ship becomes unavailable

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b451eb420c8326b6c89b09598bf3cb