### PR TITLE
Improve shared board placement and add regression test

### DIFF
--- a/tests/test_three_player_full_fleet.py
+++ b/tests/test_three_player_full_fleet.py
@@ -1,0 +1,11 @@
+from logic import placement
+
+
+def test_three_player_full_fleet():
+    global_mask = [[0] * 15 for _ in range(15)]
+
+    boards = [placement.random_board_global(global_mask) for _ in range(3)]
+
+    for board in boards:
+        total = sum(cell == 1 for row in board.grid for cell in row)
+        assert total == 20


### PR DESCRIPTION
## Summary
- allow `logic.placement.can_place` to operate on dynamically-sized grids
- rework `random_board_global` to place ships while checking only real ship cells against the shared mask and to update the global contour once accepted
- add a regression test that exercises three sequential placements against a shared 15×15 mask

## Testing
- pytest tests/test_three_player_full_fleet.py
- pytest tests/test_placement.py

------
https://chatgpt.com/codex/tasks/task_e_68de4e110fd0832689e6e0a32a7ea0b4