### PR TITLE
Prevent revealing fleets in shared chats

### DIFF
--- a/game_board15/router.py
+++ b/game_board15/router.py
@@ -30,7 +30,14 @@ from .utils import (
 logger = logging.getLogger(__name__)
 
 
-async def _send_state(context: ContextTypes.DEFAULT_TYPE, match, player_key: str, message: str) -> None:
+async def _send_state(
+    context: ContextTypes.DEFAULT_TYPE,
+    match,
+    player_key: str,
+    message: str,
+    *,
+    reveal_ships: bool = True,
+) -> None:
     """Render and send main board image followed by text message."""
 
     chat_id = match.players[player_key].chat_id
@@ -46,20 +53,21 @@ async def _send_state(context: ContextTypes.DEFAULT_TYPE, match, player_key: str
         history_source = match.history
     merged_states = [[_get_cell_state(cell) for cell in row] for row in history_source]
     owners = [[_get_cell_owner(cell) for cell in row] for row in history_source]
-    if snapshot and player_key in snapshot.get("boards", {}):
-        own_grid = snapshot["boards"][player_key]["grid"]
-    else:
-        own_grid = match.boards[player_key].grid
-    for r in range(15):
-        for c in range(15):
-            cell = own_grid[r][c]
-            if _get_cell_state(cell) != 1:
-                continue
-            history_state = merged_states[r][c]
-            if history_state in {2, 5}:
-                continue
-            merged_states[r][c] = 1
-            owners[r][c] = player_key
+    if reveal_ships:
+        if snapshot and player_key in snapshot.get("boards", {}):
+            own_grid = snapshot["boards"][player_key]["grid"]
+        else:
+            own_grid = match.boards[player_key].grid
+        for r in range(15):
+            for c in range(15):
+                cell = own_grid[r][c]
+                if _get_cell_state(cell) != 1:
+                    continue
+                history_state = merged_states[r][c]
+                if history_state in {2, 5}:
+                    continue
+                merged_states[r][c] = 1
+                owners[r][c] = player_key
     state.board = merged_states
     state.owners = owners
     state.player_key = player_key
@@ -347,7 +355,10 @@ async def router_text(update: Update, context: ContextTypes.DEFAULT_TYPE) -> Non
     record_snapshot(match, actor=player_key, coord=coord)
     next_obj = match.players.get(next_player)
     next_name = getattr(next_obj, 'name', '') or next_player
-    same_chat = len({p.chat_id for p in match.players.values()}) == 1
+    chat_counts: dict[int, int] = {}
+    for participant in match.players.values():
+        chat_counts[participant.chat_id] = chat_counts.get(participant.chat_id, 0) + 1
+    same_chat = len(chat_counts) == 1
     if enemy_msgs and not same_chat:
         for enemy, (res_enemy, msg_body_enemy) in enemy_msgs.items():
             if match.players[enemy].user_id != 0:
@@ -375,15 +386,60 @@ async def router_text(update: Update, context: ContextTypes.DEFAULT_TYPE) -> Non
     body_self = msg_body.rstrip()
     if not body_self.endswith(('.', '!', '?')):
         body_self += '.'
-    if same_chat or single_user:
-        result_self = (
-            f"Ход игрока {player_label}: {coord_str} - {body_self} {phrase_self} Следующим ходит {next_name}."
+    shared_text = (
+        f"Ход игрока {player_label}: {coord_str} - {body_self} {phrase_self} Следующим ходит {next_name}."
+    )
+    personal_text = (
+        f"Ваш ход: {coord_str} - {body_self} {phrase_self} Следующим ходит {next_name}."
+    )
+    if same_chat:
+        await _send_state(
+            context,
+            match,
+            player_key,
+            shared_text,
+            reveal_ships=False,
         )
-        view_key = player_key
+        private_receivers = [
+            key
+            for key, participant in match.players.items()
+            if chat_counts.get(participant.chat_id, 0) == 1 and participant.user_id != 0
+        ]
+        for key in private_receivers:
+            if key == player_key:
+                await _send_state(
+                    context,
+                    match,
+                    key,
+                    personal_text,
+                    reveal_ships=True,
+                )
+            elif key in enemy_msgs:
+                _, msg_body_enemy = enemy_msgs[key]
+                next_phrase = f" Следующим ходит {next_name}."
+                await _send_state(
+                    context,
+                    match,
+                    key,
+                    f"Ход игрока {player_label}: {coord_str} - {msg_body_enemy}{next_phrase}",
+                    reveal_ships=True,
+                )
+            elif key in others:
+                next_phrase = f" Следующим ходит {next_name}."
+                watch_body = msg_watch.rstrip()
+                if not watch_body.endswith((".", "!", "?")):
+                    watch_body += "."
+                await _send_state(
+                    context,
+                    match,
+                    key,
+                    f"Ход игрока {player_label}: {coord_str} - {watch_body} {phrase_self}{next_phrase}",
+                    reveal_ships=True,
+                )
+    elif single_user:
+        await _send_state(context, match, player_key, shared_text)
     else:
-        result_self = f"Ваш ход: {coord_str} - {body_self} {phrase_self} Следующим ходит {next_name}."
-        view_key = player_key
-    await _send_state(context, match, view_key, result_self)
+        await _send_state(context, match, player_key, personal_text)
 
     storage.save_match(match)
 

--- a/tests/test_board15_history.py
+++ b/tests/test_board15_history.py
@@ -6,7 +6,7 @@ from unittest.mock import AsyncMock
 
 from game_board15 import handlers, router, storage
 from game_board15.battle import apply_shot, update_history, KILL, HIT, MISS
-from game_board15.models import Board15, Ship, Match15
+from game_board15.models import Board15, Ship, Match15, Player
 from game_board15.utils import _get_cell_state, _get_cell_owner, _set_cell_state
 from tests.utils import _new_grid, _state
 
@@ -140,6 +140,121 @@ def test_multiple_hits_recorded(monkeypatch):
 
         assert captured['A'][coord[0]][coord[1]] == 3
         assert captured['B'][coord[0]][coord[1]] == 3
+
+    asyncio.run(run_test())
+
+
+def test_shared_chat_board_hides_enemy_ships(monkeypatch):
+    async def run_test():
+        shared_chat = 555
+        match = Match15.new(1, shared_chat, "A")
+        match.players['A'].name = 'A'
+        match.players['B'] = Player(user_id=2, chat_id=shared_chat, name='B')
+        match.status = 'playing'
+        match.turn = 'A'
+        match.history = _new_grid(15)
+        match.snapshots = []
+        match.last_highlight = []
+        match.messages = {key: {} for key in ('A', 'B')}
+        match.boards['A'] = Board15()
+        match.boards['B'] = Board15()
+        match.boards.pop('C', None)
+        ship_a = Ship(cells=[(2, 2)])
+        match.boards['A'].ships = [ship_a]
+        match.boards['A'].grid[2][2] = 1
+        match.boards['A'].alive_cells = len(ship_a.cells)
+        ship_b = Ship(cells=[(0, 2)])
+        match.boards['B'].ships = [ship_b]
+        match.boards['B'].grid[0][2] = 1
+        match.boards['B'].alive_cells = len(ship_b.cells)
+        match.shots = {
+            'A': {'history': [], 'last_result': None, 'move_count': 0, 'joke_start': 10, 'last_coord': None},
+            'B': {'history': [], 'last_result': None, 'move_count': 0, 'joke_start': 10, 'last_coord': None},
+        }
+
+        monkeypatch.setattr(
+            router.storage,
+            'find_match_by_user',
+            lambda user_id, chat_id=None: match if chat_id == shared_chat else None,
+        )
+        monkeypatch.setattr(router.storage, 'save_match', lambda m: None)
+        monkeypatch.setattr(router, '_phrase_or_joke', lambda m, pk, ph: '')
+        coords = {'a1': (0, 0), 'c3': (2, 2)}
+        monkeypatch.setattr(router.parser, 'parse_coord', lambda text: coords.get(text))
+        monkeypatch.setattr(
+            router.parser,
+            'format_coord',
+            lambda coord: next((label for label, value in coords.items() if value == coord), 'a1'),
+        )
+
+        orig_send_state = router._send_state
+        send_state_calls: list[tuple[str, bool]] = []
+        history_snapshots: list[list[list[int]]] = []
+
+        async def capture_send_state(context, match_obj, player_key, message, *, reveal_ships=True):
+            send_state_calls.append((player_key, reveal_ships))
+            history_snapshots.append(
+                [[_get_cell_state(cell) for cell in row] for row in match_obj.history]
+            )
+            await orig_send_state(
+                context,
+                match_obj,
+                player_key,
+                message,
+                reveal_ships=reveal_ships,
+            )
+
+        monkeypatch.setattr(router, '_send_state', capture_send_state)
+
+        rendered: list[tuple[str, list[list[int]]]] = []
+
+        def fake_render_board(state, player_key=None):
+            rendered.append((player_key, [row[:] for row in state.board]))
+            return BytesIO(b'img')
+
+        monkeypatch.setattr(router, 'render_board', fake_render_board)
+
+        context = SimpleNamespace(
+            bot=SimpleNamespace(
+                send_message=AsyncMock(),
+                send_photo=AsyncMock(return_value=SimpleNamespace(message_id=1)),
+                edit_message_media=AsyncMock(),
+                edit_message_text=AsyncMock(),
+            ),
+            bot_data={},
+            chat_data={},
+        )
+
+        update_a = SimpleNamespace(
+            message=SimpleNamespace(text='a1', reply_text=AsyncMock()),
+            effective_user=SimpleNamespace(id=1),
+            effective_chat=SimpleNamespace(id=shared_chat),
+        )
+
+        await router.router_text(update_a, context)
+        assert match.turn == 'B'
+
+        update_b = SimpleNamespace(
+            message=SimpleNamespace(text='c3', reply_text=AsyncMock()),
+            effective_user=SimpleNamespace(id=2),
+            effective_chat=SimpleNamespace(id=shared_chat),
+        )
+
+        await router.router_text(update_b, context)
+
+        assert len(send_state_calls) == 2
+        assert send_state_calls == [('A', False), ('B', False)]
+        assert len(rendered) == len(history_snapshots) == 2
+        for idx, ((player_key, board), history_state) in enumerate(zip(rendered, history_snapshots)):
+            assert player_key in {'A', 'B'}
+            assert board == history_state
+            assert board[0][2] == 0
+            if idx == 0:
+                assert board[0][0] == 2
+                assert board[2][2] == 0
+            else:
+                assert board[0][0] == 2
+                assert board[2][2] == 4
 
     asyncio.run(run_test())
 
@@ -558,7 +673,7 @@ def test_router_text_patches_history_on_noop_update(monkeypatch):
 
         calls: list[tuple[str, list[list[int]]]] = []
 
-        async def fake_send_state(ctx, match_obj, player_key, message):
+        async def fake_send_state(ctx, match_obj, player_key, message, *, reveal_ships=True):
             board_copy = [
                 [_get_cell_state(cell) for cell in row]
                 for row in match_obj.history

--- a/tests/test_board15_human_autoplay_message.py
+++ b/tests/test_board15_human_autoplay_message.py
@@ -37,7 +37,7 @@ def test_human_shot_no_autoplay_and_message(monkeypatch):
 
         send_calls = []
 
-        async def fake_send_state(context, match_, player_key, message):
+        async def fake_send_state(context, match_, player_key, message, *, reveal_ships=True):
             send_calls.append((player_key, message))
 
         monkeypatch.setattr(router, '_send_state', fake_send_state)
@@ -114,7 +114,7 @@ def test_human_board_highlight_before_bot_move(monkeypatch):
 
         events: list[dict[str, object]] = []
 
-        async def fake_send_state(context, match_obj, player_key, message):
+        async def fake_send_state(context, match_obj, player_key, message, *, reveal_ships=True):
             history = getattr(match_obj, 'history', [])
             history_state = [
                 [_state(cell) for cell in row]

--- a/tests/test_board15_router.py
+++ b/tests/test_board15_router.py
@@ -192,7 +192,7 @@ def test_router_text_fallback_stamps_cell(monkeypatch, scenario, expected_state,
 
         send_state_calls = 0
 
-        async def fake_send_state(context, match_obj, key, message):
+        async def fake_send_state(context, match_obj, key, message, *, reveal_ships=True):
             nonlocal send_state_calls
             send_state_calls += 1
             cell = match_obj.history[coord[0]][coord[1]]

--- a/tests/test_board15_send_state.py
+++ b/tests/test_board15_send_state.py
@@ -35,7 +35,7 @@ def test_send_state_for_all_players(tmp_path, monkeypatch):
     storage.save_board(match, "C", placement.random_board())
 
     called = []
-    async def fake_send_state(context, match_obj, player_key, message):
+    async def fake_send_state(context, match_obj, player_key, message, *, reveal_ships=True):
         called.append(player_key)
     monkeypatch.setattr(router, "_send_state", fake_send_state)
 

--- a/tests/test_board15_test_autoplay.py
+++ b/tests/test_board15_test_autoplay.py
@@ -122,7 +122,7 @@ def test_auto_play_bots_notifies_human(monkeypatch):
 
         calls: list[tuple[str, str]] = []
 
-        async def fake_send_state(context, match_, player_key, message):
+        async def fake_send_state(context, match_, player_key, message, *, reveal_ships=True):
             calls.append((player_key, message))
 
         monkeypatch.setattr(router, '_send_state', fake_send_state)
@@ -246,7 +246,7 @@ def test_auto_play_bots_reports_hits(monkeypatch):
 
         calls: list[tuple[str, str]] = []
 
-        async def fake_send_state(context, match_, player_key, message):
+        async def fake_send_state(context, match_, player_key, message, *, reveal_ships=True):
             calls.append((player_key, message))
 
             await asyncio.sleep(0)

--- a/tests/test_board15_test_manual.py
+++ b/tests/test_board15_test_manual.py
@@ -79,7 +79,7 @@ def test_board15_test_manual(monkeypatch):
 
         sent_to: list[str] = []
 
-        async def fake_send_state(context, match_obj, player_key, message):
+        async def fake_send_state(context, match_obj, player_key, message, *, reveal_ships=True):
             sent_to.append(player_key)
 
         monkeypatch.setattr(router, "_send_state", fake_send_state)

--- a/tests/test_history_before_send.py
+++ b/tests/test_history_before_send.py
@@ -45,7 +45,7 @@ def test_board15_router_updates_history_before_send(monkeypatch):
 
         captured = {}
 
-        async def fake_send_state(context, match_obj, player_key, message):
+        async def fake_send_state(context, match_obj, player_key, message, *, reveal_ships=True):
             captured["cell"] = match_obj.history[0][0][0]
             captured["saved"] = saved
 
@@ -103,7 +103,7 @@ def test_board_test_router_updates_history_before_send(monkeypatch):
 
         captured = {}
 
-        async def fake_send_state(context, match_obj, player_key, message):
+        async def fake_send_state(context, match_obj, player_key, message, *, reveal_ships=True):
             captured["cell"] = match_obj.history[0][0]
             captured["saved"] = saved
 

--- a/tests/test_history_before_send_n1.py
+++ b/tests/test_history_before_send_n1.py
@@ -44,7 +44,7 @@ def test_board15_router_updates_history_before_send_n1(monkeypatch):
 
         captured = {}
 
-        async def fake_send_state(context, match_obj, player_key, message):
+        async def fake_send_state(context, match_obj, player_key, message, *, reveal_ships=True):
             captured["cell"] = match_obj.history[0][13][0]
             captured["saved"] = saved
 
@@ -98,7 +98,7 @@ def test_router_updates_board_before_send(monkeypatch):
 
         captured = {}
 
-        async def fake_send_state(context, match_obj, player_key, message):
+        async def fake_send_state(context, match_obj, player_key, message, *, reveal_ships=True):
             captured["cell"] = match_obj.boards["B"].grid[0][0]
             captured["saved"] = saved
 


### PR DESCRIPTION
## Summary
- add a `reveal_ships` option to `_send_state` so callers can control whether personal fleets are merged into the rendered board
- adjust the shared-chat branch in `router_text` to send a sanitized board image to the common chat while still delivering private views when available
- extend the Board15 history tests (and update mocks) to cover shared-chat move sequences and the new `_send_state` signature

## Testing
- pytest tests/test_board15_history.py

------
https://chatgpt.com/codex/tasks/task_e_68e02c7a3bcc8326a8678b947583d017