### PR TITLE
Refine board header alignment

### DIFF
--- a/logic/render.py
+++ b/logic/render.py
@@ -63,6 +63,7 @@ def format_cell(symbol: str) -> str:
 
 
 COL_HEADERS = ''.join(format_cell(letter) for letter in ROWS)
+HEADER_PREFIX = format_cell("") + "| "
 
 
 def _render_line(cells: List[str]) -> str:
@@ -81,7 +82,7 @@ def _resolve_cell(v: Union[int, Tuple[int, str]]) -> Tuple[int, str | None]:
 
 
 def render_board_own(board: Board) -> str:
-    header = format_cell("") + " " + COL_HEADERS
+    header = HEADER_PREFIX + COL_HEADERS
     lines = [header]
     highlight = set(board.highlight)
     for r_idx, row in enumerate(board.grid):
@@ -115,7 +116,7 @@ def render_board_own(board: Board) -> str:
 
 
 def render_board_enemy(board: Board) -> str:
-    header = format_cell("") + " " + COL_HEADERS
+    header = HEADER_PREFIX + COL_HEADERS
     lines = [header]
     highlight = set(board.highlight)
     for r_idx, row in enumerate(board.grid):

--- a/tests/test_render.py
+++ b/tests/test_render.py
@@ -10,6 +10,7 @@ from logic.render import (
     format_cell,
     CELL_WIDTH,
     COL_HEADERS,
+    HEADER_PREFIX,
 )
 from logic.parser import ROWS
 from logic.battle import apply_shot, KILL
@@ -124,10 +125,11 @@ def test_render_axis_labels():
     own_lines = _extract_lines(render_board_own(board))
     enemy_lines = _extract_lines(render_board_enemy(board))
 
-    expected_header = (format_cell('') + ' ' + COL_HEADERS).strip()
+    expected_header = HEADER_PREFIX + COL_HEADERS
     for lines in (own_lines, enemy_lines):
-        header = lines[0].strip()
+        header = lines[0]
         assert header == expected_header
+        assert len(lines[0]) == len(lines[1])
         row_labels = [line.split('|', 1)[0].strip() for line in lines[1:]]
         assert row_labels == [str(i) for i in range(1, 11)]
 


### PR DESCRIPTION
## Summary
- add a shared `HEADER_PREFIX` constant so both board renderers build identical headers
- tighten the axis label test to verify the exact header text and that header width matches rendered rows

## Testing
- pytest *(fails: test_board15_human_autoplay_message::test_human_board_highlight_before_bot_move, test_board15_test_manual::test_board15_test_manual, test_history_before_send_n1::test_board15_router_updates_history_before_send_n1, tests/test_render.py::test_render_last_move_symbols, tests/test_render.py::test_render_state5_symbol, tests/test_render_failure.py::test_render_failure)*

------
https://chatgpt.com/codex/tasks/task_e_68e14754ce34832688c1e9b1e64b05e7