### PR TITLE
Simplify board cell padding logic

### DIFF
--- a/tests/test_render.py
+++ b/tests/test_render.py
@@ -6,7 +6,6 @@ from logic.render import (
     SUNK_SYMBOL,
     format_cell,
     CELL_WIDTH,
-    THIN_SPACE,
 )
 from logic.parser import ROWS
 from logic.battle import apply_shot, KILL
@@ -135,4 +134,5 @@ def test_format_cell_keeps_visual_width():
 
     assert wcswidth(single) == CELL_WIDTH
     assert wcswidth(double) == CELL_WIDTH
-    assert THIN_SPACE in double
+    assert double.endswith(' ')
+    assert not double.startswith(' ')


### PR DESCRIPTION
## Summary
- simplify the board cell formatter to right-pad with regular spaces after removing HTML tags
- remove the thin-space constant and update tests to reflect the new padding strategy

## Testing
- pytest tests/test_render.py

------
https://chatgpt.com/codex/tasks/task_e_68e12e471a648326a562466265029cc9