### PR TITLE
Switch board rendering to Cyrillic axes and ASCII symbols

### DIFF
--- a/logic/parser.py
+++ b/logic/parser.py
@@ -2,11 +2,10 @@ from __future__ import annotations
 import re
 from typing import Optional, Tuple
 
-# Columns on the board are identified by latin letters when rendered for
-# users, while internally we still support both latin and Cyrillic inputs.
-# ``ROWS`` keeps the Cyrillic representation to remain backward compatible
-# with existing games, and ``LATIN`` mirrors it with latin characters so that
-# outbound messages and rendered boards use latin coordinates.
+# Columns on the board use Cyrillic letters in user-facing messages, while we
+# still accept latin input for convenience. ``ROWS`` keeps the Cyrillic
+# representation and ``LATIN`` mirrors it with latin characters so that we can
+# normalise incoming coordinates.
 ROWS = 'абвгдежзик'
 LATIN = 'abcdefghik'
 
@@ -17,7 +16,7 @@ def normalize(cell: str) -> str:
 
 
 def parse_coord(cell: str) -> Optional[Tuple[int, int]]:
-    """Parse user coordinate like 'e5' into (row, col)."""
+    """Parse user coordinate like 'г7' or 'e5' into ``(row, col)``."""
     cell = normalize(cell)
     if len(cell) < 2:
         return None
@@ -38,11 +37,6 @@ def parse_coord(cell: str) -> Optional[Tuple[int, int]]:
 
 
 def format_coord(coord: Tuple[int, int]) -> str:
-    """Convert internal (row, col) into user-facing string.
-
-    Even though we accept both latin and Cyrillic letters as input, users see
-    the board labelled with latin letters.  Therefore coordinates in outgoing
-    messages must also use latin letters.
-    """
+    """Convert internal (row, col) into user-facing string with Cyrillic axes."""
     r, c = coord
-    return f"{LATIN[c]}{r+1}"
+    return f"{ROWS[c]}{r+1}"

--- a/tests/test_render.py
+++ b/tests/test_render.py
@@ -1,34 +1,22 @@
-import pytest
-from logic.render import (
-    render_board_own,
-    render_board_enemy,
-    PLAYER_COLORS,
-    PLAYER_COLORS_DARK,
-)
+from logic.render import render_board_own, render_board_enemy
 from logic.battle import apply_shot, KILL
 from models import Board, Ship
 from tests.utils import _new_grid, _state
 from constants import BOMB
 
 
-def test_render_board_own_uses_board_owner_color():
+def test_render_board_own_renders_ship_symbol():
     b = Board(owner='A')
     b.grid[0][0] = 1
     own = render_board_own(b)
-    assert PLAYER_COLORS['A'] in own
-@pytest.mark.parametrize(
-    "owner, expected",
-    [
-        ("A", PLAYER_COLORS_DARK["A"]),
-        ("B", PLAYER_COLORS_DARK["B"]),
-        ("C", PLAYER_COLORS_DARK["C"]),
-    ],
-)
-def test_render_board_enemy_marks_hit_player_color(owner, expected):
-    b = Board(owner=owner)
+    assert '■' in own
+
+
+def test_render_board_enemy_marks_hit():
+    b = Board(owner='A')
     b.grid[0][0] = 3
     enemy = render_board_enemy(b)
-    assert expected in enemy
+    assert '■' in enemy
 
 
 def test_render_last_move_symbols():
@@ -39,20 +27,20 @@ def test_render_last_move_symbols():
     b.grid[0][0] = [2, 'A']
     b.highlight = [(0, 0)]
     own = render_board_own(b)
-    assert "<b>✖</b>" in own
+    assert "<b>x</b>" in own
     b.highlight = []
     own = render_board_own(b)
-    assert "<b>✖</b>" not in own
-    assert '✖' in own
+    assert "<b>x</b>" not in own
+    assert 'x' in own
 
     # hit highlight
     b.grid[1][1] = [3, 'B']
     b.highlight = [(1, 1)]
     enemy = render_board_enemy(b)
-    assert f"<b>{PLAYER_COLORS_DARK['B']}</b>" in enemy
+    assert "<b>■</b>" in enemy
     b.highlight = []
     enemy = render_board_enemy(b)
-    assert f"<b>{PLAYER_COLORS_DARK['B']}</b>" not in enemy and PLAYER_COLORS_DARK['B'] in enemy
+    assert "<b>■</b>" not in enemy and '■' in enemy
 
     # kill highlight
     b.grid[2][2] = [4, 'B']
@@ -68,15 +56,15 @@ def test_render_last_move_symbols():
     b.highlight = [(2, 3)]
     enemy = render_board_enemy(b)
     assert BOMB not in enemy
-    assert enemy.count('⚠️') >= 1
+    assert enemy.count('x') >= 1
     assert enemy.count('<b>') >= 1
 
     # no highlight
     b.highlight = []
     enemy = render_board_enemy(b)
     assert BOMB not in enemy and '<b>' not in enemy
-    assert '💥' in enemy
-    assert '✖' in enemy
+    assert '▓' in enemy
+    assert 'x' in enemy
 
 
 def test_apply_shot_marks_contour():
@@ -107,5 +95,5 @@ def test_render_state5_symbol():
     own = render_board_own(b)
     enemy = render_board_enemy(b)
 
-    assert '•' in own
-    assert '•' in enemy
+    assert '·' in own
+    assert 'x' in enemy


### PR DESCRIPTION
## Summary
- replace the board renderers with ASCII symbols, Cyrillic axis labels, and the required contour markers
- return Cyrillic coordinates from the parser to match the new board labels
- update render tests for the new symbols and highlight behaviour

## Testing
- pytest tests/test_render.py

------
https://chatgpt.com/codex/tasks/task_e_68dffe31e6008326861fb2011830f3ed