### PR TITLE
Adjust contour marking for variable board sizes

### DIFF
--- a/logic/battle.py
+++ b/logic/battle.py
@@ -33,12 +33,17 @@ def mark_contour(board: Board, cells: list[Tuple[int, int]]) -> None:
     around the destroyed ship becomes unavailable for subsequent shots.
     """
 
+    rows = len(board.grid)
+    cols = len(board.grid[0]) if rows else 0
+    if rows == 0 or cols == 0:
+        return
+
     contour: set[Tuple[int, int]] = set()
     for r, c in cells:
         for dr in (-1, 0, 1):
             for dc in (-1, 0, 1):
                 nr, nc = r + dr, c + dc
-                if 0 <= nr < 10 and 0 <= nc < 10:
+                if 0 <= nr < rows and 0 <= nc < cols:
                     contour.add((nr, nc))
 
     for r, c in contour.difference(cells):

--- a/tests/test_battle.py
+++ b/tests/test_battle.py
@@ -51,3 +51,18 @@ def test_apply_shot_kill_marks_contour():
     assert apply_shot(board, (1, 2)) == KILL
     assert _state(board.grid[0][0]) == 5
     assert _state(board.grid[2][3]) == 5
+
+
+def test_apply_shot_kill_marks_contour_on_larger_board_edge():
+    board = Board()
+    board.grid = _new_grid(15)
+    ship = Ship(cells=[(14, 14)])
+    board.ships.append(ship)
+    board.grid[14][14] = [1, 'A']
+    board.alive_cells = 1
+
+    assert apply_shot(board, (14, 14)) == KILL
+    assert _state(board.grid[14][14]) == 4
+    assert _state(board.grid[13][13]) == 5
+    assert _state(board.grid[13][14]) == 5
+    assert _state(board.grid[14][13]) == 5


### PR DESCRIPTION
## Summary
- update `logic.battle.mark_contour` to derive board dimensions before marking neighbours
- guard against empty grids and rely on computed bounds for contour updates
- add a regression test that destroys an edge ship on a 15×15 board to ensure contour cells are marked as shot

## Testing
- `pytest tests/test_battle.py`


------
https://chatgpt.com/codex/tasks/task_e_68def2e86fe48326a1c8ceee022ba02b