### PR TITLE
Hide opponent ships in personal board views

### DIFF
--- a/game_board15/router.py
+++ b/game_board15/router.py
@@ -151,6 +151,8 @@ async def _send_state(
                     if owners[r][c] is None and cell_state in {3, 4, 5}:
                         owners[r][c] = owner_key
                     continue
+                if not include_all_ships and owner_key != player_key:
+                    continue
                 if merged_states[r][c] == 0:
                     merged_states[r][c] = 1
                 if owners[r][c] is None:


### PR DESCRIPTION
## Summary
- respect the include_all_ships flag when merging board grids so personal views hide untouched enemy ships
- ensure personal rendering still reveals the current player's fleet while keeping enemy hits from history visible
- update board15 history tests to cover the new personal visibility rules and add a regression test for history hits

## Testing
- pytest tests/test_board15_history.py

------
https://chatgpt.com/codex/tasks/task_e_68e210bc66648326be67326e1b392fe3