### PR TITLE
Use emoji highlights for last-move indicators

### DIFF
--- a/logic/render.py
+++ b/logic/render.py
@@ -5,8 +5,6 @@ import re
 from models import Board
 from logic.parser import ROWS
 from wcwidth import wcswidth
-from constants import BOMB
-
 
 # fixed-width layout for board cells
 CELL_WIDTH = 2
@@ -16,6 +14,8 @@ EMPTY_SYMBOL = "·"
 MISS_SYMBOL = "x"
 HIT_SYMBOL = "■"
 SUNK_SYMBOL = "▓"
+LAST_MOVE_MISS_SYMBOL = "❌"
+LAST_MOVE_HIT_SYMBOL = "🟥"
 
 
 def format_cell(symbol: str) -> str:
@@ -71,10 +71,10 @@ def render_board_own(board: Board) -> str:
             else:
                 sym = EMPTY_SYMBOL
             if coord in highlight:
-                if cell_state == 4:
-                    sym = f"<b>{BOMB}</b>"
-                else:
-                    sym = f"<b>{sym}</b>"
+                if cell_state in (2, 5):
+                    sym = LAST_MOVE_MISS_SYMBOL
+                elif cell_state in (3, 4):
+                    sym = LAST_MOVE_HIT_SYMBOL
             cells.append(format_cell(sym))
         row_label = format_cell(str(r_idx + 1))
         lines.append(f"{row_label}| " + _render_line(cells))
@@ -101,10 +101,10 @@ def render_board_enemy(board: Board) -> str:
             else:
                 sym = EMPTY_SYMBOL
             if coord in highlight:
-                if cell_state == 4:
-                    sym = f"<b>{BOMB}</b>"
-                else:
-                    sym = f"<b>{sym}</b>"
+                if cell_state in (2, 5):
+                    sym = LAST_MOVE_MISS_SYMBOL
+                elif cell_state in (3, 4):
+                    sym = LAST_MOVE_HIT_SYMBOL
             cells.append(format_cell(sym))
         row_label = format_cell(str(r_idx + 1))
         lines.append(f"{row_label}| " + _render_line(cells))

--- a/tests/test_render.py
+++ b/tests/test_render.py
@@ -3,7 +3,6 @@ from logic.parser import ROWS
 from logic.battle import apply_shot, KILL
 from models import Board, Ship
 from tests.utils import _new_grid, _state
-from constants import BOMB
 
 
 def test_render_board_own_renders_ship_symbol():
@@ -28,20 +27,20 @@ def test_render_last_move_symbols():
     b.grid[0][0] = [2, 'A']
     b.highlight = [(0, 0)]
     own = render_board_own(b)
-    assert "<b>x</b>" in own
+    assert "❌" in own
     b.highlight = []
     own = render_board_own(b)
-    assert "<b>x</b>" not in own
+    assert "❌" not in own
     assert 'x' in own
 
     # hit highlight
     b.grid[1][1] = [3, 'B']
     b.highlight = [(1, 1)]
     enemy = render_board_enemy(b)
-    assert "<b>■</b>" in enemy
+    assert "🟥" in enemy
     b.highlight = []
     enemy = render_board_enemy(b)
-    assert "<b>■</b>" not in enemy and '■' in enemy
+    assert "🟥" not in enemy and '■' in enemy
 
     # kill highlight
     b.grid[2][2] = [4, 'B']
@@ -50,20 +49,18 @@ def test_render_last_move_symbols():
     # highlight the kill cell
     b.highlight = [(2, 2)]
     enemy = render_board_enemy(b)
-    assert enemy.count(BOMB) == 1
-    assert enemy.count('<b>') == 1
+    assert enemy.count('🟥') == 1
 
     # highlight the contour cell
     b.highlight = [(2, 3)]
     enemy = render_board_enemy(b)
-    assert BOMB not in enemy
-    assert enemy.count('x') >= 1
-    assert enemy.count('<b>') >= 1
+    assert '🟥' not in enemy
+    assert enemy.count('❌') == 1
 
     # no highlight
     b.highlight = []
     enemy = render_board_enemy(b)
-    assert BOMB not in enemy and '<b>' not in enemy
+    assert '🟥' not in enemy and '❌' not in enemy
     assert '▓' in enemy
     assert 'x' in enemy
 


### PR DESCRIPTION
## Summary
- replace bold markup and bomb icon with dedicated red cross/square constants for last-move highlights
- keep highlight handling consistent in both own and enemy board renderers so cleared highlights show default symbols
- adjust render tests to cover the new highlight icons and verify reset behaviour

## Testing
- pytest tests/test_render.py::test_render_last_move_symbols

------
https://chatgpt.com/codex/tasks/task_e_68e0ee793d0c8326aa045ee57f32c6e6