### PR TITLE
Show intact fleets in shared Board15 views

### DIFF
--- a/game_board15/router.py
+++ b/game_board15/router.py
@@ -157,11 +157,12 @@ async def _send_state(
                 merged_states[r][c] = 1
                 owners[r][c] = player_key
 
-    for r in range(15):
-        for c in range(15):
-            if owners[r][c] and owners[r][c] != player_key and merged_states[r][c] == 1:
-                merged_states[r][c] = 0
-                owners[r][c] = None
+    if not include_all_ships:
+        for r in range(15):
+            for c in range(15):
+                if owners[r][c] and owners[r][c] != player_key and merged_states[r][c] == 1:
+                    merged_states[r][c] = 0
+                    owners[r][c] = None
     state.board = merged_states
     state.owners = owners
     state.player_key = player_key


### PR DESCRIPTION
## Summary
- honor `include_all_ships` when rendering Board15 states so shared views keep every fleet visible
- update the shared-chat history regression to expect intact ships in shared snapshots and add coverage for the shared view helper
- add a personal-view regression to ensure individual boards continue hiding intact enemy ships

## Testing
- pytest tests/test_board15_history.py

------
https://chatgpt.com/codex/tasks/task_e_68e155e19e588326b0e936e2f0a41afc