### PR TITLE
Normalize webhook URL configuration

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -28,6 +28,9 @@ from handlers.commands import (
 from handlers.board_test import board_test_two
 from handlers.router import router_text, router_text_board_test_two
 
+from app.webhook_utils import normalize_webhook_base
+
+
 BOARD15_ENABLED = os.getenv("BOARD15_ENABLED") == "1"
 BOARD15_TEST_ENABLED = os.getenv("BOARD15_TEST_ENABLED") == "1"
 if BOARD15_ENABLED:
@@ -43,13 +46,15 @@ token = os.getenv("BOT_TOKEN")
 if not token:
     raise RuntimeError("BOT_TOKEN environment variable is not set")
 
-webhook_url = os.getenv("WEBHOOK_URL")
-if not webhook_url:
+webhook_url_raw = os.getenv("WEBHOOK_URL")
+if not webhook_url_raw:
     raise RuntimeError("WEBHOOK_URL environment variable is not set")
-webhook_url = webhook_url.rstrip("/")
+webhook_url = normalize_webhook_base(webhook_url_raw)
 
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
+
+logger.info("Using webhook base URL %s", webhook_url)
 
 
 def _handle_exit(sig: int, frame: object | None) -> None:

--- a/app/webhook_utils.py
+++ b/app/webhook_utils.py
@@ -1,0 +1,30 @@
+"""Utilities for normalising webhook URLs."""
+
+
+def normalize_webhook_base(raw_url: str) -> str:
+    """Normalise a webhook base URL by removing trailing slashes and suffixes.
+
+    Telegram expects the webhook endpoint to end with ``/webhook``. Operators
+    may configure the environment variable with or without that suffix,
+    potentially including extra trailing slashes. This helper ensures we always
+    compute the effective base URL consistently so the final webhook path is
+    predictable.
+
+    Parameters
+    ----------
+    raw_url:
+        The URL provided via configuration, typically the ``WEBHOOK_URL``
+        environment variable.
+
+    Returns
+    -------
+    str
+        The normalised base URL without the ``/webhook`` suffix.
+    """
+
+    normalized = raw_url.rstrip("/")
+    if normalized.endswith("/webhook"):
+        normalized = normalized[: -len("/webhook")]
+        normalized = normalized.rstrip("/")
+    return normalized
+

--- a/tests/test_webhook_url.py
+++ b/tests/test_webhook_url.py
@@ -1,0 +1,32 @@
+import pytest
+
+from app.webhook_utils import normalize_webhook_base
+
+
+@pytest.mark.parametrize(
+    "raw_url, expected_base",
+    [
+        ("https://host", "https://host"),
+        ("https://host/webhook", "https://host"),
+        ("https://host/webhook/", "https://host"),
+    ],
+)
+def test_normalize_webhook_base(raw_url: str, expected_base: str) -> None:
+    assert normalize_webhook_base(raw_url) == expected_base
+
+
+@pytest.mark.parametrize(
+    "raw_url",
+    [
+        "https://host",
+        "https://host/webhook",
+    ],
+)
+def test_webhook_path_has_single_suffix(raw_url: str) -> None:
+    base = normalize_webhook_base(raw_url)
+    webhook = f"{base}/webhook"
+
+    assert webhook.endswith("/webhook")
+    assert webhook.count("/webhook") == 1
+    assert webhook == "https://host/webhook"
+


### PR DESCRIPTION
## Summary
- normalise the configured webhook base URL, including removing redundant /webhook suffixes
- log the effective base URL and build the webhook endpoint from the normalised value
- add unit tests covering webhook URL normalisation scenarios

## Testing
- pytest tests/test_webhook_url.py

------
https://chatgpt.com/codex/tasks/task_e_68de649e080483269f4a9c7cf3613b3c