### PR TITLE
Restore three-character cell width with thin-space centering

### DIFF
--- a/logic/render.py
+++ b/logic/render.py
@@ -11,10 +11,12 @@ from wcwidth import wcswidth
 # Emoji symbols that we use for hits, misses and ships can have a display
 # width larger than the standard ASCII characters.  When Telegram renders the
 # board, these wide symbols tend to stretch a cell beyond the intended column
-# boundaries, which breaks the rectangular shape of the grid.  By increasing
-# the cell width padding we make sure every cell reserves enough horizontal
-# space so that even wide emoji fit without affecting neighbouring columns.
+# boundaries, which breaks the rectangular shape of the grid.  With a compact
+# ``CELL_WIDTH`` of three characters we stay within narrow screens, and when a
+# symbol consumes two visual columns we rely on a thin-space shim to keep it
+# visually centred.
 CELL_WIDTH = 3
+THIN_SPACE = "\u200A"
 
 # text symbols for board rendering
 EMPTY_SYMBOL = "·"
@@ -36,9 +38,20 @@ def format_cell(symbol: str) -> str:
     pad = CELL_WIDTH - wcswidth(visible)
     if pad < 0:
         pad = 0
-    pad_left = (pad + 1) // 2
+    pad_left = pad // 2
     pad_right = pad - pad_left
-    return (" " * pad_left) + symbol + (" " * pad_right)
+    thin_left = ""
+    thin_right = ""
+    if pad % 2 == 1:
+        if pad_left < pad_right and pad_right:
+            pad_right -= 1
+            thin_left = THIN_SPACE
+        elif pad_left > pad_right and pad_left:
+            pad_left -= 1
+            thin_right = THIN_SPACE
+        else:
+            thin_right = THIN_SPACE
+    return (" " * pad_left) + thin_left + symbol + thin_right + (" " * pad_right)
 
 
 COL_HEADERS = ''.join(format_cell(letter) for letter in ROWS)

--- a/tests/test_render.py
+++ b/tests/test_render.py
@@ -5,11 +5,14 @@ from logic.render import (
     HIT_SYMBOL,
     SUNK_SYMBOL,
     format_cell,
+    CELL_WIDTH,
+    THIN_SPACE,
 )
 from logic.parser import ROWS
 from logic.battle import apply_shot, KILL
 from models import Board, Ship
 from tests.utils import _new_grid, _state
+from wcwidth import wcswidth
 
 
 def test_render_board_own_renders_ship_symbol():
@@ -124,3 +127,12 @@ def test_render_axis_labels():
         assert header == expected_header
         row_labels = [line.split('|', 1)[0].strip() for line in lines[1:]]
         assert row_labels == [str(i) for i in range(1, 11)]
+
+
+def test_format_cell_keeps_visual_width():
+    single = format_cell('x')
+    double = format_cell('💣')
+
+    assert wcswidth(single) == CELL_WIDTH
+    assert wcswidth(double) == CELL_WIDTH
+    assert THIN_SPACE in double


### PR DESCRIPTION
## Summary
- reduce the board cell width back to three characters while introducing a thin-space shim for odd padding
- update `format_cell` to rebalance spacing when wide emoji need centering
- extend the render tests to assert the preserved visual width for both single- and double-width symbols

## Testing
- pytest tests/test_render.py

------
https://chatgpt.com/codex/tasks/task_e_68e10ee31c608326b38e03a741db98d0