### PR TITLE
Persist board highlights in 15x15 autoplay

### DIFF
--- a/game_board15/handlers.py
+++ b/game_board15/handlers.py
@@ -25,6 +25,7 @@ from .utils import (
     _get_cell_state,
     _get_cell_owner,
     _set_cell_state,
+    _persist_highlight_to_history,
     record_snapshot,
 )
 import random
@@ -234,12 +235,7 @@ async def _auto_play_bots(
             coord = random.choice(candidates)
         # Persist previous highlights before clearing them so that temporary
         # red marks become permanent dots on the history grid.
-        for b in match.boards.values():
-            if b.highlight:
-                for rr, cc in b.highlight:
-                    if _get_cell_state(match.history[rr][cc]) == 0:
-                        _set_cell_state(match.history, rr, cc, 2)
-            b.highlight = []
+        _persist_highlight_to_history(match)
         results = {}
         hit_any = False
         eliminated: list[str] = []

--- a/game_board15/router.py
+++ b/game_board15/router.py
@@ -23,6 +23,7 @@ from .utils import (
     _get_cell_state,
     _get_cell_owner,
     _set_cell_state,
+    _persist_highlight_to_history,
     record_snapshot,
 )
 
@@ -209,45 +210,7 @@ async def router_text(update: Update, context: ContextTypes.DEFAULT_TYPE) -> Non
 
     # Persist previous highlights before clearing so that red marks remain
     # as permanent dots on the board history.
-    for owner_key, board in match.boards.items():
-        if board.highlight:
-            for rr, cc in board.highlight:
-                history_state = _get_cell_state(match.history[rr][cc])
-                if history_state != 0:
-                    continue
-                board_state = _get_cell_state(board.grid[rr][cc])
-                if board_state == 1:
-                    continue
-                if board_state == 3:
-                    _set_cell_state(match.history, rr, cc, 3, owner_key)
-                    continue
-                if board_state == 4:
-                    _set_cell_state(match.history, rr, cc, 4, owner_key)
-                    for dr in (-1, 0, 1):
-                        for dc in (-1, 0, 1):
-                            nr, nc = rr + dr, cc + dc
-                            if 0 <= nr < 15 and 0 <= nc < 15:
-                                if _get_cell_state(match.history[nr][nc]) == 0 and _get_cell_state(board.grid[nr][nc]) == 5:
-                                    _set_cell_state(
-                                        match.history,
-                                        nr,
-                                        nc,
-                                        5,
-                                        _get_cell_owner(match.history[nr][nc]),
-                                    )
-                    continue
-                if board_state == 5:
-                    _set_cell_state(
-                        match.history,
-                        rr,
-                        cc,
-                        5,
-                        _get_cell_owner(match.history[rr][cc]),
-                    )
-                    continue
-                if all(_get_cell_state(other.grid[rr][cc]) != 1 for other in match.boards.values()):
-                    _set_cell_state(match.history, rr, cc, 2)
-        board.highlight = []
+    _persist_highlight_to_history(match)
 
     state = _get_cell_state(match.history[r][c])
     if state in {2, 3, 4, 5}:


### PR DESCRIPTION
## Summary
- extract the board highlight persistence logic into a reusable helper
- apply the helper in manual router moves and bot autoplay so hits stay recorded
- add a regression test ensuring bot moves keep the previous highlight in history

## Testing
- pytest tests/test_board15_test_autoplay.py::test_auto_play_bots_persists_previous_highlight

------
https://chatgpt.com/codex/tasks/task_e_68e10575118c8326912d9f402ed00b65