### PR TITLE
Preserve prior states when marking kill contours

### DIFF
--- a/game_board15/battle.py
+++ b/game_board15/battle.py
@@ -78,13 +78,14 @@ def update_history(
                     for dc in (-1, 0, 1):
                         nr, nc = rr + dr, cc + dc
                         if 0 <= nr < 15 and 0 <= nc < 15:
-                            _set_cell_state(
-                                history,
-                                nr,
-                                nc,
-                                5,
-                                _get_cell_owner(history[nr][nc]),
-                            )
+                            if _get_cell_state(history[nr][nc]) == 0:
+                                _set_cell_state(
+                                    history,
+                                    nr,
+                                    nc,
+                                    5,
+                                    _get_cell_owner(history[nr][nc]),
+                                )
             for rr, cc in ship.cells:
                 _set_cell_state(history, rr, cc, 4, key)
     elif any(res == HIT for res in results.values()):


### PR DESCRIPTION
## Summary
- avoid overwriting existing history entries when a kill contour is drawn
- update board15 history tests to cover preservation of prior results and contouring behavior
- adjust related router/history expectations to reflect persistent shot results

## Testing
- pytest tests/test_board15_history.py tests/test_board15_router.py

------
https://chatgpt.com/codex/tasks/task_e_68dff212a8308326a164b0911ca99ded