### PR TITLE
Adjust board axis labels for renderers

### DIFF
--- a/logic/render.py
+++ b/logic/render.py
@@ -31,7 +31,7 @@ def format_cell(symbol: str) -> str:
     return symbol + " " * pad
 
 
-COL_NUMBERS = ''.join(format_cell(str(i)) for i in range(1, 11))
+COL_HEADERS = ''.join(format_cell(letter) for letter in ROWS)
 
 
 def _render_line(cells: List[str]) -> str:
@@ -50,7 +50,7 @@ def _resolve_cell(v: Union[int, Tuple[int, str]]) -> Tuple[int, str | None]:
 
 
 def render_board_own(board: Board) -> str:
-    header = format_cell("") + "|" + " " + COL_NUMBERS
+    header = format_cell("") + "|" + " " + COL_HEADERS
     lines = [header]
     highlight = set(board.highlight)
     for r_idx, row in enumerate(board.grid):
@@ -76,13 +76,13 @@ def render_board_own(board: Board) -> str:
                 else:
                     sym = f"<b>{sym}</b>"
             cells.append(format_cell(sym))
-        row_label = format_cell(ROWS[r_idx])
+        row_label = format_cell(str(r_idx + 1))
         lines.append(f"{row_label}| " + _render_line(cells))
     return '<pre>' + '\n'.join(lines) + '</pre>'
 
 
 def render_board_enemy(board: Board) -> str:
-    header = format_cell("") + "|" + " " + COL_NUMBERS
+    header = format_cell("") + "|" + " " + COL_HEADERS
     lines = [header]
     highlight = set(board.highlight)
     for r_idx, row in enumerate(board.grid):
@@ -106,6 +106,6 @@ def render_board_enemy(board: Board) -> str:
                 else:
                     sym = f"<b>{sym}</b>"
             cells.append(format_cell(sym))
-        row_label = format_cell(ROWS[r_idx])
+        row_label = format_cell(str(r_idx + 1))
         lines.append(f"{row_label}| " + _render_line(cells))
     return '<pre>' + '\n'.join(lines) + '</pre>'

--- a/tests/test_render.py
+++ b/tests/test_render.py
@@ -1,4 +1,5 @@
 from logic.render import render_board_own, render_board_enemy
+from logic.parser import ROWS
 from logic.battle import apply_shot, KILL
 from models import Board, Ship
 from tests.utils import _new_grid, _state
@@ -97,3 +98,24 @@ def test_render_state5_symbol():
 
     assert '·' in own
     assert 'x' in enemy
+
+
+def _extract_lines(rendered: str):
+    assert rendered.startswith('<pre>')
+    assert rendered.endswith('</pre>')
+    inner = rendered[len('<pre>'):-len('</pre>')]
+    inner = inner.strip('\n')
+    return inner.split('\n')
+
+
+def test_render_axis_labels():
+    board = Board()
+    own_lines = _extract_lines(render_board_own(board))
+    enemy_lines = _extract_lines(render_board_enemy(board))
+
+    expected_header = ' '.join(ROWS)
+    for lines in (own_lines, enemy_lines):
+        header = lines[0].split('|', 1)[1].strip()
+        assert header == expected_header
+        row_labels = [line.split('|', 1)[0].strip() for line in lines[1:]]
+        assert row_labels == [str(i) for i in range(1, 11)]


### PR DESCRIPTION
## Summary
- render column headers using the Cyrillic letters from logic.parser.ROWS
- display numeric row labels in both own and enemy board renderers
- extend renderer unit tests to cover the updated axis labels

## Testing
- pytest tests/test_render.py

------
https://chatgpt.com/codex/tasks/task_e_68e00e85f8c883268f8d554a085b16d0