### PR TITLE
Hide intact enemy ships from shared chat board view

### DIFF
--- a/game_board15/router.py
+++ b/game_board15/router.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 import logging
 import random
 import asyncio
-import inspect
 from telegram import Update
 from telegram.ext import ContextTypes
 
@@ -487,18 +486,11 @@ async def router_text(update: Update, context: ContextTypes.DEFAULT_TYPE) -> Non
     if save_before_send:
         storage.save_match(match)
     if same_chat:
-        include_kwargs: dict[str, object] = {}
-        try:
-            if "include_all_ships" in inspect.signature(_send_state).parameters:
-                include_kwargs["include_all_ships"] = True
-        except (TypeError, ValueError):
-            include_kwargs = {}
         await _send_state(
             context,
             match,
             player_key,
             shared_text,
-            **include_kwargs,
         )
         private_receivers = [
             key


### PR DESCRIPTION
## Summary
- avoid forcing the shared chat branch to render all intact ships
- update shared-view tests to reflect the new hidden-ship behaviour

## Testing
- pytest tests/test_board15_history.py

------
https://chatgpt.com/codex/tasks/task_e_68e21df4d47c8326a31ea09f01d383e5