### PR TITLE
Handle multiple hit results and add m1 hit test

### DIFF
--- a/game_board15/battle.py
+++ b/game_board15/battle.py
@@ -88,8 +88,9 @@ def update_history(
             for rr, cc in ship.cells:
                 _set_cell_state(history, rr, cc, 4, key)
     elif any(res == HIT for res in results.values()):
-        hit_key = next((k for k, res in results.items() if res == HIT), None)
-        _set_cell_state(history, r, c, 3, hit_key)
+        for key, res in results.items():
+            if res == HIT:
+                _set_cell_state(history, r, c, 3, key)
     elif all(res == MISS for res in results.values()):
         if _get_cell_state(history[r][c]) == 0 and all(
             _get_cell_state(b.grid[r][c]) != 1 for b in boards.values()


### PR DESCRIPTION
## Summary
- Ensure `update_history` records every HIT result rather than just the first
- Add regression test verifying that a hit at m1 marks history and board as wounded

## Testing
- `pytest tests/test_board15_history.py::test_hit_at_m1_updates_history_and_board -q`
- `pytest tests/test_board15_history.py -q`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b49fac5d7c8326b6daab6573f5a7e0