### PR TITLE
Make board rendering HTML-safe

### DIFF
--- a/game_board15/router.py
+++ b/game_board15/router.py
@@ -41,9 +41,13 @@ async def _send_state(context: ContextTypes.DEFAULT_TYPE, match, player_key: str
     for r in range(15):
         for c in range(15):
             cell = own_grid[r][c]
-            if _get_cell_state(cell) == 1:
-                merged_states[r][c] = 1
-                owners[r][c] = player_key
+            if _get_cell_state(cell) != 1:
+                continue
+            history_state = merged_states[r][c]
+            if history_state in {2, 5}:
+                continue
+            merged_states[r][c] = 1
+            owners[r][c] = player_key
     state.board = merged_states
     state.owners = owners
     state.player_key = player_key

--- a/logic/render.py
+++ b/logic/render.py
@@ -16,18 +16,18 @@ FIGURE_SPACE = "\u2007"
 # expanded slightly so that emoji icons do not stretch rows or columns
 CELL_WIDTH = 3
 
-# colours per player for ship cells
+# colourful emoji per player for ship cells
 PLAYER_COLORS = {
-    "A": "#add8e6",  # light blue
-    "B": "#90ee90",  # light green
-    "C": "#ffc88c",  # light orange
+    "A": "🟦",
+    "B": "🟩",
+    "C": "🟧",
 }
 
-# darker colours for hit cells per player
+# darker emoji for hit cells per player
 PLAYER_COLORS_DARK = {
-    "A": "#00008b",  # dark blue
-    "B": "#228b22",  # dark green
-    "C": "#ff8c00",  # dark orange
+    "A": "🔵",
+    "B": "🟢",
+    "C": "🟠",
 }
 
 
@@ -76,37 +76,28 @@ def render_board_own(board: Board) -> str:
         for c_idx, v in enumerate(row):
             coord = (r_idx, c_idx)
             cell_state, owner = _resolve_cell(v)
-            color = PLAYER_COLORS.get(owner or getattr(board, "owner", None), "#000")
+            owner_id = owner or getattr(board, "owner", None)
+            ship_symbol = PLAYER_COLORS.get(owner_id, "⬜")
+            hit_symbol = PLAYER_COLORS_DARK.get(owner_id, "💥")
             if cell_state == 1:
-                sym = f'<span style="color:{color}">□</span>'
+                sym = ship_symbol
             elif cell_state == 2:
-                if coord in highlight:
-                    sym = '<span style="color:red;background-color:orange">x</span>'
-                else:
-                    sym = '<span style="color:black">x</span>'
+                sym = "✖"
             elif cell_state == 5:
-                if coord in highlight:
-                    sym = '<span style="color:red;background-color:orange">x</span>'
-                else:
-                    sym = '<span style="color:#808080">x</span>'
+                sym = "•"
             elif cell_state == 3:
-                if coord in highlight:
-                    hit_color = "#8b0000"
-                else:
-                    hit_color = PLAYER_COLORS_DARK.get(
-                        owner or getattr(board, "owner", None), "#8b0000"
-                    )
-                sym = f'<span style="color:{hit_color}">■</span>'
+                sym = hit_symbol
             elif cell_state == 4:
-                if coord in highlight:
-                    sym = BOMB
-                else:
-                    hit_color = "#ff8c00" if owner == "C" else "#8b0000"
-                    sym = f'<span style="color:{hit_color}">■</span>'
+                sym = "💥"
             else:
-                sym = '·'
+                sym = "·"
             if coord in highlight:
-                sym = f'<span style="border:1px solid red">{sym}</span>'
+                if cell_state == 4:
+                    sym = f"<b>{BOMB}</b>"
+                elif cell_state == 5:
+                    sym = "<b>⚠️</b>"
+                else:
+                    sym = f"<b>{sym}</b>"
             cells.append(format_cell(sym))
         num = str(r_idx + 1)
         pad = FIGURE_SPACE * (CELL_WIDTH - wcswidth(num))
@@ -122,37 +113,27 @@ def render_board_enemy(board: Board) -> str:
         for c_idx, v in enumerate(row):
             coord = (r_idx, c_idx)
             cell_state, owner = _resolve_cell(v)
-            color = PLAYER_COLORS.get(owner or getattr(board, "owner", None), "#000")
+            owner_id = owner or getattr(board, "owner", None)
+            hit_symbol = PLAYER_COLORS_DARK.get(owner_id, "💥")
             if cell_state == 1:
-                sym = '·'
+                sym = "·"
             elif cell_state == 2:
-                if coord in highlight:
-                    sym = '<span style="color:red;background-color:orange">x</span>'
-                else:
-                    sym = '<span style="color:black">x</span>'
+                sym = "✖"
             elif cell_state == 5:
-                if coord in highlight:
-                    sym = '<span style="color:red;background-color:orange">x</span>'
-                else:
-                    sym = '<span style="color:#808080">x</span>'
+                sym = "•"
             elif cell_state == 3:
-                if coord in highlight:
-                    hit_color = "#8b0000"
-                else:
-                    hit_color = PLAYER_COLORS_DARK.get(
-                        owner or getattr(board, "owner", None), "#8b0000"
-                    )
-                sym = f'<span style="color:{hit_color}">■</span>'
+                sym = hit_symbol
             elif cell_state == 4:
-                if coord in highlight:
-                    sym = BOMB
-                else:
-                    hit_color = "#ff8c00" if owner == "C" else "#8b0000"
-                    sym = f'<span style="color:{hit_color}">■</span>'
+                sym = "💥"
             else:
-                sym = '·'
+                sym = "·"
             if coord in highlight:
-                sym = f'<span style="border:1px solid red">{sym}</span>'
+                if cell_state == 4:
+                    sym = f"<b>{BOMB}</b>"
+                elif cell_state == 5:
+                    sym = "<b>⚠️</b>"
+                else:
+                    sym = f"<b>{sym}</b>"
             cells.append(format_cell(sym))
         num = str(r_idx + 1)
         pad = FIGURE_SPACE * (CELL_WIDTH - wcswidth(num))

--- a/tests/test_render.py
+++ b/tests/test_render.py
@@ -39,22 +39,20 @@ def test_render_last_move_symbols():
     b.grid[0][0] = [2, 'A']
     b.highlight = [(0, 0)]
     own = render_board_own(b)
-    assert "border:1px solid red" in own
-    assert "background-color:orange" in own
+    assert "<b>✖</b>" in own
     b.highlight = []
     own = render_board_own(b)
-    assert "border:1px solid red" not in own
-    assert 'background-color:orange' not in own
-    assert '<span style="color:black">x</span>' in own
+    assert "<b>✖</b>" not in own
+    assert '✖' in own
 
     # hit highlight
     b.grid[1][1] = [3, 'B']
     b.highlight = [(1, 1)]
     enemy = render_board_enemy(b)
-    assert "border:1px solid red" in enemy and "#8b0000" in enemy
+    assert f"<b>{PLAYER_COLORS_DARK['B']}</b>" in enemy
     b.highlight = []
     enemy = render_board_enemy(b)
-    assert "border:1px solid red" not in enemy and PLAYER_COLORS_DARK['B'] in enemy
+    assert f"<b>{PLAYER_COLORS_DARK['B']}</b>" not in enemy and PLAYER_COLORS_DARK['B'] in enemy
 
     # kill highlight
     b.grid[2][2] = [4, 'B']
@@ -64,21 +62,21 @@ def test_render_last_move_symbols():
     b.highlight = [(2, 2)]
     enemy = render_board_enemy(b)
     assert enemy.count(BOMB) == 1
-    assert enemy.count("border:1px solid red") == 1
+    assert enemy.count('<b>') == 1
 
     # highlight the contour cell
     b.highlight = [(2, 3)]
     enemy = render_board_enemy(b)
     assert BOMB not in enemy
-    assert enemy.count('background-color:orange') >= 1
-    assert enemy.count("border:1px solid red") == 1
+    assert enemy.count('⚠️') >= 1
+    assert enemy.count('<b>') >= 1
 
     # no highlight
     b.highlight = []
     enemy = render_board_enemy(b)
-    assert BOMB not in enemy and "border:1px solid red" not in enemy
-    assert '<span style="color:#8b0000">■</span>' in enemy
-    assert '<span style="color:black">x</span>' in enemy
+    assert BOMB not in enemy and '<b>' not in enemy
+    assert '💥' in enemy
+    assert '✖' in enemy
 
 
 def test_apply_shot_marks_contour():
@@ -109,5 +107,5 @@ def test_render_state5_symbol():
     own = render_board_own(b)
     enemy = render_board_enemy(b)
 
-    assert '<span style="color:#808080">x</span>' in own
-    assert '<span style="color:#808080">x</span>' in enemy
+    assert '•' in own
+    assert '•' in enemy


### PR DESCRIPTION
## Summary
- replace inline styles in the text board renderer with emoji markers and bold tags that are compatible with Telegram HTML
- adjust render-related tests to assert the new symbols and highlight markup
- keep 15x board renders from overwriting recorded misses when merging a player's ships

## Testing
- pytest tests/test_render.py tests/test_board_command.py tests/test_router_text.py tests/test_board15_history.py tests/test_board15_keyboard.py -q

------
https://chatgpt.com/codex/tasks/task_e_68dff296ecfc83268d4aa0d030486d6d