### PR TITLE
Add separate ship symbol for own board rendering

### DIFF
--- a/logic/render.py
+++ b/logic/render.py
@@ -15,6 +15,7 @@ CELL_WIDTH = 2
 EMPTY_SYMBOL = "·"
 MISS_SYMBOL = "x"
 HIT_SYMBOL = "■"
+SHIP_SYMBOL = "□"
 SUNK_SYMBOL = "▓"
 
 
@@ -59,7 +60,7 @@ def render_board_own(board: Board) -> str:
             coord = (r_idx, c_idx)
             cell_state, owner = _resolve_cell(v)
             if cell_state == 1:
-                sym = HIT_SYMBOL
+                sym = SHIP_SYMBOL
             elif cell_state == 2:
                 sym = MISS_SYMBOL
             elif cell_state == 3:

--- a/tests/test_render.py
+++ b/tests/test_render.py
@@ -1,4 +1,4 @@
-from logic.render import render_board_own, render_board_enemy
+from logic.render import render_board_own, render_board_enemy, SHIP_SYMBOL
 from logic.parser import ROWS
 from logic.battle import apply_shot, KILL
 from models import Board, Ship
@@ -10,7 +10,7 @@ def test_render_board_own_renders_ship_symbol():
     b = Board(owner='A')
     b.grid[0][0] = 1
     own = render_board_own(b)
-    assert '■' in own
+    assert SHIP_SYMBOL in own
 
 
 def test_render_board_enemy_marks_hit():


### PR DESCRIPTION
## Summary
- introduce a dedicated ship symbol constant for intact decks during board rendering
- render the owner's board with the new symbol and adjust tests to match

## Testing
- pytest tests/test_render.py

------
https://chatgpt.com/codex/tasks/task_e_68e0ea04cd248326a2cc2030f7eaecd2