### PR TITLE
Track last shot coordinate for human duels

### DIFF
--- a/handlers/router.py
+++ b/handlers/router.py
@@ -474,6 +474,7 @@ async def router_text(update: Update, context: ContextTypes.DEFAULT_TYPE) -> Non
     result = apply_shot(match.boards[enemy_key], coord)
     match.shots[player_key]['history'].append(text)
     match.shots[player_key]['last_result'] = result
+    match.shots[player_key]['last_coord'] = coord
     for k in ('A', 'B'):
         shots = match.shots.setdefault(k, {})
         shots.setdefault('move_count', 0)


### PR DESCRIPTION
## Summary
- ensure the last shot coordinate is stored alongside the result for live matches

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e13f361c9883268ac98f91d53ec90c