### PR TITLE
Restrict three-player test updates to hit opponents

### DIFF
--- a/tests/test_three_player_match.py
+++ b/tests/test_three_player_match.py
@@ -6,7 +6,7 @@ from unittest.mock import AsyncMock
 from telegram.error import BadRequest
 
 from game_board15 import handlers, router, storage
-from game_board15.models import Board15, Ship, Match15
+from game_board15.models import Board15, Ship, Match15, Player
 
 
 def test_three_player_match(monkeypatch):
@@ -97,5 +97,72 @@ def test_three_player_match(monkeypatch):
         # ensure board images were produced for each turn
         assert update.message.reply_photo.call_count == 1
         assert bot.send_photo.call_count >= 3
+
+    asyncio.run(run())
+
+
+def test_admin_turn_skips_unaffected_boards(monkeypatch):
+    async def run():
+        match = Match15.new(1, 101, "Admin")
+        match.status = "playing"
+        match.turn = "A"
+
+        match.players["B"] = Player(user_id=2, chat_id=202, name="Beta", ready=True)
+        match.players["C"] = Player(user_id=3, chat_id=303, name="Gamma", ready=True)
+
+        board_b = match.boards["B"]
+        board_b.grid = [[0] * 15 for _ in range(15)]
+        board_b.grid[0][0] = 1
+        board_b.ships = [Ship(cells=[(0, 0)])]
+        board_b.alive_cells = 1
+
+        board_c = match.boards["C"]
+        board_c.grid = [[0] * 15 for _ in range(15)]
+        board_c.grid[4][4] = 1
+        board_c.ships = [Ship(cells=[(4, 4)])]
+        board_c.alive_cells = 1
+
+        monkeypatch.setattr(storage, "find_match_by_user", lambda uid, chat_id=None: match)
+        monkeypatch.setattr(storage, "save_match", lambda m: None)
+        monkeypatch.setattr(storage, "finish", lambda m, w: None)
+        monkeypatch.setattr(storage, "get_match", lambda mid: match)
+
+        monkeypatch.setattr(router, "render_board", lambda *a, **k: BytesIO(b"buf"))
+
+        photo_chats: list[int] = []
+        message_chats: list[int] = []
+
+        async def fake_send_photo(chat_id, *args, **kwargs):
+            photo_chats.append(chat_id)
+            return SimpleNamespace(message_id=len(photo_chats))
+
+        async def fake_send_message(chat_id, *args, **kwargs):
+            message_chats.append(chat_id)
+            return SimpleNamespace(message_id=len(message_chats))
+
+        send_photo = AsyncMock(side_effect=fake_send_photo)
+        send_message = AsyncMock(side_effect=fake_send_message)
+
+        bot = SimpleNamespace(
+            send_photo=send_photo,
+            send_message=send_message,
+            edit_message_media=AsyncMock(),
+            edit_message_text=AsyncMock(),
+            delete_message=AsyncMock(),
+        )
+        context = SimpleNamespace(bot=bot, bot_data={}, chat_data={})
+
+        update = SimpleNamespace(
+            message=SimpleNamespace(text="a1", reply_text=AsyncMock()),
+            effective_user=SimpleNamespace(id=1),
+            effective_chat=SimpleNamespace(id=101),
+        )
+
+        await router.router_text(update, context)
+
+        assert 202 in photo_chats
+        assert 303 not in photo_chats
+
+        assert 303 in message_chats
 
     asyncio.run(run())


### PR DESCRIPTION
## Summary
- send plain text notifications to non-targeted players in the three-player test router instead of updating their boards
- ensure board updates are only delivered to players whose ships were hit while deduplicating per chat
- add a regression test covering the admin turn to confirm unaffected opponents no longer receive board snapshots

## Testing
- pytest tests/test_three_player_match.py -q

------
https://chatgpt.com/codex/tasks/task_e_68e4285e3adc8326b8a37728ec26503a