### PR TITLE
Ensure personal board views preserve snapshot ships

### DIFF
--- a/game_board15/router.py
+++ b/game_board15/router.py
@@ -177,12 +177,6 @@ async def _send_state(
                 merged_states[r][c] = 1
                 owners[r][c] = player_key
 
-    if not include_all_ships:
-        for r in range(15):
-            for c in range(15):
-                if owners[r][c] and owners[r][c] != player_key and merged_states[r][c] == 1:
-                    merged_states[r][c] = 0
-                    owners[r][c] = None
     state.board = merged_states
     state.owners = owners
     state.player_key = player_key

--- a/tests/test_three_player_snapshots.py
+++ b/tests/test_three_player_snapshots.py
@@ -208,11 +208,11 @@ def test_send_state_hides_intact_enemy_ships(monkeypatch):
 
     asyncio.run(router._send_state(context, match, "A", "test"))
 
-    # Own ships remain visible, enemy intact ships hidden, hits visible
+    # Own ships remain visible, intact enemy ships preserved by snapshot, hits visible
     assert captured["board"][0][0] == 1
     assert captured["owners"][0][0] == "A"
-    assert captured["board"][0][1] == 0
-    assert captured["owners"][0][1] is None
+    assert captured["board"][0][1] == 1
+    assert captured["owners"][0][1] == "B"
     assert captured["board"][1][1] == 3
     assert captured["owners"][1][1] == "B"
 


### PR DESCRIPTION
## Summary
- keep snapshot and live ship markers visible in personal board renders
- cover the new visibility rules in the board15 history test suite
- align three-player snapshot expectations with the shared ship view

## Testing
- pytest tests/test_board15_history.py
- pytest tests/test_three_player_snapshots.py

------
https://chatgpt.com/codex/tasks/task_e_68e184743d9c83269578fe07273e7956