### PR TITLE
Guard miss history from friendly ships

### DIFF
--- a/game_board15/battle.py
+++ b/game_board15/battle.py
@@ -91,5 +91,7 @@ def update_history(
         hit_key = next((k for k, res in results.items() if res == HIT), None)
         _set_cell_state(history, r, c, 3, hit_key)
     elif all(res == MISS for res in results.values()):
-        if _get_cell_state(history[r][c]) == 0:
+        if _get_cell_state(history[r][c]) == 0 and all(
+            _get_cell_state(b.grid[r][c]) != 1 for b in boards.values()
+        ):
             _set_cell_state(history, r, c, 2)

--- a/game_board15/router.py
+++ b/game_board15/router.py
@@ -145,7 +145,9 @@ async def router_text(update: Update, context: ContextTypes.DEFAULT_TYPE) -> Non
     for b in match.boards.values():
         if b.highlight:
             for rr, cc in b.highlight:
-                if _get_cell_state(match.history[rr][cc]) == 0:
+                if _get_cell_state(match.history[rr][cc]) == 0 and all(
+                    _get_cell_state(bb.grid[rr][cc]) != 1 for bb in match.boards.values()
+                ):
                     _set_cell_state(match.history, rr, cc, 2)
         b.highlight = []
 

--- a/logic/battle_test.py
+++ b/logic/battle_test.py
@@ -64,13 +64,17 @@ def apply_shot_multi(
                     for dc in (-1, 0, 1):
                         nr, nc = rr + dr, cc + dc
                         if 0 <= nr < 10 and 0 <= nc < 10:
-                            if _get_cell_state(history[nr][nc]) == 0:
+                            if _get_cell_state(history[nr][nc]) == 0 and all(
+                                _get_cell_state(b.grid[nr][nc]) != 1 for b in boards.values()
+                            ):
                                 _set_cell_state(history, nr, nc, 5)
         _set_cell_state(history, r, c, 4)
     elif any(res == HIT for res in results.values()):
         _set_cell_state(history, r, c, 3)
     elif all(res == MISS for res in results.values()):
-        if _get_cell_state(history[r][c]) == 0:
+        if _get_cell_state(history[r][c]) == 0 and all(
+            _get_cell_state(b.grid[r][c]) != 1 for b in boards.values()
+        ):
             _set_cell_state(history, r, c, 2)
 
     return results


### PR DESCRIPTION
## Summary
- Avoid recording misses in shared history when any board still has a ship at the target cell
- Skip persisting highlights as dots when friendly ships occupy the cell
- Prevent test harness from marking misses/contours over living ships and add regression coverage

## Testing
- `pytest tests/test_board15_history.py::test_friendly_ship_survives_other_board_miss -q`
- `pytest tests/test_board15_history.py -q`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b4910a85308326b40ca2565d01672c