### PR TITLE
Ensure router stamps fallback history cell

### DIFF
--- a/game_board15/router.py
+++ b/game_board15/router.py
@@ -183,7 +183,13 @@ async def router_text(update: Update, context: ContextTypes.DEFAULT_TYPE) -> Non
         logger.warning("History unchanged after shot %s", coord_str)
     if history_empty:
         logger.warning("History is empty after shot %s", coord_str)
-    if history_unchanged or history_empty:
+    cell_state = _get_cell_state(match.history[r][c])
+    if cell_state == 0:
+        logger.warning(
+            "History cell %s is still empty after shot %s; applying fallback",
+            (r, c),
+            coord_str,
+        )
         if any(res == battle.KILL for res in results.values()):
             best_value = 4
             owner = next(


### PR DESCRIPTION
## Summary
- ensure router_text logs and stamps the shot cell when update_history leaves it empty
- add regression coverage to verify fallback stamping before `_send_state`

## Testing
- pytest tests/test_board15_router.py::test_router_text_fallback_stamps_cell -q

------
https://chatgpt.com/codex/tasks/task_e_68dff12c85b08326ba9aac3bbc7df496