### PR TITLE
Remove redundant board header separator

### DIFF
--- a/logic/render.py
+++ b/logic/render.py
@@ -17,7 +17,7 @@ CELL_WIDTH = 2
 
 # text symbols for board rendering
 EMPTY_SYMBOL = " "
-MISS_SYMBOL = "·"
+MISS_SYMBOL = "x"
 SHIP_SYMBOL = "▢"
 HIT_SYMBOL = "■"
 SUNK_SYMBOL = "▩"
@@ -80,7 +80,7 @@ def _resolve_cell(v: Union[int, Tuple[int, str]]) -> Tuple[int, str | None]:
 
 
 def render_board_own(board: Board) -> str:
-    header = format_cell("") + "|" + " " + COL_HEADERS
+    header = format_cell("") + " " + COL_HEADERS
     lines = [header]
     highlight = set(board.highlight)
     for r_idx, row in enumerate(board.grid):
@@ -114,7 +114,7 @@ def render_board_own(board: Board) -> str:
 
 
 def render_board_enemy(board: Board) -> str:
-    header = format_cell("") + "|" + " " + COL_HEADERS
+    header = format_cell("") + " " + COL_HEADERS
     lines = [header]
     highlight = set(board.highlight)
     for r_idx, row in enumerate(board.grid):

--- a/tests/test_render.py
+++ b/tests/test_render.py
@@ -9,6 +9,7 @@ from logic.render import (
     LAST_MOVE_SUNK_SYMBOL,
     format_cell,
     CELL_WIDTH,
+    COL_HEADERS,
 )
 from logic.parser import ROWS
 from logic.battle import apply_shot, KILL
@@ -123,9 +124,9 @@ def test_render_axis_labels():
     own_lines = _extract_lines(render_board_own(board))
     enemy_lines = _extract_lines(render_board_enemy(board))
 
-    expected_header = ''.join(format_cell(letter) for letter in ROWS).strip()
+    expected_header = (format_cell('') + ' ' + COL_HEADERS).strip()
     for lines in (own_lines, enemy_lines):
-        header = lines[0].split('|', 1)[1].strip()
+        header = lines[0].strip()
         assert header == expected_header
         row_labels = [line.split('|', 1)[0].strip() for line in lines[1:]]
         assert row_labels == [str(i) for i in range(1, 11)]


### PR DESCRIPTION
## Summary
- remove the leading separator bar from the rendered board header for both own and enemy views
- restore the miss marker to the expected `x` glyph so contour cells render correctly
- update render tests to match the new header layout

## Testing
- pytest tests/test_render.py

------
https://chatgpt.com/codex/tasks/task_e_68e141f9fd548326874a1cd8fb2b601f