### PR TITLE
Increase bot move delay in test game to five seconds

### DIFF
--- a/game_board15/handlers.py
+++ b/game_board15/handlers.py
@@ -410,7 +410,7 @@ async def board15_test(update: Update, context: ContextTypes.DEFAULT_TYPE) -> No
     storage.save_match(match)
     asyncio.create_task(
         _auto_play_bots(
-            match, context, update.effective_chat.id, human='A', delay=3
+            match, context, update.effective_chat.id, human='A', delay=5
         )
     )
 

--- a/handlers/board_test.py
+++ b/handlers/board_test.py
@@ -271,6 +271,6 @@ async def board_test(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None
     )
     asyncio.create_task(
         _auto_play_bots(
-            match, context, update.effective_chat.id, human="A", delay=3
+            match, context, update.effective_chat.id, human="A", delay=5
         )
     )


### PR DESCRIPTION
## Summary
- slow down board test bots by waiting 5 seconds between moves
- apply the same delay for 15x15 test mode bots

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68b476bf01fc8326bcc5fe55493717fa