### PR TITLE
Use even board cell width for emoji padding

### DIFF
--- a/logic/render.py
+++ b/logic/render.py
@@ -14,7 +14,8 @@ from wcwidth import wcswidth
 # boundaries, which breaks the rectangular shape of the grid.  By increasing
 # the cell width padding we make sure every cell reserves enough horizontal
 # space so that even wide emoji fit without affecting neighbouring columns.
-CELL_WIDTH = 3
+# An even width keeps left/right padding symmetric for double-width emoji.
+CELL_WIDTH = 4
 
 # text symbols for board rendering
 EMPTY_SYMBOL = "·"


### PR DESCRIPTION
## Summary
- increase the fixed-width cell padding to four characters so double-width emoji stay centered
- document the need for an even cell width when formatting board output

## Testing
- pytest tests/test_render.py

------
https://chatgpt.com/codex/tasks/task_e_68e10ee31c608326b38e03a741db98d0