### PR TITLE
Send new board messages and persist history

### DIFF
--- a/tests/test_router_keyboard.py
+++ b/tests/test_router_keyboard.py
@@ -1,11 +1,11 @@
 import asyncio
 from types import SimpleNamespace
-from unittest.mock import AsyncMock, call
+from unittest.mock import AsyncMock
 
 from handlers import router
 
 
-def test_send_state_sets_keyboard_on_new_board(monkeypatch):
+def test_send_state_sends_new_board_message_and_updates_history(monkeypatch):
     async def run_test():
         match = SimpleNamespace(
             players={'A': SimpleNamespace(chat_id=1)},
@@ -16,84 +16,66 @@ def test_send_state_sets_keyboard_on_new_board(monkeypatch):
         monkeypatch.setattr(router, 'render_board_enemy', lambda b: 'enemy')
         monkeypatch.setattr(router.storage, 'save_match', lambda m: None)
         bot = SimpleNamespace(
-            send_message=AsyncMock(side_effect=[
-                SimpleNamespace(message_id=50),
-                SimpleNamespace(message_id=51),
-            ]),
-            edit_message_text=AsyncMock(),
-            delete_message=AsyncMock(),
+            send_message=AsyncMock(return_value=SimpleNamespace(message_id=50)),
         )
         context = SimpleNamespace(bot=bot)
 
         await router._send_state(context, match, 'A', 'msg')
 
-        assert bot.send_message.await_count == 2
-        first_call, second_call = bot.send_message.await_args_list
-        assert first_call.args[0] == 1
-        assert 'reply_markup' not in first_call.kwargs
-        assert 'reply_markup' not in second_call.kwargs
-        assert bot.delete_message.await_count == 0
-        assert match.messages['A']['board'] == 50
-        assert match.messages['A']['text'] == 51
-
-    asyncio.run(run_test())
-
-
-def test_send_state_edits_existing_messages(monkeypatch):
-    async def run_test():
-        match = SimpleNamespace(
-            players={'A': SimpleNamespace(chat_id=1)},
-            boards={'A': SimpleNamespace(), 'B': SimpleNamespace()},
-            messages={'A': {'board': 10, 'text': 11}},
-        )
-        monkeypatch.setattr(router, 'render_board_own', lambda b: 'own')
-        monkeypatch.setattr(router, 'render_board_enemy', lambda b: 'enemy')
-        monkeypatch.setattr(router.storage, 'save_match', lambda m: None)
-        bot = SimpleNamespace(
-            edit_message_text=AsyncMock(),
-            send_message=AsyncMock(return_value=SimpleNamespace(message_id=20)),
-            delete_message=AsyncMock(),
-        )
-        context = SimpleNamespace(bot=bot)
-
-        await router._send_state(context, match, 'A', 'msg')
-
-        bot.edit_message_text.assert_awaited_once()
         bot.send_message.assert_awaited_once()
-        assert bot.delete_message.await_args_list == [call(1, 10)]
-        assert match.messages['A']['board'] == 20
-        assert match.messages['A']['text'] == 11
+        call_args = bot.send_message.await_args
+        assert call_args.args[0] == 1
+        assert 'reply_markup' not in call_args.kwargs
+        assert match.messages['A']['board'] == 50
+        assert match.messages['A']['board_history'] == [50]
+        assert 'text' not in match.messages['A']
 
     asyncio.run(run_test())
 
 
-def test_send_state_recreates_messages_on_edit_failure(monkeypatch):
+def test_send_state_appends_new_board_messages_to_history(monkeypatch):
     async def run_test():
         match = SimpleNamespace(
             players={'A': SimpleNamespace(chat_id=1)},
             boards={'A': SimpleNamespace(), 'B': SimpleNamespace()},
-            messages={'A': {'board': 10, 'text': 11}},
+            messages={'A': {'board': 10, 'board_history': [10]}},
         )
         monkeypatch.setattr(router, 'render_board_own', lambda b: 'own')
         monkeypatch.setattr(router, 'render_board_enemy', lambda b: 'enemy')
         monkeypatch.setattr(router.storage, 'save_match', lambda m: None)
         bot = SimpleNamespace(
-            edit_message_text=AsyncMock(side_effect=[Exception(), Exception()]),
-            send_message=AsyncMock(side_effect=[
-                SimpleNamespace(message_id=60),
-                SimpleNamespace(message_id=61),
-            ]),
-            delete_message=AsyncMock(),
+            send_message=AsyncMock(return_value=SimpleNamespace(message_id=20)),
         )
         context = SimpleNamespace(bot=bot)
 
         await router._send_state(context, match, 'A', 'msg')
 
-        assert bot.delete_message.await_args_list == [call(1, 10), call(1, 11)]
-        first_call, second_call = bot.send_message.await_args_list
-        assert 'reply_markup' not in first_call.kwargs
-        assert 'reply_markup' not in second_call.kwargs
+        bot.send_message.assert_awaited_once()
+        assert match.messages['A']['board'] == 20
+        assert match.messages['A']['board_history'] == [10, 20]
+
+    asyncio.run(run_test())
+
+
+def test_send_state_initialises_history_if_missing(monkeypatch):
+    async def run_test():
+        match = SimpleNamespace(
+            players={'A': SimpleNamespace(chat_id=1)},
+            boards={'A': SimpleNamespace(), 'B': SimpleNamespace()},
+            messages={'A': {'board': 10}},
+        )
+        monkeypatch.setattr(router, 'render_board_own', lambda b: 'own')
+        monkeypatch.setattr(router, 'render_board_enemy', lambda b: 'enemy')
+        monkeypatch.setattr(router.storage, 'save_match', lambda m: None)
+        bot = SimpleNamespace(
+            send_message=AsyncMock(return_value=SimpleNamespace(message_id=60)),
+        )
+        context = SimpleNamespace(bot=bot)
+
+        await router._send_state(context, match, 'A', 'msg')
+
         assert match.messages['A']['board'] == 60
-        assert match.messages['A']['text'] == 61
+        assert match.messages['A']['board_history'] == [60]
+        assert 'text' not in match.messages['A']
 
     asyncio.run(run_test())

--- a/tests/test_router_message_order.py
+++ b/tests/test_router_message_order.py
@@ -77,6 +77,6 @@ def test_router_message_order(tmp_path, monkeypatch):
 
     asyncio.run(play_moves())
 
-    expected = ['board_send', 'board_edit']
+    expected = ['board_send', 'board_send']
     assert bot.logs[1] == expected
     assert bot.logs[2] == expected

--- a/tests/test_router_mode_test2.py
+++ b/tests/test_router_mode_test2.py
@@ -59,4 +59,4 @@ def test_mode_test2_autoplace_sends_single_board(tmp_path, monkeypatch):
 
     asyncio.run(router.router_text(update, context))
 
-    assert bot.logs[1] == ['board_send', 'text_send']
+    assert bot.logs[1] == ['board_send']


### PR DESCRIPTION
## Summary
- always send fresh board messages from `_send_state` and store their identifiers in the per-player history
- adjust router-related tests to expect accumulated board messages instead of edits
- expose a `STATE_DELAY` constant so tests can disable delays

## Testing
- pytest tests/test_router_keyboard.py tests/test_router_message_order.py tests/test_router_mode_test2.py

------
https://chatgpt.com/codex/tasks/task_e_68e0bc0fe4808326b1dd876e8a5843c1