### PR TITLE
Stop showing other players' boards to the admin in three-player test

### DIFF
--- a/handlers/board_test.py
+++ b/handlers/board_test.py
@@ -165,7 +165,6 @@ async def _auto_play_bots(
         match.turn = next_player
 
         parts_self: list[str] = []
-        watch_parts: list[str] = []
         enemy_msgs: dict[str, tuple[int, str, str]] = {}
         player_obj = match.players.get(current)
         player_label = getattr(player_obj, "name", "") or current
@@ -182,9 +181,6 @@ async def _auto_play_bots(
             elif res == battle.REPEAT:
                 phrase_enemy = _phrase_or_joke(match, enemy, ENEMY_MISS).strip()
                 parts_self.append("клетка уже обстреляна.")
-                watch_parts.append(
-                    f"игрок {player_label} стрелял по уже обстрелянной клетке."
-                )
                 enemy_msgs[enemy] = (
                     res,
                     f"Ход игрока {player_label}: {coord_str} - клетка уже обстреляна.",
@@ -193,9 +189,6 @@ async def _auto_play_bots(
             elif res == battle.HIT:
                 phrase_enemy = _phrase_or_joke(match, enemy, ENEMY_HIT).strip()
                 parts_self.append(f"корабль игрока {enemy_label} ранен.")
-                watch_parts.append(
-                    f"игрок {player_label} поразил корабль игрока {enemy_label}."
-                )
                 enemy_msgs[enemy] = (
                     res,
                     f"Ход игрока {player_label}: {coord_str} - ваш корабль ранен.",
@@ -204,9 +197,6 @@ async def _auto_play_bots(
             elif res == battle.KILL:
                 phrase_enemy = _phrase_or_joke(match, enemy, ENEMY_KILL).strip()
                 parts_self.append(f"уничтожен корабль игрока {enemy_label}!")
-                watch_parts.append(
-                    f"игрок {player_label} поразил корабль игрока {enemy_label}."
-                )
                 enemy_msgs[enemy] = (
                     res,
                     f"Ход игрока {player_label}: {coord_str} - ваш корабль уничтожен.",
@@ -252,25 +242,6 @@ async def _auto_play_bots(
                 f"Следующим ходит {next_name}.",
             )
             await _safe_send_state(human, message_human)
-        elif (
-            current != human
-            and player_is_bot
-            and human in match.players
-            and match.players[human].user_id != 0
-            and match.boards[human].alive_cells > 0
-            and (human_entry is None or human_entry[0] in (battle.MISS, battle.REPEAT))
-        ):
-            msg_watch = " ".join(watch_parts).strip() or "мимо"
-            watch_body = msg_watch.rstrip()
-            if not watch_body.endswith((".", "!", "?")):
-                watch_body += "."
-            watch_message = _compose_move_message(
-                f"Ход игрока {player_label}: {coord_str} - {watch_body}",
-                phrase_self,
-                f"Следующим ходит {next_name}.",
-            )
-            await _safe_send_state(human, watch_message)
-
         msg_body = " ".join(parts_self).strip() or "мимо"
         body_self = msg_body.rstrip()
         if not body_self.endswith((".", "!", "?")):

--- a/tests/test_board_test_autoplay.py
+++ b/tests/test_board_test_autoplay.py
@@ -1,0 +1,64 @@
+import asyncio
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+from handlers import board_test
+from handlers import router as router_std
+import storage
+from models import Match, Player
+
+
+def test_auto_play_bots_skips_unrelated_human_updates(monkeypatch):
+    async def run():
+        match = Match.new(1, 100)
+        match.players["B"] = Player(user_id=0, chat_id=200, name="B")
+        match.players["C"] = Player(user_id=0, chat_id=300, name="C")
+        match.status = "playing"
+        match.turn = "B"
+
+        state_calls: list[tuple[str, str]] = []
+
+        async def fake_send_state(context, match_, player_key, message):
+            state_calls.append((player_key, message))
+
+        monkeypatch.setattr(router_std, "_send_state_board_test", fake_send_state)
+
+        shots = {"count": 0}
+
+        def fake_apply_shot_multi(coord, enemy_boards, history):
+            shots["count"] += 1
+            for board in enemy_boards.values():
+                board.highlight = [coord]
+            if shots["count"] == 1:
+                return {
+                    "A": board_test.battle.MISS,
+                    "C": board_test.battle.HIT,
+                }
+            raise RuntimeError("stop")
+
+        monkeypatch.setattr(board_test.battle, "apply_shot_multi", fake_apply_shot_multi)
+        monkeypatch.setattr(board_test.parser, "format_coord", lambda coord: "a1")
+        monkeypatch.setattr(board_test, "_phrase_or_joke", lambda *args, **kwargs: "")
+        monkeypatch.setattr(storage, "save_match", lambda m: None)
+        monkeypatch.setattr(storage, "finish", lambda m, w: None)
+        monkeypatch.setattr(storage, "get_match", lambda mid: match)
+
+        orig_sleep = asyncio.sleep
+
+        async def fast_sleep(delay):
+            await orig_sleep(0)
+
+        monkeypatch.setattr(asyncio, "sleep", fast_sleep)
+
+        context = SimpleNamespace(bot=SimpleNamespace(send_message=AsyncMock()), bot_data={})
+
+        with pytest.raises(RuntimeError):
+            await board_test._auto_play_bots(match, context, 0, human="A", delay=0)
+
+        assert state_calls == []
+        context.bot.send_message.assert_not_called()
+
+    asyncio.run(run())
+


### PR DESCRIPTION
## Summary
- prevent the three-player test autoplay from sending spectator updates to the human admin
- add a regression test that ensures the admin chat is quiet when bots shoot each other

## Testing
- pytest tests/test_board_test_autoplay.py
- pytest tests/test_board_test_start.py

------
https://chatgpt.com/codex/tasks/task_e_68e39e33335083269a0e639ce1fcb90a