### PR TITLE
Ensure own ships override history markers

### DIFF
--- a/game_board15/router.py
+++ b/game_board15/router.py
@@ -41,9 +41,9 @@ async def _send_state(context: ContextTypes.DEFAULT_TYPE, match, player_key: str
     for r in range(15):
         for c in range(15):
             cell = own_grid[r][c]
-            if merged_states[r][c] == 0 and _get_cell_state(cell) == 1:
+            if _get_cell_state(cell) == 1:
                 merged_states[r][c] = 1
-                owners[r][c] = _get_cell_owner(cell) or player_key
+                owners[r][c] = player_key
     state.board = merged_states
     state.owners = owners
     state.player_key = player_key

--- a/tests/test_board15_keyboard.py
+++ b/tests/test_board15_keyboard.py
@@ -81,3 +81,37 @@ def test_history_not_recorded_when_inactive(monkeypatch):
         assert match.messages["A"]["board_history"] == []
         assert match.messages["A"]["text_history"] == []
     asyncio.run(run_test())
+
+
+def test_send_state_shows_own_ships_even_with_history_marks(monkeypatch):
+    async def run_test():
+        match = SimpleNamespace(
+            players={"A": SimpleNamespace(chat_id=1)},
+            boards={"A": Board15()},
+            history=_new_grid(15),
+            messages={"A": {"history_active": False, "board_history": [], "text_history": []}},
+        )
+        match.boards["A"].grid[2][3] = 1
+        match.history[2][3] = [3, "B"]
+
+        captured = {}
+
+        def fake_render(state, player_key=None):
+            captured["board"] = [row[:] for row in state.board]
+            captured["owners"] = [row[:] for row in state.owners]
+            return BytesIO(b"img")
+
+        monkeypatch.setattr(router, "render_board", fake_render)
+        monkeypatch.setattr(router.storage, "save_match", lambda m: None)
+        bot = SimpleNamespace(
+            send_photo=AsyncMock(return_value=SimpleNamespace(message_id=1)),
+            send_message=AsyncMock(),
+        )
+        context = SimpleNamespace(bot=bot, bot_data={}, chat_data={})
+
+        await router._send_state(context, match, "A", "msg")
+
+        assert captured["board"][2][3] == 1
+        assert captured["owners"][2][3] == "A"
+
+    asyncio.run(run_test())


### PR DESCRIPTION
## Summary
- ensure a player's own ships are always merged into the rendered board state
- add a regression test verifying ships remain visible when history contains another state code

## Testing
- pytest tests/test_board15_keyboard.py::test_send_state_shows_own_ships_even_with_history_marks

------
https://chatgpt.com/codex/tasks/task_e_68df7b20aac883268716e562a2a790f0