### PR TITLE
Add player naming flow for two-player games

### DIFF
--- a/handlers/board_test.py
+++ b/handlers/board_test.py
@@ -422,7 +422,10 @@ async def _auto_play_bot(
 async def board_test(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
     """Start a three-player test match with two dummy opponents."""
 
-    match = storage.create_match(update.effective_user.id, update.effective_chat.id)
+    name = getattr(update.effective_user, "first_name", "") or getattr(
+        update.effective_user, "username", ""
+    )
+    match = storage.create_match(update.effective_user.id, update.effective_chat.id, name)
     match.players["B"] = Player(user_id=0, chat_id=update.effective_chat.id)
     match.players["C"] = Player(user_id=0, chat_id=update.effective_chat.id)
     match.status = "playing"
@@ -466,7 +469,8 @@ async def board_test_two(update: Update, context: ContextTypes.DEFAULT_TYPE) -> 
 
     chat = update.effective_chat
     user = update.effective_user
-    match = storage.create_match(user.id, chat.id)
+    name = getattr(user, "first_name", "") or getattr(user, "username", "")
+    match = storage.create_match(user.id, chat.id, name)
     match.players["B"] = Player(user_id=0, chat_id=chat.id)
     match.players["B"].ready = True
     match.status = "placing"

--- a/models.py
+++ b/models.py
@@ -30,6 +30,7 @@ class Board:
 class Player:
     user_id: int
     chat_id: int
+    name: str = ""
     ready: bool = False
 
 
@@ -71,10 +72,14 @@ class Match:
     )
 
     @staticmethod
-    def new(a_user_id: int, a_chat_id: int) -> 'Match':
+    def new(a_user_id: int, a_chat_id: int, a_name: str = "") -> 'Match':
         match_id = uuid.uuid4().hex
         match = Match(match_id=match_id)
-        match.players["A"] = Player(user_id=a_user_id, chat_id=a_chat_id)
+        match.players["A"] = Player(
+            user_id=a_user_id,
+            chat_id=a_chat_id,
+            name=a_name.strip(),
+        )
         for k in ("A", "B", "C"):
             match.boards[k] = Board(owner=k)
         match.history = [[0] * 10 for _ in range(10)]

--- a/storage.py
+++ b/storage.py
@@ -39,8 +39,8 @@ def _save_all(data: Dict[str, dict]) -> str | None:
     return None
 
 
-def create_match(a_user_id: int, a_chat_id: int) -> Match:
-    match = Match.new(a_user_id, a_chat_id)
+def create_match(a_user_id: int, a_chat_id: int, a_name: str = "") -> Match:
+    match = Match.new(a_user_id, a_chat_id, a_name)
     save_match(match)
     return match
 
@@ -80,7 +80,12 @@ def get_match(match_id: str) -> Match | None:
     return match
 
 
-def join_match(match_id: str, b_user_id: int, b_chat_id: int) -> Match | None:
+def join_match(
+    match_id: str,
+    b_user_id: int,
+    b_chat_id: int,
+    b_name: str = "",
+) -> Match | None:
     match = get_match(match_id)
     if (
         not match
@@ -89,7 +94,11 @@ def join_match(match_id: str, b_user_id: int, b_chat_id: int) -> Match | None:
     ):
         return None
     from models import Player
-    match.players['B'] = Player(user_id=b_user_id, chat_id=b_chat_id)
+    match.players['B'] = Player(
+        user_id=b_user_id,
+        chat_id=b_chat_id,
+        name=b_name.strip(),
+    )
     match.status = 'placing'
     save_match(match)
     return match

--- a/tests/test_board_test_start.py
+++ b/tests/test_board_test_start.py
@@ -11,7 +11,7 @@ from models import Match, Board
 def test_board_test_start_order(monkeypatch):
     async def run():
         match = Match.new(1, 100)
-        monkeypatch.setattr(storage, "create_match", lambda uid, cid: match)
+        monkeypatch.setattr(storage, "create_match", lambda uid, cid, name=None: match)
         monkeypatch.setattr(storage, "save_match", lambda m: None)
         monkeypatch.setattr(placement, "random_board_global", lambda mask: Board())
 
@@ -51,7 +51,7 @@ def test_board_test_start_order(monkeypatch):
 def test_board_test_two_schedules_bot_with_delay(monkeypatch):
     async def run():
         match = Match.new(1, 200)
-        monkeypatch.setattr(storage, "create_match", lambda uid, cid: match)
+        monkeypatch.setattr(storage, "create_match", lambda uid, cid, name=None: match)
         monkeypatch.setattr(storage, "save_match", lambda m: None)
         monkeypatch.setattr(placement, "random_board", lambda: Board())
 

--- a/tests/test_newgame.py
+++ b/tests/test_newgame.py
@@ -9,7 +9,11 @@ from handlers.commands import newgame, send_invite_link
 def test_newgame_message_sequence(monkeypatch):
     async def run_test():
         match = SimpleNamespace(match_id='m1')
-        monkeypatch.setattr(storage, 'create_match', lambda user_id, chat_id: match)
+        monkeypatch.setattr(
+            storage,
+            'create_match',
+            lambda user_id, chat_id, name=None: match,
+        )
         monkeypatch.setattr(storage, 'find_match_by_user', lambda uid: None)
 
         reply_text = AsyncMock()
@@ -20,7 +24,7 @@ def test_newgame_message_sequence(monkeypatch):
             effective_chat=SimpleNamespace(id=1),
         )
         bot = SimpleNamespace(get_me=AsyncMock(return_value=SimpleNamespace(username='TestBot')))
-        context = SimpleNamespace(bot=bot)
+        context = SimpleNamespace(bot=bot, user_data={'player_name': 'Игрок'})
 
         await newgame(update, context)
 
@@ -48,7 +52,7 @@ def test_send_invite_link(monkeypatch):
         )
         update = SimpleNamespace(callback_query=query, effective_chat=SimpleNamespace(id=1))
         bot = SimpleNamespace(get_me=AsyncMock(return_value=SimpleNamespace(username='TestBot')))
-        context = SimpleNamespace(bot=bot)
+        context = SimpleNamespace(bot=bot, user_data={'player_name': 'Игрок'})
 
         await send_invite_link(update, context)
 
@@ -69,7 +73,7 @@ def test_newgame_existing_match_prompts(monkeypatch):
             effective_user=SimpleNamespace(id=1),
             effective_chat=SimpleNamespace(id=1),
         )
-        context = SimpleNamespace()
+        context = SimpleNamespace(user_data={'player_name': 'Игрок'})
         await newgame(update, context)
         assert reply_text.call_args_list == [
             call('У вас уже есть незавершенный матч. Завершить его и начать новый?', reply_markup=ANY)

--- a/tests/test_start.py
+++ b/tests/test_start.py
@@ -14,7 +14,7 @@ def test_start_shows_logo_and_menu(monkeypatch):
             effective_user=SimpleNamespace(id=1),
             effective_chat=SimpleNamespace(id=1),
         )
-        context = SimpleNamespace()
+        context = SimpleNamespace(user_data={})
 
         await start(update, context)
 
@@ -41,12 +41,10 @@ def test_choose_mode_two_players():
 
         await choose_mode(update, context)
 
-        expected = (
-            'Используйте /newgame чтобы создать матч. '
-            'Если вы переходили по ссылке-приглашению, отправьте её текст '
-            'вручную: /start inv_<id>.'
-        )
-        assert reply_text.call_args_list == [call(expected)]
+        assert reply_text.call_args_list == [
+            call('Перед началом игры напишите, как вас представить сопернику.'),
+            call('Введите имя одним сообщением (например: Иван).'),
+        ]
         assert query.answer.call_count == 1
 
     asyncio.run(run_test())


### PR DESCRIPTION
## Summary
- add persistent player names to matches and reuse them when matches are created or joined
- gate two-player commands behind a name prompt and capture the first free-form message as the chosen name
- update notifications, handlers, and tests to reflect the name-based flow and revised copy

## Testing
- pytest tests/test_start.py tests/test_newgame.py tests/test_router_text.py tests/test_router_mode_test2.py

------
https://chatgpt.com/codex/tasks/task_e_68e1611d6338832685d99702fe68b64d