### PR TITLE
Ignore ships on unrelated boards when marking miss

### DIFF
--- a/game_board15/battle.py
+++ b/game_board15/battle.py
@@ -93,6 +93,6 @@ def update_history(
                 _set_cell_state(history, r, c, 3, key)
     elif all(res == MISS for res in results.values()):
         if _get_cell_state(history[r][c]) == 0 and all(
-            _get_cell_state(b.grid[r][c]) != 1 for b in boards.values()
+            _get_cell_state(boards[k].grid[r][c]) != 1 for k in results
         ):
             _set_cell_state(history, r, c, 2)


### PR DESCRIPTION
## Summary
- ensure update_history considers only boards included in shot results when deciding a miss
- test that foreign-board ships no longer block miss history and rendering
- adjust existing friendly board test to match new miss behavior

## Testing
- `pytest tests/test_board15_history.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b4af9bb554832683e89ea420a35e08