### PR TITLE
Show enemy board before own board in board state messages

### DIFF
--- a/handlers/commands.py
+++ b/handlers/commands.py
@@ -410,7 +410,7 @@ async def board(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
     own = render_board_own(match.boards[player_key])
     enemy = render_board_enemy(match.boards[enemy_key])
     await update.message.reply_text(
-        f"Ваше поле:\n{own}\nПоле соперника:\n{enemy}",
+        f"Поле соперника:\n{enemy}\nВаше поле:\n{own}",
         parse_mode='HTML',
     )
 

--- a/handlers/router.py
+++ b/handlers/router.py
@@ -82,7 +82,7 @@ async def _send_state(
 
     own = render_board_own(match.boards[player_key])
     enemy = render_board_enemy(match.boards[enemy_key])
-    board_text = f"Ваше поле:\n{own}\nПоле соперника:\n{enemy}\n{message}"
+    board_text = f"Поле соперника:\n{enemy}\nВаше поле:\n{own}\n{message}"
 
     board_msg = await context.bot.send_message(
         chat_id,

--- a/tests/test_board_command.py
+++ b/tests/test_board_command.py
@@ -29,7 +29,7 @@ def test_board_command_shows_fields(monkeypatch):
         await commands.board(update, None)
 
         assert reply_text.call_args_list == [
-            call('Ваше поле:\nown\nПоле соперника:\nenemy', parse_mode='HTML')
+            call('Поле соперника:\nenemy\nВаше поле:\nown', parse_mode='HTML')
         ]
 
     asyncio.run(run_test())

--- a/tests/test_router_text.py
+++ b/tests/test_router_text.py
@@ -393,7 +393,7 @@ def test_router_invalid_cell_shows_board(monkeypatch):
         assert msg_call.args[0] == 10
         assert msg_call.kwargs.get('parse_mode') == 'HTML'
         assert msg_call.args[1] == (
-            'Ваше поле:\nown\nПоле соперника:\nenemy\nНе понял клетку. Пример: е5 или д10.'
+            'Поле соперника:\nenemy\nВаше поле:\nown\nНе понял клетку. Пример: е5 или д10.'
         )
     asyncio.run(run_test())
 
@@ -428,7 +428,7 @@ def test_router_wrong_turn_shows_board(monkeypatch):
         assert msg_call.args[0] == 10
         assert msg_call.kwargs.get('parse_mode') == 'HTML'
         assert msg_call.args[1] == (
-            'Ваше поле:\nown\nПоле соперника:\nenemy\nСейчас ход соперника.'
+            'Поле соперника:\nenemy\nВаше поле:\nown\nСейчас ход соперника.'
         )
     asyncio.run(run_test())
 
@@ -472,10 +472,10 @@ def test_router_auto_shows_board(monkeypatch):
             assert call_args.kwargs.get('parse_mode') == 'HTML'
         messages_by_chat = {c.args[0]: c.args[1] for c in calls}
         assert messages_by_chat[10] == (
-            'Ваше поле:\nown\nПоле соперника:\nenemy\nКорабли расставлены. Бой начинается! Ваш ход.'
+            'Поле соперника:\nenemy\nВаше поле:\nown\nКорабли расставлены. Бой начинается! Ваш ход.'
         )
         assert messages_by_chat[20] == (
-            'Ваше поле:\nown\nПоле соперника:\nenemy\nИгрок A готов. Бой начинается! Ход соперника.'
+            'Поле соперника:\nenemy\nВаше поле:\nown\nИгрок A готов. Бой начинается! Ход соперника.'
         )
     asyncio.run(run_test())
 
@@ -523,11 +523,11 @@ def test_router_auto_waits_and_sends_instruction(monkeypatch):
         messages_by_chat = [(c.args[0], c.args[1]) for c in calls]
         assert messages_by_chat[0] == (
             10,
-            'Ваше поле:\nown\nПоле соперника:\nenemy\nКорабли расставлены. Ожидаем соперника.',
+            'Поле соперника:\nenemy\nВаше поле:\nown\nКорабли расставлены. Ожидаем соперника.',
         )
         assert messages_by_chat[1] == (
             20,
-            'Ваше поле:\nown\nПоле соперника:\nenemy\nИгрок A готов. Отправьте "авто" для расстановки кораблей.',
+            'Поле соперника:\nenemy\nВаше поле:\nown\nИгрок A готов. Отправьте "авто" для расстановки кораблей.',
         )
         assert messages_by_chat[2] == (
             20,


### PR DESCRIPTION
## Summary
- reorder board message formatting to show the opponent field before the player field in router updates and the /board command
- update board-related tests to match the new ordering

## Testing
- pytest tests/test_board_command.py tests/test_router_text.py

------
https://chatgpt.com/codex/tasks/task_e_68e16af6f5f483268afb695cee10f3ae