### PR TITLE
Skip bot board updates in test mode

### DIFF
--- a/handlers/board_test.py
+++ b/handlers/board_test.py
@@ -165,7 +165,6 @@ async def _auto_play_bots(
         match.turn = next_player
 
         parts_self: list[str] = []
-        watch_parts: list[str] = []
         enemy_msgs: dict[str, tuple[int, str, str]] = {}
         player_obj = match.players.get(current)
         player_label = getattr(player_obj, "name", "") or current
@@ -182,9 +181,6 @@ async def _auto_play_bots(
             elif res == battle.REPEAT:
                 phrase_enemy = _phrase_or_joke(match, enemy, ENEMY_MISS).strip()
                 parts_self.append("клетка уже обстреляна.")
-                watch_parts.append(
-                    f"игрок {player_label} стрелял по уже обстрелянной клетке."
-                )
                 enemy_msgs[enemy] = (
                     res,
                     f"Ход игрока {player_label}: {coord_str} - клетка уже обстреляна.",
@@ -193,9 +189,6 @@ async def _auto_play_bots(
             elif res == battle.HIT:
                 phrase_enemy = _phrase_or_joke(match, enemy, ENEMY_HIT).strip()
                 parts_self.append(f"корабль игрока {enemy_label} ранен.")
-                watch_parts.append(
-                    f"игрок {player_label} поразил корабль игрока {enemy_label}."
-                )
                 enemy_msgs[enemy] = (
                     res,
                     f"Ход игрока {player_label}: {coord_str} - ваш корабль ранен.",
@@ -204,9 +197,6 @@ async def _auto_play_bots(
             elif res == battle.KILL:
                 phrase_enemy = _phrase_or_joke(match, enemy, ENEMY_KILL).strip()
                 parts_self.append(f"уничтожен корабль игрока {enemy_label}!")
-                watch_parts.append(
-                    f"игрок {player_label} поразил корабль игрока {enemy_label}."
-                )
                 enemy_msgs[enemy] = (
                     res,
                     f"Ход игрока {player_label}: {coord_str} - ваш корабль уничтожен.",
@@ -252,25 +242,6 @@ async def _auto_play_bots(
                 f"Следующим ходит {next_name}.",
             )
             await _safe_send_state(human, message_human)
-        elif (
-            current != human
-            and player_is_bot
-            and human in match.players
-            and match.players[human].user_id != 0
-            and match.boards[human].alive_cells > 0
-            and (human_entry is None or human_entry[0] in (battle.MISS, battle.REPEAT))
-        ):
-            msg_watch = " ".join(watch_parts).strip() or "мимо"
-            watch_body = msg_watch.rstrip()
-            if not watch_body.endswith((".", "!", "?")):
-                watch_body += "."
-            watch_message = _compose_move_message(
-                f"Ход игрока {player_label}: {coord_str} - {watch_body}",
-                phrase_self,
-                f"Следующим ходит {next_name}.",
-            )
-            await _safe_send_state(human, watch_message)
-
         msg_body = " ".join(parts_self).strip() or "мимо"
         body_self = msg_body.rstrip()
         if not body_self.endswith((".", "!", "?")):

--- a/handlers/board_test.py
+++ b/handlers/board_test.py
@@ -438,6 +438,11 @@ async def board_test(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None
     match.status = "playing"
     match.turn = "A"
 
+    flags = match.messages.setdefault("_flags", {})
+    flags["mode_test3"] = True
+    flags["mode_test3_admin_player"] = "A"
+    flags["mode_test3_admin_chat"] = update.effective_chat.id
+
     mask = [[0] * 10 for _ in range(10)]
     for key in ("A", "B", "C"):
         board = placement.random_board_global(mask)

--- a/handlers/router.py
+++ b/handlers/router.py
@@ -116,8 +116,25 @@ async def _send_state_board_test(
     """Send the shared board with global history to ``player_key``."""
 
     player = match.players.get(player_key)
-    if not player or player.user_id == 0:
+    if not player:
         return
+
+    flags = {}
+    if isinstance(match.messages, dict):
+        flags = match.messages.get("_flags", {}) or {}
+
+    if player.user_id == 0:
+        return
+
+    if flags.get("mode_test3"):
+        admin_player = flags.get("mode_test3_admin_player", "A")
+        admin_chat_id = flags.get("mode_test3_admin_chat")
+        if (
+            player_key != admin_player
+            and admin_chat_id is not None
+            and player.chat_id == admin_chat_id
+        ):
+            return
 
     chat_id = player.chat_id
     msgs = match.messages.setdefault(player_key, {})

--- a/tests/test_board_test_autoplay.py
+++ b/tests/test_board_test_autoplay.py
@@ -1,0 +1,64 @@
+import asyncio
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+from handlers import board_test
+from handlers import router as router_std
+import storage
+from models import Match, Player
+
+
+def test_auto_play_bots_skips_unrelated_human_updates(monkeypatch):
+    async def run():
+        match = Match.new(1, 100)
+        match.players["B"] = Player(user_id=0, chat_id=200, name="B")
+        match.players["C"] = Player(user_id=0, chat_id=300, name="C")
+        match.status = "playing"
+        match.turn = "B"
+
+        state_calls: list[tuple[str, str]] = []
+
+        async def fake_send_state(context, match_, player_key, message):
+            state_calls.append((player_key, message))
+
+        monkeypatch.setattr(router_std, "_send_state_board_test", fake_send_state)
+
+        shots = {"count": 0}
+
+        def fake_apply_shot_multi(coord, enemy_boards, history):
+            shots["count"] += 1
+            for board in enemy_boards.values():
+                board.highlight = [coord]
+            if shots["count"] == 1:
+                return {
+                    "A": board_test.battle.MISS,
+                    "C": board_test.battle.HIT,
+                }
+            raise RuntimeError("stop")
+
+        monkeypatch.setattr(board_test.battle, "apply_shot_multi", fake_apply_shot_multi)
+        monkeypatch.setattr(board_test.parser, "format_coord", lambda coord: "a1")
+        monkeypatch.setattr(board_test, "_phrase_or_joke", lambda *args, **kwargs: "")
+        monkeypatch.setattr(storage, "save_match", lambda m: None)
+        monkeypatch.setattr(storage, "finish", lambda m, w: None)
+        monkeypatch.setattr(storage, "get_match", lambda mid: match)
+
+        orig_sleep = asyncio.sleep
+
+        async def fast_sleep(delay):
+            await orig_sleep(0)
+
+        monkeypatch.setattr(asyncio, "sleep", fast_sleep)
+
+        context = SimpleNamespace(bot=SimpleNamespace(send_message=AsyncMock()), bot_data={})
+
+        with pytest.raises(RuntimeError):
+            await board_test._auto_play_bots(match, context, 0, human="A", delay=0)
+
+        assert state_calls == []
+        context.bot.send_message.assert_not_called()
+
+    asyncio.run(run())
+

--- a/tests/test_board_test_last_highlight.py
+++ b/tests/test_board_test_last_highlight.py
@@ -17,7 +17,7 @@ def test_send_state_board_test_uses_match_highlight(monkeypatch):
     async def run_test():
         board = Board()
         match = SimpleNamespace(
-            players={"A": SimpleNamespace(chat_id=1)},
+            players={"A": SimpleNamespace(user_id=1, chat_id=1)},
             messages={"A": {}},
             history=_new_grid(),
             boards={"A": board},

--- a/tests/test_board_test_visibility.py
+++ b/tests/test_board_test_visibility.py
@@ -1,0 +1,104 @@
+import asyncio
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+from handlers import router
+import storage
+
+
+def _grid():
+    return [[0] * 10 for _ in range(10)]
+
+
+def test_router_text_board_test_skips_unaffected_enemy(monkeypatch):
+    async def run():
+        match = SimpleNamespace(
+            status="playing",
+            players={
+                "A": SimpleNamespace(user_id=1, chat_id=10, name="A"),
+                "B": SimpleNamespace(user_id=2, chat_id=20, name="B"),
+                "C": SimpleNamespace(user_id=3, chat_id=30, name="C"),
+            },
+            boards={
+                "A": SimpleNamespace(grid=_grid(), highlight=[], alive_cells=20),
+                "B": SimpleNamespace(grid=_grid(), highlight=[], alive_cells=20),
+                "C": SimpleNamespace(grid=_grid(), highlight=[], alive_cells=20),
+            },
+            turn="A",
+            shots={
+                "A": {"history": [], "move_count": 0, "joke_start": 10},
+                "B": {"history": [], "move_count": 0, "joke_start": 10},
+                "C": {"history": [], "move_count": 0, "joke_start": 10},
+            },
+            messages={"A": {}, "B": {}, "C": {}},
+            history=_grid(),
+            last_highlight=[],
+        )
+
+        update = SimpleNamespace(
+            message=SimpleNamespace(text="a1", reply_text=AsyncMock()),
+            effective_user=SimpleNamespace(id=1),
+            effective_chat=SimpleNamespace(id=10),
+        )
+        context = SimpleNamespace(bot=SimpleNamespace(send_message=AsyncMock()), bot_data={})
+
+        monkeypatch.setattr(storage, "find_match_by_user", lambda uid, chat_id: match)
+        monkeypatch.setattr(storage, "save_match", lambda m: None)
+        monkeypatch.setattr(router, "parse_coord", lambda text: (0, 0))
+        monkeypatch.setattr(router, "format_coord", lambda coord: "a1")
+        monkeypatch.setattr(router, "_phrase_or_joke", lambda *args, **kwargs: "")
+        monkeypatch.setattr(
+            router,
+            "apply_shot_multi",
+            lambda coord, boards, history: {"B": router.HIT, "C": router.MISS},
+        )
+        monkeypatch.setattr(router.random, "choice", lambda seq: seq[0])
+
+        calls: list[str] = []
+
+        async def fake_send_state(context_obj, match_obj, player_key, message):
+            calls.append(player_key)
+
+        monkeypatch.setattr(router, "_send_state_board_test", fake_send_state)
+
+        await router.router_text_board_test(update, context)
+
+        assert calls.count("A") == 1
+        assert calls.count("B") == 1
+        assert calls.count("C") == 0
+
+    asyncio.run(run())
+
+
+def test_send_state_board_test_skips_bot(monkeypatch):
+    async def run():
+        match = SimpleNamespace(
+            players={
+                "A": SimpleNamespace(user_id=1, chat_id=10),
+                "B": SimpleNamespace(user_id=0, chat_id=10),
+            },
+            messages={},
+            history=[[0] * 10 for _ in range(10)],
+            boards={
+                "A": SimpleNamespace(grid=_grid(), highlight=[]),
+                "B": SimpleNamespace(grid=_grid(), highlight=[]),
+            },
+            last_highlight=[],
+        )
+
+        bot = SimpleNamespace(
+            send_message=AsyncMock(),
+            edit_message_text=AsyncMock(),
+            delete_message=AsyncMock(),
+        )
+        context = SimpleNamespace(bot=bot)
+
+        monkeypatch.setattr(storage, "save_match", lambda m: None)
+
+        await router._send_state_board_test(context, match, "B", "any")
+
+        bot.send_message.assert_not_called()
+        bot.edit_message_text.assert_not_called()
+        bot.delete_message.assert_not_called()
+
+    asyncio.run(run())

--- a/tests/test_board_test_visibility.py
+++ b/tests/test_board_test_visibility.py
@@ -102,3 +102,43 @@ def test_send_state_board_test_skips_bot(monkeypatch):
         bot.delete_message.assert_not_called()
 
     asyncio.run(run())
+
+
+def test_send_state_board_test_skips_admin_duplicates(monkeypatch):
+    async def run():
+        match = SimpleNamespace(
+            players={
+                "A": SimpleNamespace(user_id=1, chat_id=10),
+                "B": SimpleNamespace(user_id=2, chat_id=10),
+            },
+            messages={
+                "_flags": {
+                    "mode_test3": True,
+                    "mode_test3_admin_player": "A",
+                    "mode_test3_admin_chat": 10,
+                }
+            },
+            history=[[0] * 10 for _ in range(10)],
+            boards={
+                "A": SimpleNamespace(grid=_grid(), highlight=[]),
+                "B": SimpleNamespace(grid=_grid(), highlight=[]),
+            },
+            last_highlight=[],
+        )
+
+        bot = SimpleNamespace(
+            send_message=AsyncMock(),
+            edit_message_text=AsyncMock(),
+            delete_message=AsyncMock(),
+        )
+        context = SimpleNamespace(bot=bot)
+
+        monkeypatch.setattr(storage, "save_match", lambda m: None)
+
+        await router._send_state_board_test(context, match, "B", "any")
+
+        bot.send_message.assert_not_called()
+        bot.edit_message_text.assert_not_called()
+        bot.delete_message.assert_not_called()
+
+    asyncio.run(run())


### PR DESCRIPTION
## Summary
- skip sending test board updates to players without a real user id so the admin no longer receives bot boards
- extend the board test visibility suite to cover bot recipients and update existing fixtures for the new guard

## Testing
- pytest tests/test_board_test_autoplay.py tests/test_board_test_visibility.py tests/test_board_test_last_highlight.py

------
https://chatgpt.com/codex/tasks/task_e_68e39e33335083269a0e639ce1fcb90a