### PR TITLE
Add two-player board test mode with bot opponent

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -25,7 +25,8 @@ from handlers.commands import (
     confirm_newgame,
     confirm_join,
 )
-from handlers.router import router_text
+from handlers.board_test import board_test_two
+from handlers.router import router_text, router_text_board_test_two
 
 BOARD15_ENABLED = os.getenv("BOARD15_ENABLED") == "1"
 BOARD15_TEST_ENABLED = os.getenv("BOARD15_TEST_ENABLED") == "1"
@@ -70,6 +71,7 @@ bot_app = ApplicationBuilder().token(token).updater(None).build()
 bot_app.add_handler(CommandHandler("start", start))
 bot_app.add_handler(CommandHandler("newgame", newgame))
 bot_app.add_handler(CommandHandler("board", board))
+bot_app.add_handler(CommandHandler("boardtest2", board_test_two))
 bot_app.add_handler(CommandHandler(["quit", "exit"], quit_game))
 bot_app.add_handler(CallbackQueryHandler(send_invite_link, pattern="^get_link$"))
 bot_app.add_handler(CallbackQueryHandler(choose_mode, pattern="^mode_test2$"))
@@ -81,6 +83,10 @@ if BOARD15_ENABLED:
     bot_app.add_handler(CallbackQueryHandler(send_board15_invite_link, pattern="^b15_get_link$"))
     if BOARD15_TEST_ENABLED:
         bot_app.add_handler(CommandHandler("board15test", board15_test))
+bot_app.add_handler(
+    MessageHandler(filters.TEXT & ~filters.COMMAND, router_text_board_test_two),
+    block=False,
+)
 bot_app.add_handler(MessageHandler(filters.TEXT & ~filters.COMMAND, router_text))
 
 

--- a/handlers/commands.py
+++ b/handlers/commands.py
@@ -13,6 +13,7 @@ import os
 
 import storage
 from logic.render import render_board_own, render_board_enemy
+from .board_test import board_test_two
 
 
 logger = logging.getLogger(__name__)
@@ -312,6 +313,11 @@ async def choose_mode(update: Update, context: ContextTypes.DEFAULT_TYPE) -> Non
     elif query.data == 'mode_3':
         await query.message.reply_text('Используйте /board15 для игры втроем на поле 15×15.')
     elif query.data == 'mode_test2':
-        await query.message.reply_text('Используйте /boardtest2 для тестовой игры вдвоем.')
+        fake_update = SimpleNamespace(
+            message=query.message,
+            effective_user=query.from_user,
+            effective_chat=query.message.chat,
+        )
+        await board_test_two(fake_update, context)
     elif query.data == 'mode_test3':
         await query.message.reply_text('Используйте /board15test для тестовой игры втроем.')


### PR DESCRIPTION
## Summary
- add a dedicated two-player test match that seeds both boards, flags the mode, and starts a bot-driven coroutine
- implement routing for the new mode so human turns and bot replies reuse the standard board renderer while skipping bot messaging
- register the `/boardtest2` command and hook the start menu callback to launch the new mode automatically

## Testing
- pytest tests/test_board_test_start.py
- pytest tests/test_history_before_send.py
- pytest tests/test_board_test_last_highlight.py

------
https://chatgpt.com/codex/tasks/task_e_68de4957257c83269257752a6a5f2803