### PR TITLE
Fix board15 ship overlay for owners

### DIFF
--- a/game_board15/router.py
+++ b/game_board15/router.py
@@ -95,8 +95,17 @@ async def _send_state(
                 if _get_cell_state(cell) != 1:
                     continue
                 history_state = merged_states[r][c]
-                if history_state in {2, 5}:
+                history_owner = owners[r][c]
+                if history_state in {3, 4} and history_owner == player_key:
                     continue
+                if history_state in {2, 5}:
+                    logger.warning(
+                        "Correcting state %s for player %s at (%s, %s)",
+                        history_state,
+                        player_key,
+                        r,
+                        c,
+                    )
                 merged_states[r][c] = 1
                 owners[r][c] = player_key
     state.board = merged_states

--- a/tests/test_board15_history.py
+++ b/tests/test_board15_history.py
@@ -523,7 +523,7 @@ def test_send_state_uses_history(monkeypatch):
     asyncio.run(run_test())
 
 
-def test_friendly_ship_replaced_by_miss(monkeypatch):
+def test_friendly_ship_visible_to_owner_after_miss(monkeypatch):
     async def run_test():
         match = SimpleNamespace(
             players={
@@ -606,7 +606,7 @@ def test_friendly_ship_replaced_by_miss(monkeypatch):
         await router._send_state(context, match, 'A', 'msg')
         await router._send_state(context, match, 'B', 'msg')
 
-        assert captured['A'][0][0] == 2
+        assert captured['A'][0][0] == 1
         assert captured['B'][0][0] == 2
 
     asyncio.run(run_test())


### PR DESCRIPTION
## Summary
- ensure the board15 state overlay keeps intact ships visible to their owner even if history shows a miss or contour
- update the friendly ship visibility regression test to reflect the corrected overlay behaviour

## Testing
- pytest tests/test_board15_history.py tests/test_board15_send_state.py

------
https://chatgpt.com/codex/tasks/task_e_68e0f90800208326b9e7c1b624dc36fb