### PR TITLE
Restrict board15 test mode to admin

### DIFF
--- a/handlers/commands.py
+++ b/handlers/commands.py
@@ -135,8 +135,8 @@ async def start(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
         ]
         if ADMIN_ID is not None and update.effective_user and update.effective_user.id == ADMIN_ID:
             buttons.append([InlineKeyboardButton('Тест 2 игроков', callback_data='mode_test2')])
-        if BOARD15_TEST_ENABLED:
-            buttons.append([InlineKeyboardButton('Тест 3 игроков', callback_data='mode_test3')])
+            if BOARD15_TEST_ENABLED:
+                buttons.append([InlineKeyboardButton('Тест 3 игроков', callback_data='mode_test3')])
         keyboard = InlineKeyboardMarkup(buttons)
         await update.message.reply_text('Выберите режим игры:', reply_markup=keyboard)
 
@@ -320,4 +320,11 @@ async def choose_mode(update: Update, context: ContextTypes.DEFAULT_TYPE) -> Non
         )
         await board_test_two(fake_update, context)
     elif query.data == 'mode_test3':
+        if ADMIN_ID is None or not query.from_user or query.from_user.id != ADMIN_ID:
+            logger.info(
+                'Unauthorized mode_test3 selection: user_id=%s admin_id=%s',
+                getattr(query.from_user, 'id', None),
+                ADMIN_ID,
+            )
+            return
         await query.message.reply_text('Используйте /board15test для тестовой игры втроем.')

--- a/tests/test_router_text.py
+++ b/tests/test_router_text.py
@@ -6,6 +6,7 @@ from unittest.mock import AsyncMock, call
 
 import storage
 from handlers import router
+from handlers import commands as commands_module
 from models import Board, Ship
 import logic.phrases as phrases
 
@@ -22,6 +23,34 @@ def test_router_text_board_test_two_not_registered(monkeypatch):
 
     assert "router_text" in callbacks
     assert "router_text_board_test_two" not in callbacks
+
+
+def test_choose_mode_mode_test3_requires_admin():
+    async def run_test():
+        original_admin = commands_module.ADMIN_ID
+        original_board15 = commands_module.BOARD15_TEST_ENABLED
+        commands_module.ADMIN_ID = 42
+        commands_module.BOARD15_TEST_ENABLED = True
+        try:
+            reply_text = AsyncMock()
+            query = SimpleNamespace(
+                data='mode_test3',
+                message=SimpleNamespace(reply_text=reply_text),
+                from_user=SimpleNamespace(id=1),
+                answer=AsyncMock(),
+            )
+            update = SimpleNamespace(callback_query=query)
+            context = SimpleNamespace()
+
+            await commands_module.choose_mode(update, context)
+
+            assert reply_text.call_count == 0
+            assert query.answer.await_count == 1
+        finally:
+            commands_module.ADMIN_ID = original_admin
+            commands_module.BOARD15_TEST_ENABLED = original_board15
+
+    asyncio.run(run_test())
 
 
 def test_router_text_handles_latin_coords_standard_match(monkeypatch):


### PR DESCRIPTION
## Summary
- hide the three-player test menu button behind the admin check alongside the two-player test mode
- reject non-admin callback attempts for the three-player test selector and log the access attempt
- add coverage to ensure choose_mode ignores unauthorized mode_test3 requests

## Testing
- pytest tests/test_router_text.py tests/test_start.py

------
https://chatgpt.com/codex/tasks/task_e_68e0a6e314448326be4740d5e9a14c18