### PR TITLE
Fix render state 5 symbol on own board

### DIFF
--- a/logic/render.py
+++ b/logic/render.py
@@ -67,7 +67,7 @@ def render_board_own(board: Board) -> str:
             elif cell_state == 4:
                 sym = SUNK_SYMBOL
             elif cell_state == 5:
-                sym = EMPTY_SYMBOL
+                sym = MISS_SYMBOL
             else:
                 sym = EMPTY_SYMBOL
             if coord in highlight:

--- a/tests/test_render.py
+++ b/tests/test_render.py
@@ -96,7 +96,7 @@ def test_render_state5_symbol():
     own = render_board_own(b)
     enemy = render_board_enemy(b)
 
-    assert '·' in own
+    assert 'x' in own
     assert 'x' in enemy
 
 


### PR DESCRIPTION
## Summary
- ensure state 5 cells render as the miss symbol on the owner's board
- update render tests to expect the miss symbol for state 5 cells

## Testing
- pytest tests/test_render.py

------
https://chatgpt.com/codex/tasks/task_e_68e02c8ee5948326b9123d6ed9b113af