### PR TITLE
Show human board updates during bot turns

### DIFF
--- a/game_board15/handlers.py
+++ b/game_board15/handlers.py
@@ -374,15 +374,15 @@ async def _auto_play_bots(
                     f"Ход игрока {player_label}: {coord_str} - {body} {phrase_self}{next_phrase}"
                 )
 
-            if (
-                player_key == human
-                and current != human
-                and results.get(human) not in {battle.HIT, battle.KILL}
-            ):
-                continue
-
             if player_key == human and current != human:
-                await _safe_send_message(participant.chat_id, msg_text)
+                human_participant = match.players.get(human)
+                if not human_participant or human_participant.user_id == 0:
+                    continue
+                await _safe_send_state(
+                    player_key,
+                    msg_text,
+                    snapshot_override=snapshot,
+                )
             else:
                 await _safe_send_state(
                     player_key,


### PR DESCRIPTION
## Summary
- send full board snapshots to the human player for every automated bot move so they can track the game state
- guard the update logic so the human still receives only their own board view while bots remain silent
- update autoplay tests to expect board deliveries instead of plain text notifications

## Testing
- pytest tests/test_board15_test_autoplay.py

------
https://chatgpt.com/codex/tasks/task_e_68e363f7c27c83268a9369a7c91f478e