### PR TITLE
Add snapshot tracking for three-player boards

### DIFF
--- a/game_board15/models.py
+++ b/game_board15/models.py
@@ -39,6 +39,7 @@ class Match15:
     players: Dict[str, Player] = field(default_factory=dict)
     turn: str = "A"
     boards: Dict[str, Board15] = field(default_factory=dict)
+    snapshots: list[dict] = field(default_factory=list)
     # global shot history for rendering target board
     history: List[List[List[object]]] = field(
         default_factory=lambda: [[[0, None] for _ in range(15)] for _ in range(15)]

--- a/tests/test_three_player_snapshots.py
+++ b/tests/test_three_player_snapshots.py
@@ -1,0 +1,147 @@
+from __future__ import annotations
+
+import asyncio
+from io import BytesIO
+from types import SimpleNamespace
+
+import pytest
+
+from game_board15 import router, storage, placement, parser
+from game_board15.models import Match15, Player
+
+
+class DummyBot:
+    def __init__(self):
+        self.sent_photos: list[tuple[int, str]] = []
+        self.sent_messages: list[tuple[tuple, dict]] = []
+
+    async def send_photo(self, chat_id, buf, caption):
+        self.sent_photos.append((chat_id, caption))
+        return SimpleNamespace(message_id=len(self.sent_photos))
+
+    async def send_message(self, *args, **kwargs):
+        self.sent_messages.append((args, kwargs))
+        return SimpleNamespace(message_id=len(self.sent_messages))
+
+
+class DummyMessage:
+    def __init__(self, text: str):
+        self.text = text
+
+    async def reply_text(self, *args, **kwargs):
+        return None
+
+
+def _safe_coord(match: Match15) -> tuple[int, int]:
+    for r in range(15):
+        for c in range(15):
+            if all(board.grid[r][c] == 0 for board in match.boards.values()):
+                return r, c
+    raise AssertionError("No safe coordinate found")
+
+
+def test_three_player_snapshots_increment_each_turn(tmp_path, monkeypatch):
+    monkeypatch.setattr(storage, "DATA_FILE", tmp_path / "data15.json")
+
+    match = storage.create_match(1, 101, "Alpha")
+    match = storage.join_match(match.match_id, 2, 202, "Beta")
+    match = storage.join_match(match.match_id, 3, 303, "Gamma")
+
+    storage.save_board(match, "A", placement.random_board())
+    storage.save_board(match, "B", placement.random_board())
+    storage.save_board(match, "C", placement.random_board())
+
+    initial_snapshots = len(match.snapshots)
+    assert initial_snapshots == 1
+
+    captured_boards: list[tuple[str, list[list[int]]]] = []
+
+    def fake_render_board(state, player_key):
+        board_copy = [row[:] for row in state.board]
+        captured_boards.append((player_key, board_copy))
+        return BytesIO(b"x")
+
+    monkeypatch.setattr(router, "render_board", fake_render_board)
+
+    async def play_turns():
+        context = SimpleNamespace(bot=DummyBot(), bot_data={}, chat_data={})
+        order = ["A", "B", "C"]
+        for expected in order:
+            current = storage.get_match(match.match_id)
+            coord = _safe_coord(current)
+            coord_text = parser.format_coord(coord)
+            player = current.players[expected]
+            update = SimpleNamespace(
+                message=DummyMessage(coord_text),
+                effective_user=SimpleNamespace(id=player.user_id),
+                effective_chat=SimpleNamespace(id=player.chat_id),
+            )
+            await router.router_text(update, context)
+
+    asyncio.run(play_turns())
+
+    updated = storage.get_match(match.match_id)
+    assert len(updated.snapshots) == initial_snapshots + 3
+    assert len(captured_boards) > 0
+
+
+def test_send_state_prefers_latest_snapshot(monkeypatch):
+    match = Match15.new(1, 111, "Alpha")
+    match.players["B"] = Player(user_id=2, chat_id=222, name="Beta", ready=True)
+    match.players["C"] = Player(user_id=3, chat_id=333, name="Gamma", ready=True)
+
+    base_grid = [[0 for _ in range(15)] for _ in range(15)]
+    base_grid[0][0] = 1
+    snapshot_history = [[[0, None] for _ in range(15)] for _ in range(15)]
+    snapshot_history[0][1] = [2, "B"]
+    snapshot = {
+        "timestamp": "now",
+        "move": 0,
+        "actor": None,
+        "coord": None,
+        "next_turn": "A",
+        "history": snapshot_history,
+        "last_highlight": [(0, 1)],
+        "boards": {
+            "A": {
+                "grid": [row[:] for row in base_grid],
+                "ships": [],
+                "alive_cells": 20,
+            },
+            "B": {
+                "grid": [[0 for _ in range(15)] for _ in range(15)],
+                "ships": [],
+                "alive_cells": 20,
+            },
+            "C": {
+                "grid": [[0 for _ in range(15)] for _ in range(15)],
+                "ships": [],
+                "alive_cells": 20,
+            },
+        },
+    }
+    match.snapshots = [snapshot]
+    match.history = [[[0, None] for _ in range(15)] for _ in range(15)]
+    match.last_highlight = []
+
+    captured = {}
+
+    def fake_render_board(state, player_key):
+        captured["board"] = [row[:] for row in state.board]
+        captured["owners"] = [row[:] for row in state.owners]
+        captured["highlight"] = list(state.highlight)
+        return BytesIO(b"x")
+
+    class Bot:
+        async def send_photo(self, *args, **kwargs):
+            return SimpleNamespace(message_id=1)
+
+    context = SimpleNamespace(bot=Bot(), bot_data={}, chat_data={})
+    monkeypatch.setattr(router, "render_board", fake_render_board)
+
+    asyncio.run(router._send_state(context, match, "A", "test"))
+
+    assert captured["board"][0][0] == 1
+    assert captured["board"][0][1] == 2
+    assert captured["owners"][0][1] == "B"
+    assert captured["highlight"] == [(0, 1)]


### PR DESCRIPTION
## Summary
- extend the 15x15 match model and persistence layer to capture per-turn board snapshots and properly serialize them
- add a snapshot recording utility and update the router to render boards from the latest snapshot during play and when starting a match
- cover the behaviour with a new three-player test that exercises turn progression and snapshot-backed rendering

## Testing
- pytest tests/test_three_player_snapshots.py

------
https://chatgpt.com/codex/tasks/task_e_68e0299274908326b5e3274a10fcfd11