### PR TITLE
Combine board and result updates into single message

### DIFF
--- a/game_board15/handlers.py
+++ b/game_board15/handlers.py
@@ -122,7 +122,7 @@ async def _auto_play_bots(
                     msgs = match.messages.setdefault(human, {})
                     hist = msgs.setdefault("text_history", [])
                     hist.append(msg.message_id)
-                    msgs["text"] = msg.message_id
+                    msgs.setdefault("service_messages", []).append(msg.message_id)
                 except asyncio.CancelledError:
                     raise
                 except Exception:

--- a/game_board15/router.py
+++ b/game_board15/router.py
@@ -124,7 +124,7 @@ async def _send_state(
         return
     state.message_id = msg.message_id
     msgs["board"] = msg.message_id
-    msgs["text"] = msg.message_id
+    msgs.pop("text", None)
     board_hist = msgs.setdefault("board_history", [])
     text_hist = msgs.setdefault("text_history", [])
     if msgs.get("history_active"):

--- a/tests/test_board15_keyboard.py
+++ b/tests/test_board15_keyboard.py
@@ -27,7 +27,7 @@ def test_send_state_records_history(monkeypatch):
         assert bot.send_photo.await_count == 1
         assert bot.send_message.await_count == 0
         assert match.messages["A"]["board"] == 51
-        assert match.messages["A"]["text"] == 51
+        assert "text" not in match.messages["A"]
         assert match.messages["A"]["board_history"] == [51]
         assert match.messages["A"]["text_history"] == [51]
     asyncio.run(run_test())
@@ -56,7 +56,7 @@ def test_send_state_appends_history(monkeypatch):
         assert bot.send_photo.await_count == 2
         assert bot.send_message.await_count == 0
         assert match.messages["A"]["board"] == 13
-        assert match.messages["A"]["text"] == 13
+        assert "text" not in match.messages["A"]
         assert match.messages["A"]["board_history"] == [11, 13]
         assert match.messages["A"]["text_history"] == [11, 13]
     asyncio.run(run_test())

--- a/tests/test_router_message_order.py
+++ b/tests/test_router_message_order.py
@@ -77,6 +77,6 @@ def test_router_message_order(tmp_path, monkeypatch):
 
     asyncio.run(play_moves())
 
-    expected = ['board_send', 'text_send', 'board_send', 'text_edit']
+    expected = ['board_send', 'board_edit']
     assert bot.logs[1] == expected
     assert bot.logs[2] == expected


### PR DESCRIPTION
## Summary
- merge board state and move result into one message in the regular and board-test flows while cleaning obsolete text message tracking
- drop legacy text message bookkeeping in board15 helpers
- update message order and keyboard tests to match the new single-message behaviour

## Testing
- pytest tests/test_router_message_order.py tests/test_board15_keyboard.py

------
https://chatgpt.com/codex/tasks/task_e_68e0ab6de9d083269a3f9618eec9834c