### PR TITLE
Switch two-player board to 2-wide centered cells

### DIFF
--- a/logic/render.py
+++ b/logic/render.py
@@ -12,28 +12,28 @@ from wcwidth import wcswidth
 # width larger than the standard ASCII characters.  When Telegram renders the
 # board, these wide symbols tend to stretch a cell beyond the intended column
 # boundaries, which breaks the rectangular shape of the grid.  With a compact
-# ``CELL_WIDTH`` of three characters we stay within narrow screens.
-CELL_WIDTH = 3
+# ``CELL_WIDTH`` of two characters we stay within narrow screens.
+CELL_WIDTH = 2
 
 # text symbols for board rendering
 EMPTY_SYMBOL = "·"
 MISS_SYMBOL = "x"
-SHIP_SYMBOL = "🔲"
-HIT_SYMBOL = "⬛️"
-SUNK_SYMBOL = "⬛️"
-LAST_MOVE_MISS_SYMBOL = "❌"
-LAST_MOVE_HIT_SYMBOL = "🟥"
-LAST_MOVE_SUNK_SYMBOL = "💣"
+SHIP_SYMBOL = "▢"
+HIT_SYMBOL = "■"
+SUNK_SYMBOL = "▩"
+LAST_MOVE_MISS_SYMBOL = "✖"
+LAST_MOVE_HIT_SYMBOL = "▣"
+LAST_MOVE_SUNK_SYMBOL = "▣"
 
-# text symbols for board rendering -  RESERVE OPTION
+# text symbols for board rendering - PREVIOUS SET
 # EMPTY_SYMBOL = "·"
 # MISS_SYMBOL = "x"
-# SHIP_SYMBOL = "◻"
-# HIT_SYMBOL = "◼"
-# SUNK_SYMBOL = "▩"
-# LAST_MOVE_MISS_SYMBOL = "✖"
-# LAST_MOVE_HIT_SYMBOL = "▣"
-# LAST_MOVE_SUNK_SYMBOL = "🔥"
+# SHIP_SYMBOL = "🔲"
+# HIT_SYMBOL = "⬛️"
+# SUNK_SYMBOL = "⬛️"
+# LAST_MOVE_MISS_SYMBOL = "❌"
+# LAST_MOVE_HIT_SYMBOL = "🟥"
+# LAST_MOVE_SUNK_SYMBOL = "💣"
 
 def format_cell(symbol: str) -> str:
     """Pad cell contents so that the board remains aligned.
@@ -43,18 +43,21 @@ def format_cell(symbol: str) -> str:
     spaces to the right until the cell reaches ``CELL_WIDTH`` columns.
     """
     visible = re.sub(r"<[^>]+>", "", symbol)
-    padded = symbol
     width = wcswidth(visible)
     if width < 0:
         # fall back to treating the cell as already correct if width can't be
         # determined (``wcswidth`` returns ``-1`` for non-printable strings)
         return symbol
-    while width < CELL_WIDTH:
-        padded += " "
-        visible += " "
-        width = wcswidth(visible)
-        if width < 0:
-            break
+    if width >= CELL_WIDTH:
+        return symbol
+    slack = CELL_WIDTH - width
+    left_pad = (slack + 1) // 2
+    right_pad = slack - left_pad
+    visible = (" " * left_pad) + visible + (" " * right_pad)
+    padded = (" " * left_pad) + symbol + (" " * right_pad)
+    # ensure the padding did not break wcswidth; fall back if it did
+    if wcswidth(visible) != CELL_WIDTH:
+        return symbol
     return padded
 
 

--- a/tests/test_render.py
+++ b/tests/test_render.py
@@ -4,6 +4,9 @@ from logic.render import (
     SHIP_SYMBOL,
     HIT_SYMBOL,
     SUNK_SYMBOL,
+    LAST_MOVE_MISS_SYMBOL,
+    LAST_MOVE_HIT_SYMBOL,
+    LAST_MOVE_SUNK_SYMBOL,
     format_cell,
     CELL_WIDTH,
 )
@@ -37,20 +40,20 @@ def test_render_last_move_symbols():
     b.grid[0][0] = [2, 'A']
     b.highlight = [(0, 0)]
     own = render_board_own(b)
-    assert "❌" in own
+    assert LAST_MOVE_MISS_SYMBOL in own
     b.highlight = []
     own = render_board_own(b)
-    assert "❌" not in own
+    assert LAST_MOVE_MISS_SYMBOL not in own
     assert 'x' in own
 
     # hit highlight
     b.grid[1][1] = [3, 'B']
     b.highlight = [(1, 1)]
     enemy = render_board_enemy(b)
-    assert "🟥" in enemy
+    assert LAST_MOVE_HIT_SYMBOL in enemy
     b.highlight = []
     enemy = render_board_enemy(b)
-    assert "🟥" not in enemy and HIT_SYMBOL in enemy
+    assert LAST_MOVE_HIT_SYMBOL not in enemy and HIT_SYMBOL in enemy
 
     # kill highlight
     b.grid[2][2] = [4, 'B']
@@ -59,18 +62,18 @@ def test_render_last_move_symbols():
     # highlight the kill cell
     b.highlight = [(2, 2)]
     enemy = render_board_enemy(b)
-    assert enemy.count('💣') == 1
+    assert enemy.count(LAST_MOVE_SUNK_SYMBOL) == 1
 
     # highlight the contour cell
     b.highlight = [(2, 3)]
     enemy = render_board_enemy(b)
-    assert '💣' not in enemy and '🟥' not in enemy
-    assert enemy.count('❌') == 1
+    assert LAST_MOVE_SUNK_SYMBOL not in enemy and LAST_MOVE_HIT_SYMBOL not in enemy
+    assert enemy.count(LAST_MOVE_MISS_SYMBOL) == 1
 
     # no highlight
     b.highlight = []
     enemy = render_board_enemy(b)
-    assert '🟥' not in enemy and '❌' not in enemy
+    assert LAST_MOVE_HIT_SYMBOL not in enemy and LAST_MOVE_MISS_SYMBOL not in enemy
     assert SUNK_SYMBOL in enemy
     assert 'x' in enemy
 
@@ -134,5 +137,5 @@ def test_format_cell_keeps_visual_width():
 
     assert wcswidth(single) == CELL_WIDTH
     assert wcswidth(double) == CELL_WIDTH
-    assert double.endswith(' ')
-    assert not double.startswith(' ')
+    assert single.startswith(' ')
+    assert not single.endswith(' ')


### PR DESCRIPTION
## Summary
- reduce the two-player board cell width to two characters and activate the new glyph set while keeping the previous values commented
- center formatted cell contents within the narrower width so the new icons stay aligned
- refresh the render tests to assert the updated highlight symbols and padding behaviour

## Testing
- pytest tests/test_render.py

------
https://chatgpt.com/codex/tasks/task_e_68e1342f7e708326b0d56d76a2f89278