### PR TITLE
fix board ship rendering after move

### DIFF
--- a/game_board15/handlers.py
+++ b/game_board15/handlers.py
@@ -65,7 +65,8 @@ async def board15(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
     own_grid = match.boards[player_key].grid
     for r in range(15):
         for c in range(15):
-            if merged[r][c] == 0 and own_grid[r][c] == 1:
+            cell = own_grid[r][c]
+            if merged[r][c] == 0 and _get_cell_state(cell) == 1:
                 merged[r][c] = 1
     state.board = merged
     state.player_key = player_key
@@ -147,7 +148,7 @@ async def _auto_play_bots(
         mask = [[False] * 15 for _ in range(15)]
         for r in range(15):
             for c in range(15):
-                if grid[r][c] == 1:
+                if _get_cell_state(grid[r][c]) == 1:
                     for dr in (-1, 0, 1):
                         for dc in (-1, 0, 1):
                             nr, nc = r + dr, c + dc
@@ -192,7 +193,7 @@ async def _auto_play_bots(
             for r in range(15)
             for c in range(15)
             if _get_cell_state(match.history[r][c]) == 0
-            and board.grid[r][c] != 1
+            and _get_cell_state(board.grid[r][c]) != 1
             and not adj[r][c]
         ]
         if not candidates:
@@ -204,7 +205,7 @@ async def _auto_play_bots(
                     (r, c)
                     for r in range(15)
                     for c in range(15)
-                    if enemy_board.grid[r][c] == 1
+                    if _get_cell_state(enemy_board.grid[r][c]) == 1
                 ),
                 None,
             )
@@ -368,9 +369,10 @@ async def board15_test(update: Update, context: ContextTypes.DEFAULT_TYPE) -> No
     own_grid = match.boards['A'].grid
     for r in range(15):
         for c in range(15):
-            if merged[r][c] == 0 and own_grid[r][c] == 1:
+            cell = own_grid[r][c]
+            if merged[r][c] == 0 and _get_cell_state(cell) == 1:
                 merged[r][c] = 1
-                owners[r][c] = 'A'
+                owners[r][c] = _get_cell_owner(cell) or 'A'
     state.board = merged
     state.owners = owners
     state.player_key = 'A'

--- a/game_board15/router.py
+++ b/game_board15/router.py
@@ -40,9 +40,10 @@ async def _send_state(context: ContextTypes.DEFAULT_TYPE, match, player_key: str
     own_grid = match.boards[player_key].grid
     for r in range(15):
         for c in range(15):
-            if merged_states[r][c] == 0 and own_grid[r][c] == 1:
+            cell = own_grid[r][c]
+            if merged_states[r][c] == 0 and _get_cell_state(cell) == 1:
                 merged_states[r][c] = 1
-                owners[r][c] = player_key
+                owners[r][c] = _get_cell_owner(cell) or player_key
     state.board = merged_states
     state.owners = owners
     state.player_key = player_key
@@ -135,7 +136,7 @@ async def router_text(update: Update, context: ContextTypes.DEFAULT_TYPE) -> Non
         await update.message.reply_text('Не понял клетку. Пример: e5.')
         return
     r, c = coord
-    if match.boards[player_key].grid[r][c] == 1:
+    if _get_cell_state(match.boards[player_key].grid[r][c]) == 1:
         await update.message.reply_text('Здесь ваш корабль')
         return
 

--- a/handlers/board_test.py
+++ b/handlers/board_test.py
@@ -22,6 +22,11 @@ from logic.phrases import (
 )
 
 
+def _cell_state(cell):
+    """Return state value for a possibly annotated board cell."""
+    return cell[0] if isinstance(cell, (list, tuple)) else cell
+
+
 def _phrase_or_joke(match, player_key: str, phrases: list[str]) -> str:
     shots = match.shots[player_key]
     start = shots.get("joke_start")
@@ -94,7 +99,7 @@ async def _auto_play_bots(
         coord = None
         for pt in coords:
             r, c = pt
-            if match.history[r][c] == 0 and match.boards[current].grid[r][c] != 1:
+            if match.history[r][c] == 0 and _cell_state(match.boards[current].grid[r][c]) != 1:
                 coord = pt
                 break
         if coord is None:

--- a/handlers/router.py
+++ b/handlers/router.py
@@ -27,6 +27,16 @@ from logic.phrases import (
 )
 
 
+def _cell_state(cell):
+    """Return numerical state from a board cell.
+
+    Cells may store a plain integer or a ``(state, owner)`` tuple. This
+    helper extracts the state value so that comparisons work regardless of the
+    underlying representation.
+    """
+    return cell[0] if isinstance(cell, (list, tuple)) else cell
+
+
 # Delay after sending the board and before sending/editing the result text.
 # Can be tuned with the ``STATE_DELAY`` environment variable.
 STATE_DELAY = float(os.getenv("STATE_DELAY", "0.2"))
@@ -123,8 +133,10 @@ async def _send_state_board_test(
     own_grid = match.boards[player_key].grid
     for r in range(10):
         for c in range(10):
-            if merged[r][c] == 0 and own_grid[r][c] == 1:
-                merged[r][c] = 1
+            cell = own_grid[r][c]
+            if merged[r][c] == 0 and _cell_state(cell) == 1:
+                # Preserve owner information by copying the full cell value
+                merged[r][c] = cell
     board = Board(grid=merged, highlight=getattr(match, "last_highlight", []).copy())
     board_text = f"Ваше поле:\n{render_board_own(board)}"
     kb = move_keyboard()


### PR DESCRIPTION
## Summary
- ensure ship cells remain visible when merging board state with history
- normalise cell state checks to support tuple-formatted cells

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b4751c41848326ba394b47a9b1e769