### PR TITLE
Ensure board test two turn prompts address the player

### DIFF
--- a/handlers/router.py
+++ b/handlers/router.py
@@ -239,7 +239,7 @@ async def _handle_board_test_two(
         phrase_self = _phrase_or_joke(match, player_key, SELF_HIT)
         phrase_enemy = _phrase_or_joke(match, enemy_key, ENEMY_HIT)
         result_self = (
-            f"Ваш ход: {coord_str} — Ранил. {phrase_self} Следующим ходит игрок A."
+            f"Ваш ход: {coord_str} — Ранил. {phrase_self} Следующим ходите вы."
         )
         result_enemy = (
             f"Ход игрока {player_label}: {coord_str} — Соперник ранил ваш корабль. {phrase_enemy}"
@@ -250,7 +250,7 @@ async def _handle_board_test_two(
         phrase_self = _phrase_or_joke(match, player_key, SELF_MISS)
         phrase_enemy = _phrase_or_joke(match, enemy_key, ENEMY_MISS)
         result_self = (
-            f"Ваш ход: {coord_str} — Клетка уже обстреляна. {phrase_self} Следующим ходит игрок A."
+            f"Ваш ход: {coord_str} — Клетка уже обстреляна. {phrase_self} Следующим ходите вы."
         )
         result_enemy = (
             f"Ход игрока {player_label}: {coord_str} — Соперник стрелял по уже обстрелянной клетке."
@@ -273,7 +273,7 @@ async def _handle_board_test_two(
             match.turn = player_key
             result_self = (
                 f"Ваш ход: {coord_str} — Корабль соперника уничтожен! {phrase_self}"
-                " Следующим ходит игрок A."
+                " Следующим ходите вы."
             )
             result_enemy = (
                 f"Ход игрока {player_label}: {coord_str} — Соперник уничтожил ваш корабль. {phrase_enemy}"


### PR DESCRIPTION
## Summary
- change board test mode messages for hits and kills to use the second-person "Следующим ходите вы."
- extend router text tests to cover the new phrasing and align expectations with the combined board/message output

## Testing
- pytest tests/test_router_text.py

------
https://chatgpt.com/codex/tasks/task_e_68e1245b71d48326b6b1610196b511ee