### PR TITLE
Persist board history before broadcasting state

### DIFF
--- a/game_board15/handlers.py
+++ b/game_board15/handlers.py
@@ -234,9 +234,6 @@ async def _auto_play_bots(
         for enemy, res in results.items():
             shot_hist.append({"coord": coord, "enemy": enemy, "result": res})
         battle.update_history(match.history, match.boards, coord, results)
-        # Save match immediately after updating history to avoid losing moves
-        # when multiple players act concurrently.
-        storage.save_match(match)
         match.shots[current]["last_coord"] = coord
         if any(res == battle.KILL for res in results.values()):
             cells: list[tuple[int, int]] = []
@@ -246,6 +243,7 @@ async def _auto_play_bots(
             match.last_highlight = [coord] + [c for c in cells if c != coord]
         else:
             match.last_highlight = [coord]
+        storage.save_match(match)
         for k in match.shots:
             shots = match.shots[k]
             shots.setdefault('move_count', 0)

--- a/game_board15/router.py
+++ b/game_board15/router.py
@@ -182,10 +182,6 @@ async def router_text(update: Update, context: ContextTypes.DEFAULT_TYPE) -> Non
         for row in match.history
     ):
         logger.warning("History is empty after shot %s", coord_str)
-    match.shots[player_key]["last_coord"] = coord
-    shot_hist = match.shots[player_key].setdefault("history", [])
-    for enemy, res in results.items():
-        shot_hist.append({"coord": coord, "enemy": enemy, "result": res})
     if any(res == battle.KILL for res in results.values()):
         cells: list[tuple[int, int]] = []
         for enemy, res in results.items():
@@ -200,6 +196,11 @@ async def router_text(update: Update, context: ContextTypes.DEFAULT_TYPE) -> Non
         match.last_highlight = [coord]
         match.shots[player_key]["last_result"] = "miss"
     storage.save_match(match)
+
+    match.shots[player_key]["last_coord"] = coord
+    shot_hist = match.shots[player_key].setdefault("history", [])
+    for enemy, res in results.items():
+        shot_hist.append({"coord": coord, "enemy": enemy, "result": res})
     for k in match.shots:
         shots = match.shots[k]
         shots.setdefault('move_count', 0)

--- a/handlers/board_test.py
+++ b/handlers/board_test.py
@@ -176,6 +176,7 @@ async def _auto_play_bots(
         phrase_self = _phrase_or_joke(match, current, phrase_map[overall_res]).rstrip()
 
         next_name = next_player
+        storage.save_match(match)
         if enemy_msgs:
             for enemy, msg_body in enemy_msgs.items():
                 if enemy == human:
@@ -198,7 +199,6 @@ async def _auto_play_bots(
                 f"Ход игрока {current}: {coord_str} - {enemy_msgs[human]}{next_phrase}",
             )
 
-        storage.save_match(match)
         parts_text = ' '.join(parts_self)
         base_self = (
             f"Ваш ход: {coord_str} - {parts_text} {phrase_self}"

--- a/tests/test_history_before_send.py
+++ b/tests/test_history_before_send.py
@@ -1,0 +1,123 @@
+import asyncio
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+from game_board15 import router as router15
+from game_board15.models import Board15, Ship as Ship15
+from handlers import router as router_std
+from models import Board, Ship
+import storage
+from tests.utils import _new_grid
+
+
+def test_board15_router_updates_history_before_send(monkeypatch):
+    async def run():
+        board_self = Board15()
+        board_enemy = Board15()
+        ship = Ship15(cells=[(0, 0)])
+        board_enemy.ships = [ship]
+        board_enemy.grid[0][0] = 1
+        board_enemy.alive_cells = 1
+        match = SimpleNamespace(
+            status="playing",
+            players={
+                "A": SimpleNamespace(user_id=1, chat_id=10, name="A"),
+                "B": SimpleNamespace(user_id=2, chat_id=20, name="B"),
+            },
+            boards={"A": board_self, "B": board_enemy},
+            turn="A",
+            messages={"A": {}, "B": {}},
+            shots={"A": {"history": []}, "B": {}},
+            history=_new_grid(15),
+            last_highlight=[],
+        )
+        saved = False
+
+        def fake_save_match(m):
+            nonlocal saved
+            saved = True
+
+        monkeypatch.setattr(router15.storage, "find_match_by_user", lambda uid, chat_id=None: match)
+        monkeypatch.setattr(router15.storage, "save_match", fake_save_match)
+        monkeypatch.setattr(router15.parser, "parse_coord", lambda text: (0, 0))
+        monkeypatch.setattr(router15.parser, "format_coord", lambda coord: "a1")
+        monkeypatch.setattr(router15, "_phrase_or_joke", lambda m, pk, ph: "")
+
+        captured = {}
+
+        async def fake_send_state(context, match_obj, player_key, message):
+            captured["cell"] = match_obj.history[0][0][0]
+            captured["saved"] = saved
+
+        monkeypatch.setattr(router15, "_send_state", fake_send_state)
+
+        update = SimpleNamespace(
+            message=SimpleNamespace(text="a1", reply_text=AsyncMock()),
+            effective_user=SimpleNamespace(id=1),
+            effective_chat=SimpleNamespace(id=10),
+        )
+        context = SimpleNamespace(bot=SimpleNamespace(send_message=AsyncMock()), bot_data={})
+
+        await router15.router_text(update, context)
+
+        assert captured["cell"] == 4
+        assert captured["saved"]
+
+    asyncio.run(run())
+
+
+def test_board_test_router_updates_history_before_send(monkeypatch):
+    async def run():
+        board_self = Board()
+        board_enemy = Board()
+        ship = Ship(cells=[(0, 0), (0, 1)])
+        board_enemy.ships = [ship]
+        board_enemy.grid[0][0] = 1
+        board_enemy.grid[0][1] = 1
+        board_enemy.alive_cells = 2
+        match = SimpleNamespace(
+            status="playing",
+            players={
+                "A": SimpleNamespace(user_id=1, chat_id=10, name="A"),
+                "B": SimpleNamespace(user_id=2, chat_id=20, name="B"),
+            },
+            boards={"A": board_self, "B": board_enemy},
+            turn="A",
+            shots={"A": {"history": [], "move_count": 0, "joke_start": 10}, "B": {}},
+            messages={"A": {}, "B": {}},
+            history=[[0] * 10 for _ in range(10)],
+            last_highlight=[],
+        )
+        saved = False
+
+        def fake_save_match(m):
+            nonlocal saved
+            saved = True
+
+        monkeypatch.setattr(storage, "find_match_by_user", lambda uid, chat_id=None: match)
+        monkeypatch.setattr(storage, "save_match", fake_save_match)
+        monkeypatch.setattr(router_std, "parse_coord", lambda text: (0, 0))
+        monkeypatch.setattr(router_std, "format_coord", lambda coord: "a1")
+        monkeypatch.setattr(router_std, "_phrase_or_joke", lambda m, pk, ph: "")
+
+        captured = {}
+
+        async def fake_send_state(context, match_obj, player_key, message):
+            captured["cell"] = match_obj.history[0][0]
+            captured["saved"] = saved
+
+        monkeypatch.setattr(router_std, "_send_state_board_test", fake_send_state)
+
+        update = SimpleNamespace(
+            message=SimpleNamespace(text="a1", reply_text=AsyncMock()),
+            effective_user=SimpleNamespace(id=1),
+            effective_chat=SimpleNamespace(id=10),
+        )
+        context = SimpleNamespace(bot=SimpleNamespace(send_message=AsyncMock()), bot_data={})
+
+        await router_std.router_text_board_test(update, context)
+
+        assert captured["cell"] == 3
+        assert captured["saved"]
+
+    asyncio.run(run())


### PR DESCRIPTION
## Summary
- ensure board15 router saves history before notifying players
- persist move state ahead of notifications in board15 bots and board_test
- add regression tests for history being saved prior to state dispatch

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b45cd6e9a08326abaedc9ece83f70a