### PR TITLE
Prevent kill contour from erasing allied ships

### DIFF
--- a/game_board15/battle.py
+++ b/game_board15/battle.py
@@ -78,7 +78,11 @@ def update_history(
                     for dc in (-1, 0, 1):
                         nr, nc = rr + dr, cc + dc
                         if 0 <= nr < 15 and 0 <= nc < 15:
-                            if _get_cell_state(history[nr][nc]) == 0:
+                            if _get_cell_state(history[nr][nc]) == 0 and all(
+                                _get_cell_state(other.grid[nr][nc]) != 1
+                                for other_key, other in boards.items()
+                                if other_key != key
+                            ):
                                 _set_cell_state(
                                     history,
                                     nr,
@@ -94,7 +98,5 @@ def update_history(
                 continue
             _set_cell_state(history, r, c, 3, key)
     elif all(res == MISS for res in results.values()):
-        if _get_cell_state(history[r][c]) == 0 and all(
-            _get_cell_state(boards[k].grid[r][c]) != 1 for k in results
-        ):
+        if _get_cell_state(history[r][c]) == 0:
             _set_cell_state(history, r, c, 2)

--- a/game_board15/utils.py
+++ b/game_board15/utils.py
@@ -88,6 +88,12 @@ def _persist_highlight_to_history(match) -> None:
                                 )
                 continue
             if board_state == 5:
+                if any(
+                    _get_cell_state(other.grid[rr][cc]) == 1
+                    for other_key, other in boards.items()
+                    if other_key != owner_key
+                ):
+                    continue
                 _set_cell_state(
                     match.history,
                     rr,

--- a/tests/test_board15_history.py
+++ b/tests/test_board15_history.py
@@ -45,6 +45,30 @@ def test_hit_then_kill_updates_all_cells():
     assert _state(history[0][3]) == 4
 
 
+def test_kill_contour_does_not_hide_friendly_ship():
+    history = _new_grid(15)
+    boards = {'A': Board15(), 'B': Board15()}
+
+    friendly = Ship(cells=[(2, 1)])
+    boards['A'].ships = [friendly]
+    boards['A'].grid[2][1] = 1
+
+    enemy_ship = Ship(cells=[(3, 0), (4, 0)])
+    boards['B'].ships = [enemy_ship]
+    for r, c in enemy_ship.cells:
+        boards['B'].grid[r][c] = 1
+
+    res_hit = apply_shot(boards['B'], (3, 0))
+    assert res_hit == HIT
+    update_history(history, boards, (3, 0), {'B': res_hit})
+
+    res_kill = apply_shot(boards['B'], (4, 0))
+    assert res_kill == KILL
+    update_history(history, boards, (4, 0), {'B': res_kill})
+
+    assert _state(history[2][1]) == 0
+
+
 def test_hit_at_m1_updates_history_and_board(monkeypatch):
     async def run_test():
         match = SimpleNamespace(


### PR DESCRIPTION
## Summary
- skip adding contour markers to the shared history when another board still holds a live ship on that cell
- ensure persisted highlights ignore contour cells that belong to other players' active ships
- add a regression test that covers the disappearing friendly ship scenario

## Testing
- pytest tests/test_board15_history.py -q

------
https://chatgpt.com/codex/tasks/task_e_68e3abd6ae6c8326ac0be5b4f874c2e0