### PR TITLE
Fix shared chat ship visibility for Board15

### DIFF
--- a/game_board15/router.py
+++ b/game_board15/router.py
@@ -69,13 +69,20 @@ async def _send_state(
         for owner_key, grid in board_sources.items():
             if not grid:
                 continue
+            is_recipient_board = owner_key == player_key
             for r in range(min(len(grid), 15)):
                 row = grid[r]
                 for c in range(min(len(row), 15)):
                     if row[c] != 1:
                         continue
-                    if merged_states[r][c] in {0, 1}:
-                        merged_states[r][c] = 1
+                    history_state = merged_states[r][c]
+                    if history_state not in {0, 1}:
+                        if owners[r][c] is None:
+                            owners[r][c] = owner_key
+                        continue
+                    if not (is_recipient_board and reveal_ships):
+                        continue
+                    merged_states[r][c] = 1
                     owners[r][c] = owner_key
     if reveal_ships:
         if snapshot and player_key in snapshot.get("boards", {}):


### PR DESCRIPTION
## Summary
- prevent `_send_state` from exposing intact enemy ships when rendering shared-chat boards while still honoring shared history
- adjust shared chat board expectations and add a regression test to ensure snapshots hide undamaged enemy fleets

## Testing
- pytest tests/test_board15_history.py -q

------
https://chatgpt.com/codex/tasks/task_e_68e0a57b06dc83269579f65201ca57f8