### PR TITLE
Adjust render cell width for emoji alignment

### DIFF
--- a/logic/render.py
+++ b/logic/render.py
@@ -7,7 +7,14 @@ from logic.parser import ROWS
 from wcwidth import wcswidth
 
 # fixed-width layout for board cells
-CELL_WIDTH = 2
+#
+# Emoji symbols that we use for hits, misses and ships can have a display
+# width larger than the standard ASCII characters.  When Telegram renders the
+# board, these wide symbols tend to stretch a cell beyond the intended column
+# boundaries, which breaks the rectangular shape of the grid.  By increasing
+# the cell width padding we make sure every cell reserves enough horizontal
+# space so that even wide emoji fit without affecting neighbouring columns.
+CELL_WIDTH = 3
 
 # text symbols for board rendering
 EMPTY_SYMBOL = "·"

--- a/tests/test_render.py
+++ b/tests/test_render.py
@@ -4,6 +4,7 @@ from logic.render import (
     SHIP_SYMBOL,
     HIT_SYMBOL,
     SUNK_SYMBOL,
+    format_cell,
 )
 from logic.parser import ROWS
 from logic.battle import apply_shot, KILL
@@ -117,7 +118,7 @@ def test_render_axis_labels():
     own_lines = _extract_lines(render_board_own(board))
     enemy_lines = _extract_lines(render_board_enemy(board))
 
-    expected_header = ' '.join(ROWS)
+    expected_header = ''.join(format_cell(letter) for letter in ROWS).strip()
     for lines in (own_lines, enemy_lines):
         header = lines[0].split('|', 1)[1].strip()
         assert header == expected_header


### PR DESCRIPTION
## Summary
- increase the board cell padding to three characters to keep emoji-aligned columns
- update the render header test to build its expectation with the same formatter

## Testing
- pytest tests/test_render.py

------
https://chatgpt.com/codex/tasks/task_e_68e0f9d8cd6483268189c8a94391f13a