### PR TITLE
Ensure history saved before state updates

### DIFF
--- a/game_board15/handlers.py
+++ b/game_board15/handlers.py
@@ -243,7 +243,6 @@ async def _auto_play_bots(
             match.last_highlight = [coord] + [c for c in cells if c != coord]
         else:
             match.last_highlight = [coord]
-        storage.save_match(match)
         for k in match.shots:
             shots = match.shots[k]
             shots.setdefault('move_count', 0)
@@ -258,8 +257,6 @@ async def _auto_play_bots(
         else:
             next_player = current
         match.turn = next_player
-
-        storage.save_match(match)
 
         parts_self: list[str] = []
         watch_parts: list[str] = []
@@ -299,6 +296,8 @@ async def _auto_play_bots(
         next_label = match.players.get(next_player)
         next_name = getattr(next_label, 'name', '') or next_player
 
+        storage.save_match(match)
+
         for player_key, msg_body in enemy_msgs.items():
             if match.players[player_key].user_id != 0:
                 next_phrase = f" Следующим ходит {next_name}."
@@ -312,8 +311,6 @@ async def _auto_play_bots(
                         f"Ход игрока {player_label}: {coord_str} - {body} {phrase_self}{next_phrase}"
                     )
                 await _safe_send_state(player_key, msg_text)
-
-        storage.save_match(match)
 
         finished = False
         for enemy in eliminated:

--- a/game_board15/router.py
+++ b/game_board15/router.py
@@ -195,7 +195,6 @@ async def router_text(update: Update, context: ContextTypes.DEFAULT_TYPE) -> Non
     else:
         match.last_highlight = [coord]
         match.shots[player_key]["last_result"] = "miss"
-    storage.save_match(match)
 
     match.shots[player_key]["last_coord"] = coord
     shot_hist = match.shots[player_key].setdefault("history", [])
@@ -270,6 +269,7 @@ async def router_text(update: Update, context: ContextTypes.DEFAULT_TYPE) -> Non
     next_obj = match.players.get(next_player)
     next_name = getattr(next_obj, 'name', '') or next_player
     same_chat = len({p.chat_id for p in match.players.values()}) == 1
+    storage.save_match(match)
     if enemy_msgs and not same_chat:
         for enemy, (res_enemy, msg_body_enemy) in enemy_msgs.items():
             if match.players[enemy].user_id != 0:

--- a/handlers/router.py
+++ b/handlers/router.py
@@ -478,7 +478,6 @@ async def router_text_board_test(update: Update, context: ContextTypes.DEFAULT_T
     else:
         match.last_highlight = [coord]
         match.shots[player_key]['last_result'] = 'miss'
-    storage.save_match(match)
     for k in match.shots:
         shots = match.shots.setdefault(k, {})
         shots.setdefault('move_count', 0)
@@ -540,6 +539,7 @@ async def router_text_board_test(update: Update, context: ContextTypes.DEFAULT_T
     else:
         self_lines = [f"Ваш ход: {coord_str}"]
     self_lines.append(next_phrase_self)
+    storage.save_match(match)
     await _send_state_board_test(
         context,
         match,

--- a/tests/test_history_before_send_n1.py
+++ b/tests/test_history_before_send_n1.py
@@ -1,0 +1,119 @@
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+import asyncio
+
+from game_board15 import router as router15
+from game_board15.models import Board15, Ship as Ship15
+from handlers import router as router_std
+from models import Board, Ship
+import storage
+
+
+def test_board15_router_updates_history_before_send_n1(monkeypatch):
+    async def run():
+        board_self = Board15()
+        board_enemy = Board15()
+        ship = Ship15(cells=[(0, 13)])
+        board_enemy.ships = [ship]
+        board_enemy.grid[0][13] = 1
+        board_enemy.alive_cells = 1
+        match = SimpleNamespace(
+            status="playing",
+            players={
+                "A": SimpleNamespace(user_id=1, chat_id=10, name="A"),
+                "B": SimpleNamespace(user_id=2, chat_id=20, name="B"),
+            },
+            boards={"A": board_self, "B": board_enemy},
+            turn="A",
+            messages={"A": {}, "B": {}},
+            shots={"A": {"history": []}, "B": {}},
+            history=[[0] * 15 for _ in range(15)],
+            last_highlight=[],
+        )
+        saved = False
+
+        def fake_save_match(m):
+            nonlocal saved
+            saved = True
+
+        monkeypatch.setattr(router15.storage, "find_match_by_user", lambda uid, chat_id=None: match)
+        monkeypatch.setattr(router15.storage, "save_match", fake_save_match)
+        monkeypatch.setattr(router15.parser, "parse_coord", lambda text: (0, 13))
+        monkeypatch.setattr(router15.parser, "format_coord", lambda coord: "n1")
+        monkeypatch.setattr(router15, "_phrase_or_joke", lambda m, pk, ph: "")
+
+        captured = {}
+
+        async def fake_send_state(context, match_obj, player_key, message):
+            captured["cell"] = match_obj.history[0][13][0]
+            captured["saved"] = saved
+
+        monkeypatch.setattr(router15, "_send_state", fake_send_state)
+
+        update = SimpleNamespace(
+            message=SimpleNamespace(text="n1", reply_text=AsyncMock()),
+            effective_user=SimpleNamespace(id=1),
+            effective_chat=SimpleNamespace(id=10),
+        )
+        context = SimpleNamespace(bot=SimpleNamespace(send_message=AsyncMock()), bot_data={})
+
+        await router15.router_text(update, context)
+
+        assert captured["cell"] == 4
+        assert captured["saved"]
+
+    asyncio.run(run())
+
+
+def test_router_updates_board_before_send(monkeypatch):
+    async def run():
+        board_self = Board()
+        board_enemy = Board()
+        ship = Ship(cells=[(0, 0)])
+        board_enemy.ships = [ship]
+        board_enemy.grid[0][0] = 1
+        board_enemy.alive_cells = 1
+        match = SimpleNamespace(
+            status="playing",
+            players={
+                "A": SimpleNamespace(user_id=1, chat_id=10, name="A"),
+                "B": SimpleNamespace(user_id=2, chat_id=20, name="B"),
+            },
+            boards={"A": board_self, "B": board_enemy},
+            turn="A",
+            messages={"A": {}, "B": {}},
+            shots={"A": {"history": []}, "B": {}},
+        )
+        saved = False
+
+        def fake_save_match(m):
+            nonlocal saved
+            saved = True
+
+        monkeypatch.setattr(storage, "find_match_by_user", lambda uid, chat_id=None: match)
+        monkeypatch.setattr(storage, "save_match", fake_save_match)
+        monkeypatch.setattr(router_std, "parse_coord", lambda text: (0, 0))
+        monkeypatch.setattr(router_std, "format_coord", lambda coord: "a1")
+        monkeypatch.setattr(router_std, "_phrase_or_joke", lambda m, pk, ph: "")
+
+        captured = {}
+
+        async def fake_send_state(context, match_obj, player_key, message):
+            captured["cell"] = match_obj.boards["B"].grid[0][0]
+            captured["saved"] = saved
+
+        monkeypatch.setattr(router_std, "_send_state", fake_send_state)
+
+        update = SimpleNamespace(
+            message=SimpleNamespace(text="a1", reply_text=AsyncMock()),
+            effective_user=SimpleNamespace(id=1),
+            effective_chat=SimpleNamespace(id=10),
+        )
+        context = SimpleNamespace(bot=SimpleNamespace(send_message=AsyncMock()), bot_data={})
+
+        await router_std.router_text(update, context)
+
+        assert captured["cell"] == 4
+        assert captured["saved"]
+
+    asyncio.run(run())


### PR DESCRIPTION
## Summary
- Save match state before broadcasting board updates across all modes
- Add regression tests for N1 shots to verify state ordering

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b467d0a2648326821719ef152b7923